### PR TITLE
Tighten parser cleanup and range translation

### DIFF
--- a/GPC/CodeGenerator/Intel_x86-64/codegen.c
+++ b/GPC/CodeGenerator/Intel_x86-64/codegen.c
@@ -20,7 +20,7 @@
 #include "../../Parser/List/List.h"
 #include "../../Parser/ParseTree/tree.h"
 #include "../../Parser/ParseTree/tree_types.h"
-#include "Grammar.tab.h"
+#include "../../Parser/ParseTree/type_tags.h"
 
 /* Platform detection */
 #if defined(__linux__) || defined(__unix__)
@@ -33,13 +33,13 @@
 void gen_label(char *buf, int buf_len, CodeGenContext *ctx)
 {
     #ifdef DEBUG_CODEGEN
-    fprintf(stderr, "DEBUG: ENTERING %s\n", __func__);
+    CODEGEN_DEBUG("DEBUG: ENTERING %s\n", __func__);
     #endif
     assert(buf != NULL);
     assert(ctx != NULL);
     snprintf(buf, buf_len, ".L%d", ++ctx->label_counter);
     #ifdef DEBUG_CODEGEN
-    fprintf(stderr, "DEBUG: LEAVING %s\n", __func__);
+    CODEGEN_DEBUG("DEBUG: LEAVING %s\n", __func__);
     #endif
 }
 
@@ -48,7 +48,7 @@ void gen_label(char *buf, int buf_len, CodeGenContext *ctx)
 ListNode_t *add_inst(ListNode_t *inst_list, char *inst)
 {
     #ifdef DEBUG_CODEGEN
-    fprintf(stderr, "DEBUG: ENTERING %s\n", __func__);
+    CODEGEN_DEBUG("DEBUG: ENTERING %s\n", __func__);
     #endif
     ListNode_t *new_node;
 
@@ -65,7 +65,7 @@ ListNode_t *add_inst(ListNode_t *inst_list, char *inst)
     }
 
     #ifdef DEBUG_CODEGEN
-    fprintf(stderr, "DEBUG: LEAVING %s\n", __func__);
+    CODEGEN_DEBUG("DEBUG: LEAVING %s\n", __func__);
     #endif
     return inst_list;
 }
@@ -74,7 +74,7 @@ ListNode_t *add_inst(ListNode_t *inst_list, char *inst)
 void free_inst_list(ListNode_t *inst_list)
 {
     #ifdef DEBUG_CODEGEN
-    fprintf(stderr, "DEBUG: ENTERING %s\n", __func__);
+    CODEGEN_DEBUG("DEBUG: ENTERING %s\n", __func__);
     #endif
     ListNode_t *cur;
 
@@ -90,7 +90,7 @@ void free_inst_list(ListNode_t *inst_list)
 
     DestroyList(inst_list);
     #ifdef DEBUG_CODEGEN
-    fprintf(stderr, "DEBUG: LEAVING %s\n", __func__);
+    CODEGEN_DEBUG("DEBUG: LEAVING %s\n", __func__);
     #endif
 }
 
@@ -99,7 +99,7 @@ void free_inst_list(ListNode_t *inst_list)
 ListNode_t *gencode_jmp(int type, int inverse, char *label, ListNode_t *inst_list)
 {
     #ifdef DEBUG_CODEGEN
-    fprintf(stderr, "DEBUG: ENTERING %s\n", __func__);
+    CODEGEN_DEBUG("DEBUG: ENTERING %s\n", __func__);
     #endif
     char buffer[30], jmp_buf[6];
 
@@ -156,7 +156,7 @@ ListNode_t *gencode_jmp(int type, int inverse, char *label, ListNode_t *inst_lis
     snprintf(buffer, 30, "\t%s\t%s\n", jmp_buf, label);
 
     #ifdef DEBUG_CODEGEN
-    fprintf(stderr, "DEBUG: LEAVING %s\n", __func__);
+    CODEGEN_DEBUG("DEBUG: LEAVING %s\n", __func__);
     #endif
     return add_inst(inst_list, buffer);
 }
@@ -165,7 +165,7 @@ ListNode_t *gencode_jmp(int type, int inverse, char *label, ListNode_t *inst_lis
 void codegen_function_header(char *func_name, CodeGenContext *ctx)
 {
     #ifdef DEBUG_CODEGEN
-    fprintf(stderr, "DEBUG: ENTERING %s\n", __func__);
+    CODEGEN_DEBUG("DEBUG: ENTERING %s\n", __func__);
     #endif
     assert(func_name != NULL);
     assert(ctx != NULL);
@@ -173,7 +173,7 @@ void codegen_function_header(char *func_name, CodeGenContext *ctx)
     fprintf(ctx->output_file, "%s:\n\tpushq\t%%rbp\n\tmovq\t%%rsp, %%rbp\n", func_name);
 
     #ifdef DEBUG_CODEGEN
-    fprintf(stderr, "DEBUG: LEAVING %s\n", __func__);
+    CODEGEN_DEBUG("DEBUG: LEAVING %s\n", __func__);
     #endif
     return;
 }
@@ -182,24 +182,24 @@ void codegen_function_header(char *func_name, CodeGenContext *ctx)
 void codegen_function_footer(char *func_name, CodeGenContext *ctx)
 {
     #ifdef DEBUG_CODEGEN
-    fprintf(stderr, "DEBUG: ENTERING %s\n", __func__);
+    CODEGEN_DEBUG("DEBUG: ENTERING %s\n", __func__);
     #endif
     assert(func_name != NULL);
     assert(ctx != NULL);
     fprintf(ctx->output_file, "\tnop\n\tleave\n\tret\n");
 
     #ifdef DEBUG_CODEGEN
-    fprintf(stderr, "DEBUG: LEAVING %s\n", __func__);
+    CODEGEN_DEBUG("DEBUG: LEAVING %s\n", __func__);
     #endif
     return;
 }
 
 
 /* This is the entry function */
-void codegen(Tree_t *tree, char *input_file_name, CodeGenContext *ctx, SymTab_t *symtab)
+void codegen(Tree_t *tree, const char *input_file_name, CodeGenContext *ctx, SymTab_t *symtab)
 {
     #ifdef DEBUG_CODEGEN
-    fprintf(stderr, "DEBUG: ENTERING %s\n", __func__);
+    CODEGEN_DEBUG("DEBUG: ENTERING %s\n", __func__);
     #endif
     char *prgm_name;
 
@@ -208,7 +208,7 @@ void codegen(Tree_t *tree, char *input_file_name, CodeGenContext *ctx, SymTab_t 
     assert(ctx != NULL);
     assert(symtab != NULL);
 
-    fprintf(stderr, "DEBUG: ENTERING codegen\n");
+    CODEGEN_DEBUG("DEBUG: ENTERING codegen\n");
     init_stackmng();
 
     codegen_program_header(input_file_name, ctx);
@@ -221,9 +221,9 @@ void codegen(Tree_t *tree, char *input_file_name, CodeGenContext *ctx, SymTab_t 
 
     free_stackmng();
 
-    fprintf(stderr, "DEBUG: LEAVING codegen\n");
+    CODEGEN_DEBUG("DEBUG: LEAVING codegen\n");
     #ifdef DEBUG_CODEGEN
-    fprintf(stderr, "DEBUG: LEAVING %s\n", __func__);
+    CODEGEN_DEBUG("DEBUG: LEAVING %s\n", __func__);
     #endif
     return;
 }
@@ -231,7 +231,7 @@ void codegen(Tree_t *tree, char *input_file_name, CodeGenContext *ctx, SymTab_t 
 void codegen_rodata(CodeGenContext *ctx)
 {
     #ifdef DEBUG_CODEGEN
-    fprintf(stderr, "DEBUG: ENTERING %s\n", __func__);
+    CODEGEN_DEBUG("DEBUG: ENTERING %s\n", __func__);
     #endif
     assert(ctx != NULL);
     fprintf(ctx->output_file, ".section .rodata\n");
@@ -247,15 +247,15 @@ void codegen_rodata(CodeGenContext *ctx)
     fprintf(ctx->output_file, ".string \"\\n\"\n");
     fprintf(ctx->output_file, ".text\n");
     #ifdef DEBUG_CODEGEN
-    fprintf(stderr, "DEBUG: LEAVING %s\n", __func__);
+    CODEGEN_DEBUG("DEBUG: LEAVING %s\n", __func__);
     #endif
 }
 
 /* Generates platform-compatible headers */
-void codegen_program_header(char *fname, CodeGenContext *ctx)
+void codegen_program_header(const char *fname, CodeGenContext *ctx)
 {
     #ifdef DEBUG_CODEGEN
-    fprintf(stderr, "DEBUG: ENTERING %s\n", __func__);
+    CODEGEN_DEBUG("DEBUG: ENTERING %s\n", __func__);
     #endif
     assert(fname != NULL);
     assert(ctx != NULL);
@@ -269,7 +269,7 @@ void codegen_program_header(char *fname, CodeGenContext *ctx)
 
     fprintf(ctx->output_file, "\t.text\n");
     #ifdef DEBUG_CODEGEN
-    fprintf(stderr, "DEBUG: LEAVING %s\n", __func__);
+    CODEGEN_DEBUG("DEBUG: LEAVING %s\n", __func__);
     #endif
     return;
 }
@@ -278,15 +278,16 @@ void codegen_program_header(char *fname, CodeGenContext *ctx)
 void codegen_program_footer(CodeGenContext *ctx)
 {
     #ifdef DEBUG_CODEGEN
-    fprintf(stderr, "DEBUG: ENTERING %s\n", __func__);
+    CODEGEN_DEBUG("DEBUG: ENTERING %s\n", __func__);
     #endif
     assert(ctx != NULL);
 #if PLATFORM_LINUX
+    fprintf(ctx->output_file, "\t.section\t.note.GNU-stack,\"\",@progbits\n");
 #else
     fprintf(ctx->output_file, ".ident\t\"GPC: 0.0.0\"\n");
 #endif
     #ifdef DEBUG_CODEGEN
-    fprintf(stderr, "DEBUG: LEAVING %s\n", __func__);
+    CODEGEN_DEBUG("DEBUG: LEAVING %s\n", __func__);
     #endif
 }
 
@@ -294,7 +295,7 @@ void codegen_program_footer(CodeGenContext *ctx)
 void codegen_main(char *prgm_name, CodeGenContext *ctx)
 {
     #ifdef DEBUG_CODEGEN
-    fprintf(stderr, "DEBUG: ENTERING %s\n", __func__);
+    CODEGEN_DEBUG("DEBUG: ENTERING %s\n", __func__);
     #endif
     assert(prgm_name != NULL);
     assert(ctx != NULL);
@@ -311,7 +312,7 @@ void codegen_main(char *prgm_name, CodeGenContext *ctx)
     fprintf(ctx->output_file, "\tcall\texit\n");
     codegen_function_footer("main", ctx);
     #ifdef DEBUG_CODEGEN
-    fprintf(stderr, "DEBUG: LEAVING %s\n", __func__);
+    CODEGEN_DEBUG("DEBUG: LEAVING %s\n", __func__);
     #endif
 }
 
@@ -319,7 +320,7 @@ void codegen_main(char *prgm_name, CodeGenContext *ctx)
 void codegen_stack_space(CodeGenContext *ctx)
 {
     #ifdef DEBUG_CODEGEN
-    fprintf(stderr, "DEBUG: ENTERING %s\n", __func__);
+    CODEGEN_DEBUG("DEBUG: ENTERING %s\n", __func__);
     #endif
     int needed_space;
 
@@ -333,7 +334,7 @@ void codegen_stack_space(CodeGenContext *ctx)
         fprintf(ctx->output_file, "\tsubq\t$%d, %%rsp\n", needed_space);
     }
     #ifdef DEBUG_CODEGEN
-    fprintf(stderr, "DEBUG: LEAVING %s\n", __func__);
+    CODEGEN_DEBUG("DEBUG: LEAVING %s\n", __func__);
     #endif
 }
 
@@ -341,7 +342,7 @@ void codegen_stack_space(CodeGenContext *ctx)
 void codegen_inst_list(ListNode_t *inst_list, CodeGenContext *ctx)
 {
     #ifdef DEBUG_CODEGEN
-    fprintf(stderr, "DEBUG: ENTERING %s\n", __func__);
+    CODEGEN_DEBUG("DEBUG: ENTERING %s\n", __func__);
     #endif
     char *inst;
 
@@ -357,7 +358,7 @@ void codegen_inst_list(ListNode_t *inst_list, CodeGenContext *ctx)
         inst_list = inst_list->next;
     }
     #ifdef DEBUG_CODEGEN
-    fprintf(stderr, "DEBUG: LEAVING %s\n", __func__);
+    CODEGEN_DEBUG("DEBUG: LEAVING %s\n", __func__);
     #endif
 }
 
@@ -365,7 +366,7 @@ void codegen_inst_list(ListNode_t *inst_list, CodeGenContext *ctx)
 char * codegen_program(Tree_t *prgm, CodeGenContext *ctx, SymTab_t *symtab)
 {
     #ifdef DEBUG_CODEGEN
-    fprintf(stderr, "DEBUG: ENTERING %s\n", __func__);
+    CODEGEN_DEBUG("DEBUG: ENTERING %s\n", __func__);
     #endif
     assert(prgm->type == TREE_PROGRAM_TYPE);
     assert(ctx != NULL);
@@ -395,7 +396,7 @@ char * codegen_program(Tree_t *prgm, CodeGenContext *ctx, SymTab_t *symtab)
     pop_stackscope();
 
     #ifdef DEBUG_CODEGEN
-    fprintf(stderr, "DEBUG: LEAVING %s\n", __func__);
+    CODEGEN_DEBUG("DEBUG: LEAVING %s\n", __func__);
     #endif
     return prgm_name;
 }
@@ -404,7 +405,7 @@ char * codegen_program(Tree_t *prgm, CodeGenContext *ctx, SymTab_t *symtab)
 void codegen_function_locals(ListNode_t *local_decl, CodeGenContext *ctx)
 {
     #ifdef DEBUG_CODEGEN
-    fprintf(stderr, "DEBUG: ENTERING %s\n", __func__);
+    CODEGEN_DEBUG("DEBUG: ENTERING %s\n", __func__);
     #endif
      ListNode_t *cur, *id_list;
      Tree_t *tree;
@@ -434,7 +435,7 @@ void codegen_function_locals(ListNode_t *local_decl, CodeGenContext *ctx)
          cur = cur->next;
      }
     #ifdef DEBUG_CODEGEN
-    fprintf(stderr, "DEBUG: LEAVING %s\n", __func__);
+    CODEGEN_DEBUG("DEBUG: LEAVING %s\n", __func__);
     #endif
 }
 
@@ -442,13 +443,13 @@ void codegen_function_locals(ListNode_t *local_decl, CodeGenContext *ctx)
 ListNode_t *codegen_vect_reg(ListNode_t *inst_list, int num_vec)
 {
     #ifdef DEBUG_CODEGEN
-    fprintf(stderr, "DEBUG: ENTERING %s\n", __func__);
+    CODEGEN_DEBUG("DEBUG: ENTERING %s\n", __func__);
     #endif
     char buffer[50];
     assert(inst_list != NULL);
     snprintf(buffer, 50, "\tmovl\t$%d, %%eax\n", num_vec);
     #ifdef DEBUG_CODEGEN
-    fprintf(stderr, "DEBUG: LEAVING %s\n", __func__);
+    CODEGEN_DEBUG("DEBUG: LEAVING %s\n", __func__);
     #endif
     return add_inst(inst_list, buffer);
 }
@@ -457,7 +458,7 @@ ListNode_t *codegen_vect_reg(ListNode_t *inst_list, int num_vec)
 void codegen_subprograms(ListNode_t *sub_list, CodeGenContext *ctx, SymTab_t *symtab)
 {
     #ifdef DEBUG_CODEGEN
-    fprintf(stderr, "DEBUG: ENTERING %s\n", __func__);
+    CODEGEN_DEBUG("DEBUG: ENTERING %s\n", __func__);
     #endif
     Tree_t *sub;
 
@@ -484,7 +485,7 @@ void codegen_subprograms(ListNode_t *sub_list, CodeGenContext *ctx, SymTab_t *sy
         sub_list = sub_list->next;
     }
     #ifdef DEBUG_CODEGEN
-    fprintf(stderr, "DEBUG: LEAVING %s\n", __func__);
+    CODEGEN_DEBUG("DEBUG: LEAVING %s\n", __func__);
     #endif
 }
 
@@ -492,7 +493,7 @@ void codegen_subprograms(ListNode_t *sub_list, CodeGenContext *ctx, SymTab_t *sy
 void codegen_procedure(Tree_t *proc_tree, CodeGenContext *ctx, SymTab_t *symtab)
 {
     #ifdef DEBUG_CODEGEN
-    fprintf(stderr, "DEBUG: ENTERING %s\n", __func__);
+    CODEGEN_DEBUG("DEBUG: ENTERING %s\n", __func__);
     #endif
     assert(proc_tree != NULL);
     assert(proc_tree->type == TREE_SUBPROGRAM);
@@ -521,7 +522,7 @@ void codegen_procedure(Tree_t *proc_tree, CodeGenContext *ctx, SymTab_t *symtab)
     free_inst_list(inst_list);
     pop_stackscope();
     #ifdef DEBUG_CODEGEN
-    fprintf(stderr, "DEBUG: LEAVING %s\n", __func__);
+    CODEGEN_DEBUG("DEBUG: LEAVING %s\n", __func__);
     #endif
 }
 
@@ -529,7 +530,7 @@ void codegen_procedure(Tree_t *proc_tree, CodeGenContext *ctx, SymTab_t *symtab)
 void codegen_function(Tree_t *func_tree, CodeGenContext *ctx, SymTab_t *symtab)
 {
     #ifdef DEBUG_CODEGEN
-    fprintf(stderr, "DEBUG: ENTERING %s\n", __func__);
+    CODEGEN_DEBUG("DEBUG: ENTERING %s\n", __func__);
     #endif
     assert(func_tree != NULL);
     assert(func_tree->type == TREE_SUBPROGRAM);
@@ -563,7 +564,7 @@ void codegen_function(Tree_t *func_tree, CodeGenContext *ctx, SymTab_t *symtab)
     free_inst_list(inst_list);
     pop_stackscope();
     #ifdef DEBUG_CODEGEN
-    fprintf(stderr, "DEBUG: LEAVING %s\n", __func__);
+    CODEGEN_DEBUG("DEBUG: LEAVING %s\n", __func__);
     #endif
 }
 
@@ -571,7 +572,7 @@ void codegen_function(Tree_t *func_tree, CodeGenContext *ctx, SymTab_t *symtab)
 ListNode_t *codegen_subprogram_arguments(ListNode_t *args, ListNode_t *inst_list, CodeGenContext *ctx)
 {
     #ifdef DEBUG_CODEGEN
-    fprintf(stderr, "DEBUG: ENTERING %s\n", __func__);
+    CODEGEN_DEBUG("DEBUG: ENTERING %s\n", __func__);
     #endif
     Tree_t *arg_decl;
     int type, arg_num;
@@ -619,7 +620,7 @@ ListNode_t *codegen_subprogram_arguments(ListNode_t *args, ListNode_t *inst_list
         args = args->next;
     }
     #ifdef DEBUG_CODEGEN
-    fprintf(stderr, "DEBUG: LEAVING %s\n", __func__);
+    CODEGEN_DEBUG("DEBUG: LEAVING %s\n", __func__);
     #endif
     return inst_list;
 }

--- a/GPC/CodeGenerator/Intel_x86-64/codegen.h
+++ b/GPC/CodeGenerator/Intel_x86-64/codegen.h
@@ -107,7 +107,14 @@
 #error "Unsupported platform"
 #endif
 
+#ifdef GPC_DEBUG_CODEGEN
 #define DEBUG_CODEGEN
+#endif
+#ifdef DEBUG_CODEGEN
+#define CODEGEN_DEBUG(...) fprintf(stderr, __VA_ARGS__)
+#else
+#define CODEGEN_DEBUG(...) ((void)0)
+#endif
 #define MAX_ARGS 3
 #define REQUIRED_OFFSET 16
 
@@ -154,12 +161,12 @@ void gen_label(char *buf, int buf_len, CodeGenContext *ctx);
 void escape_string(char *dest, const char *src, size_t dest_size);
 
 /* This is the entry function */
-void codegen(Tree_t *, char *input_file_name, CodeGenContext *ctx, SymTab_t *symtab);
+void codegen(Tree_t *, const char *input_file_name, CodeGenContext *ctx, SymTab_t *symtab);
 
 ListNode_t *add_inst(ListNode_t *, char *);
 ListNode_t *gencode_jmp(int type, int inverse, char *label, ListNode_t *inst_list);
 
-void codegen_program_header(char *, CodeGenContext *ctx);
+void codegen_program_header(const char *, CodeGenContext *ctx);
 void codegen_rodata(CodeGenContext *ctx);
 void codegen_program_footer(CodeGenContext *ctx);
 void codegen_main(char *prgm_name, CodeGenContext *ctx);

--- a/GPC/CodeGenerator/Intel_x86-64/codegen_expression.c
+++ b/GPC/CodeGenerator/Intel_x86-64/codegen_expression.c
@@ -16,7 +16,7 @@
 #include "../../Parser/List/List.h"
 #include "../../Parser/ParseTree/tree.h"
 #include "../../Parser/ParseTree/tree_types.h"
-#include "Grammar.tab.h"
+#include "../../Parser/ParseTree/type_tags.h"
 #include "../../Parser/SemanticCheck/HashTable/HashTable.h"
 
 
@@ -24,75 +24,75 @@
 ListNode_t *codegen_expr(struct Expression *expr, ListNode_t *inst_list, CodeGenContext *ctx)
 {
     #ifdef DEBUG_CODEGEN
-    fprintf(stderr, "DEBUG: ENTERING %s\n", __func__);
+    CODEGEN_DEBUG("DEBUG: ENTERING %s\n", __func__);
     #endif
     assert(expr != NULL);
     assert(ctx != NULL);
     expr_node_t *expr_tree = NULL;
     Register_t *target_reg;
 
-    fprintf(stderr, "DEBUG: Generating code for expression type %d\n", expr->type);
+    CODEGEN_DEBUG("DEBUG: Generating code for expression type %d\n", expr->type);
 
     switch(expr->type) {
         case EXPR_VAR_ID:
-            fprintf(stderr, "DEBUG: Processing variable ID expression\n");
+            CODEGEN_DEBUG("DEBUG: Processing variable ID expression\n");
             expr_tree = build_expr_tree(expr);
             target_reg = get_free_reg(get_reg_stack(), &inst_list);
             inst_list = gencode_expr_tree(expr_tree, inst_list, ctx, target_reg);
             free_reg(get_reg_stack(), target_reg);
             free_expr_tree(expr_tree);
             #ifdef DEBUG_CODEGEN
-            fprintf(stderr, "DEBUG: LEAVING %s\n", __func__);
+            CODEGEN_DEBUG("DEBUG: LEAVING %s\n", __func__);
             #endif
             return inst_list;
         case EXPR_MULOP:
-            fprintf(stderr, "DEBUG: Processing mulop expression\n");
+            CODEGEN_DEBUG("DEBUG: Processing mulop expression\n");
             expr_tree = build_expr_tree(expr);
             target_reg = get_free_reg(get_reg_stack(), &inst_list);
             inst_list = gencode_expr_tree(expr_tree, inst_list, ctx, target_reg);
             free_reg(get_reg_stack(), target_reg);
             free_expr_tree(expr_tree);
             #ifdef DEBUG_CODEGEN
-            fprintf(stderr, "DEBUG: LEAVING %s\n", __func__);
+            CODEGEN_DEBUG("DEBUG: LEAVING %s\n", __func__);
             #endif
             return inst_list;
         case EXPR_INUM:
-            fprintf(stderr, "DEBUG: Processing integer constant expression\n");
+            CODEGEN_DEBUG("DEBUG: Processing integer constant expression\n");
             expr_tree = build_expr_tree(expr);
             target_reg = get_free_reg(get_reg_stack(), &inst_list);
             inst_list = gencode_expr_tree(expr_tree, inst_list, ctx, target_reg);
             free_reg(get_reg_stack(), target_reg);
             free_expr_tree(expr_tree);
             #ifdef DEBUG_CODEGEN
-            fprintf(stderr, "DEBUG: LEAVING %s\n", __func__);
+            CODEGEN_DEBUG("DEBUG: LEAVING %s\n", __func__);
             #endif
             return inst_list;
         case EXPR_RELOP:
-            fprintf(stderr, "DEBUG: Processing relational operator expression\n");
+            CODEGEN_DEBUG("DEBUG: Processing relational operator expression\n");
             #ifdef DEBUG_CODEGEN
-            fprintf(stderr, "DEBUG: LEAVING %s\n", __func__);
+            CODEGEN_DEBUG("DEBUG: LEAVING %s\n", __func__);
             #endif
             return codegen_simple_relop(expr, inst_list, ctx, NULL);
         case EXPR_ADDOP:
-            fprintf(stderr, "DEBUG: Processing addop expression\n");
+            CODEGEN_DEBUG("DEBUG: Processing addop expression\n");
             expr_tree = build_expr_tree(expr);
             target_reg = get_free_reg(get_reg_stack(), &inst_list);
             inst_list = gencode_expr_tree(expr_tree, inst_list, ctx, target_reg);
             free_reg(get_reg_stack(), target_reg);
             free_expr_tree(expr_tree);
             #ifdef DEBUG_CODEGEN
-            fprintf(stderr, "DEBUG: LEAVING %s\n", __func__);
+            CODEGEN_DEBUG("DEBUG: LEAVING %s\n", __func__);
             #endif
             return inst_list;
         case EXPR_SIGN_TERM:
-            fprintf(stderr, "DEBUG: Processing sign term expression\n");
+            CODEGEN_DEBUG("DEBUG: Processing sign term expression\n");
             expr_tree = build_expr_tree(expr);
             target_reg = get_free_reg(get_reg_stack(), &inst_list);
             inst_list = gencode_expr_tree(expr_tree, inst_list, ctx, target_reg);
             free_reg(get_reg_stack(), target_reg);
             free_expr_tree(expr_tree);
             #ifdef DEBUG_CODEGEN
-            fprintf(stderr, "DEBUG: LEAVING %s\n", __func__);
+            CODEGEN_DEBUG("DEBUG: LEAVING %s\n", __func__);
             #endif
             return inst_list;
         default:
@@ -107,14 +107,14 @@ ListNode_t *codegen_simple_relop(struct Expression *expr, ListNode_t *inst_list,
                                 CodeGenContext *ctx, int *relop_type)
 {
     #ifdef DEBUG_CODEGEN
-    fprintf(stderr, "DEBUG: ENTERING %s\n", __func__);
+    CODEGEN_DEBUG("DEBUG: ENTERING %s\n", __func__);
     #endif
     assert(expr != NULL);
     assert(expr->type == EXPR_RELOP);
     assert(inst_list != NULL);
     assert(ctx != NULL);
 
-    fprintf(stderr, "DEBUG: Generating simple relop\n");
+    CODEGEN_DEBUG("DEBUG: Generating simple relop\n");
 
     *relop_type = expr->expr_data.relop_data.type;
     inst_list = codegen_expr(expr->expr_data.relop_data.left, inst_list, ctx);
@@ -128,9 +128,9 @@ ListNode_t *codegen_simple_relop(struct Expression *expr, ListNode_t *inst_list,
     free_reg(get_reg_stack(), left_reg);
     inst_list = add_inst(inst_list, buffer);
 
-    fprintf(stderr, "DEBUG: Simple relop generated\n");
+    CODEGEN_DEBUG("DEBUG: Simple relop generated\n");
     #ifdef DEBUG_CODEGEN
-    fprintf(stderr, "DEBUG: LEAVING %s\n", __func__);
+    CODEGEN_DEBUG("DEBUG: LEAVING %s\n", __func__);
     #endif
     return inst_list;
 }
@@ -139,9 +139,9 @@ ListNode_t *codegen_simple_relop(struct Expression *expr, ListNode_t *inst_list,
 ListNode_t *codegen_get_nonlocal(ListNode_t *inst_list, char *var_id, int *offset)
 {
     #ifdef DEBUG_CODEGEN
-    fprintf(stderr, "DEBUG: ENTERING %s\n", __func__);
+    CODEGEN_DEBUG("DEBUG: ENTERING %s\n", __func__);
     #endif
-    fprintf(stderr, "DEBUG: Generating non-local access for %s\n", var_id);
+    CODEGEN_DEBUG("DEBUG: Generating non-local access for %s\n", var_id);
 
     assert(inst_list != NULL);
     assert(var_id != NULL);
@@ -159,9 +159,9 @@ ListNode_t *codegen_get_nonlocal(ListNode_t *inst_list, char *var_id, int *offse
     snprintf(buffer, 100, "\tmovq\t-8(%%rbp), %s\n", NON_LOCAL_REG_64);
     inst_list = add_inst(inst_list, buffer);
 
-    fprintf(stderr, "DEBUG: Non-local access generated\n");
+    CODEGEN_DEBUG("DEBUG: Non-local access generated\n");
     #ifdef DEBUG_CODEGEN
-    fprintf(stderr, "DEBUG: LEAVING %s\n", __func__);
+    CODEGEN_DEBUG("DEBUG: LEAVING %s\n", __func__);
     #endif
     return inst_list;
 }
@@ -170,7 +170,7 @@ ListNode_t *codegen_get_nonlocal(ListNode_t *inst_list, char *var_id, int *offse
 ListNode_t *codegen_pass_arguments(ListNode_t *args, ListNode_t *inst_list, CodeGenContext *ctx, HashNode_t *proc_node)
 {
     #ifdef DEBUG_CODEGEN
-    fprintf(stderr, "DEBUG: ENTERING %s\n", __func__);
+    CODEGEN_DEBUG("DEBUG: ENTERING %s\n", __func__);
     #endif
     int arg_num;
     Register_t *top_reg;
@@ -187,9 +187,9 @@ ListNode_t *codegen_pass_arguments(ListNode_t *args, ListNode_t *inst_list, Code
     arg_num = 0;
     while(args != NULL)
     {
-        fprintf(stderr, "DEBUG: In codegen_pass_arguments loop, arg_num = %d\n", arg_num);
+        CODEGEN_DEBUG("DEBUG: In codegen_pass_arguments loop, arg_num = %d\n", arg_num);
         struct Expression *arg_expr = (struct Expression *)args->cur;
-        fprintf(stderr, "DEBUG: arg_expr at %p, type %d\n", arg_expr, arg_expr->type);
+        CODEGEN_DEBUG("DEBUG: arg_expr at %p, type %d\n", arg_expr, arg_expr->type);
 
         arg_reg_char = get_arg_reg64_num(arg_num);
         if(arg_reg_char == NULL)
@@ -215,7 +215,7 @@ ListNode_t *codegen_pass_arguments(ListNode_t *args, ListNode_t *inst_list, Code
             // Pass by value
             expr_tree = build_expr_tree(arg_expr);
             top_reg = get_free_reg(get_reg_stack(), &inst_list);
-            fprintf(stderr, "DEBUG: top_reg at %p\n", top_reg);
+            CODEGEN_DEBUG("DEBUG: top_reg at %p\n", top_reg);
             inst_list = gencode_expr_tree(expr_tree, inst_list, ctx, top_reg);
             free_expr_tree(expr_tree);
 
@@ -231,7 +231,7 @@ ListNode_t *codegen_pass_arguments(ListNode_t *args, ListNode_t *inst_list, Code
     }
 
     #ifdef DEBUG_CODEGEN
-    fprintf(stderr, "DEBUG: LEAVING %s\n", __func__);
+    CODEGEN_DEBUG("DEBUG: LEAVING %s\n", __func__);
     #endif
     return inst_list;
 }
@@ -240,7 +240,7 @@ ListNode_t *codegen_pass_arguments(ListNode_t *args, ListNode_t *inst_list, Code
 ListNode_t * codegen_goto_prev_scope(ListNode_t *inst_list, StackScope_t *cur_scope, char *base)
 {
     #ifdef DEBUG_CODEGEN
-    fprintf(stderr, "DEBUG: ENTERING %s\n", __func__);
+    CODEGEN_DEBUG("DEBUG: ENTERING %s\n", __func__);
     #endif
     char buffer[50];
 
@@ -252,7 +252,7 @@ ListNode_t * codegen_goto_prev_scope(ListNode_t *inst_list, StackScope_t *cur_sc
     inst_list = add_inst(inst_list, buffer);
 
     #ifdef DEBUG_CODEGEN
-    fprintf(stderr, "DEBUG: LEAVING %s\n", __func__);
+    CODEGEN_DEBUG("DEBUG: LEAVING %s\n", __func__);
     #endif
     return inst_list;
 }

--- a/GPC/CodeGenerator/Intel_x86-64/codegen_statement.c
+++ b/GPC/CodeGenerator/Intel_x86-64/codegen_statement.c
@@ -12,7 +12,7 @@
 #include "../../Parser/List/List.h"
 #include "../../Parser/ParseTree/tree.h"
 #include "../../Parser/ParseTree/tree_types.h"
-#include "Grammar.tab.h"
+#include "../../Parser/ParseTree/type_tags.h"
 #include "../../Parser/SemanticCheck/SymTab/SymTab.h"
 #include "../../Parser/SemanticCheck/HashTable/HashTable.h"
 
@@ -20,7 +20,7 @@
 ListNode_t *codegen_stmt(struct Statement *stmt, ListNode_t *inst_list, CodeGenContext *ctx, SymTab_t *symtab)
 {
     #ifdef DEBUG_CODEGEN
-    fprintf(stderr, "DEBUG: ENTERING %s\n", __func__);
+    CODEGEN_DEBUG("DEBUG: ENTERING %s\n", __func__);
     #endif
     assert(stmt != NULL);
     assert(ctx != NULL);
@@ -53,7 +53,7 @@ ListNode_t *codegen_stmt(struct Statement *stmt, ListNode_t *inst_list, CodeGenC
             break;
     }
     #ifdef DEBUG_CODEGEN
-    fprintf(stderr, "DEBUG: LEAVING %s\n", __func__);
+    CODEGEN_DEBUG("DEBUG: LEAVING %s\n", __func__);
     #endif
     return inst_list;
 }
@@ -61,7 +61,7 @@ ListNode_t *codegen_stmt(struct Statement *stmt, ListNode_t *inst_list, CodeGenC
 ListNode_t *codegen_builtin_proc(struct Statement *stmt, ListNode_t *inst_list, CodeGenContext *ctx)
 {
     #ifdef DEBUG_CODEGEN
-    fprintf(stderr, "DEBUG: ENTERING %s\n", __func__);
+    CODEGEN_DEBUG("DEBUG: ENTERING %s\n", __func__);
     #endif
     assert(stmt != NULL);
     assert(stmt->type == STMT_PROCEDURE_CALL);
@@ -80,7 +80,7 @@ ListNode_t *codegen_builtin_proc(struct Statement *stmt, ListNode_t *inst_list, 
     inst_list = add_inst(inst_list, buffer);
     free_arg_regs();
     #ifdef DEBUG_CODEGEN
-    fprintf(stderr, "DEBUG: LEAVING %s\n", __func__);
+    CODEGEN_DEBUG("DEBUG: LEAVING %s\n", __func__);
     #endif
     return inst_list;
 }
@@ -89,7 +89,7 @@ ListNode_t *codegen_builtin_proc(struct Statement *stmt, ListNode_t *inst_list, 
 ListNode_t *codegen_compound_stmt(struct Statement *stmt, ListNode_t *inst_list, CodeGenContext *ctx, SymTab_t *symtab)
 {
     #ifdef DEBUG_CODEGEN
-    fprintf(stderr, "DEBUG: ENTERING %s\n", __func__);
+    CODEGEN_DEBUG("DEBUG: ENTERING %s\n", __func__);
     #endif
     assert(stmt != NULL);
     assert(stmt->type == STMT_COMPOUND_STATEMENT);
@@ -107,7 +107,7 @@ ListNode_t *codegen_compound_stmt(struct Statement *stmt, ListNode_t *inst_list,
         stmt_list = stmt_list->next;
     }
     #ifdef DEBUG_CODEGEN
-    fprintf(stderr, "DEBUG: LEAVING %s\n", __func__);
+    CODEGEN_DEBUG("DEBUG: LEAVING %s\n", __func__);
     #endif
     return inst_list;
 }
@@ -116,7 +116,7 @@ ListNode_t *codegen_compound_stmt(struct Statement *stmt, ListNode_t *inst_list,
 ListNode_t *codegen_var_assignment(struct Statement *stmt, ListNode_t *inst_list, CodeGenContext *ctx)
 {
     #ifdef DEBUG_CODEGEN
-    fprintf(stderr, "DEBUG: ENTERING %s\n", __func__);
+    CODEGEN_DEBUG("DEBUG: ENTERING %s\n", __func__);
     #endif
     assert(stmt != NULL);
     assert(stmt->type == STMT_VAR_ASSIGN);
@@ -152,7 +152,7 @@ ListNode_t *codegen_var_assignment(struct Statement *stmt, ListNode_t *inst_list
         exit(1);
     }
     #ifdef DEBUG_CODEGEN
-    fprintf(stderr, "DEBUG: LEAVING %s\n", __func__);
+    CODEGEN_DEBUG("DEBUG: LEAVING %s\n", __func__);
     #endif
     return add_inst(inst_list, buffer);
 }
@@ -161,7 +161,7 @@ ListNode_t *codegen_var_assignment(struct Statement *stmt, ListNode_t *inst_list
 ListNode_t *codegen_proc_call(struct Statement *stmt, ListNode_t *inst_list, CodeGenContext *ctx, SymTab_t *symtab)
 {
     #ifdef DEBUG_CODEGEN
-    fprintf(stderr, "DEBUG: ENTERING %s\n", __func__);
+    CODEGEN_DEBUG("DEBUG: ENTERING %s\n", __func__);
     #endif
     assert(stmt != NULL);
     assert(stmt->type == STMT_PROCEDURE_CALL);
@@ -196,7 +196,7 @@ ListNode_t *codegen_proc_call(struct Statement *stmt, ListNode_t *inst_list, Cod
         inst_list = add_inst(inst_list, buffer);
         free_arg_regs();
         #ifdef DEBUG_CODEGEN
-        fprintf(stderr, "DEBUG: LEAVING %s\n", __func__);
+        CODEGEN_DEBUG("DEBUG: LEAVING %s\n", __func__);
         #endif
         return inst_list;
     }
@@ -206,7 +206,7 @@ ListNode_t *codegen_proc_call(struct Statement *stmt, ListNode_t *inst_list, Cod
 ListNode_t *codegen_if_then(struct Statement *stmt, ListNode_t *inst_list, CodeGenContext *ctx, SymTab_t *symtab)
 {
     #ifdef DEBUG_CODEGEN
-    fprintf(stderr, "DEBUG: ENTERING %s\n", __func__);
+    CODEGEN_DEBUG("DEBUG: ENTERING %s\n", __func__);
     #endif
     assert(stmt != NULL);
     assert(stmt->type == STMT_IF_THEN);
@@ -246,7 +246,7 @@ ListNode_t *codegen_if_then(struct Statement *stmt, ListNode_t *inst_list, CodeG
         inst_list = add_inst(inst_list, buffer);
     }
     #ifdef DEBUG_CODEGEN
-    fprintf(stderr, "DEBUG: LEAVING %s\n", __func__);
+    CODEGEN_DEBUG("DEBUG: LEAVING %s\n", __func__);
     #endif
     return inst_list;
 }
@@ -255,7 +255,7 @@ ListNode_t *codegen_if_then(struct Statement *stmt, ListNode_t *inst_list, CodeG
 ListNode_t *codegen_while(struct Statement *stmt, ListNode_t *inst_list, CodeGenContext *ctx, SymTab_t *symtab)
 {
     #ifdef DEBUG_CODEGEN
-    fprintf(stderr, "DEBUG: ENTERING %s\n", __func__);
+    CODEGEN_DEBUG("DEBUG: ENTERING %s\n", __func__);
     #endif
     assert(stmt != NULL);
     assert(stmt->type == STMT_WHILE);
@@ -287,7 +287,7 @@ ListNode_t *codegen_while(struct Statement *stmt, ListNode_t *inst_list, CodeGen
     inst_list = gencode_jmp(relop_type, inverse, label2, inst_list);
 
     #ifdef DEBUG_CODEGEN
-    fprintf(stderr, "DEBUG: LEAVING %s\n", __func__);
+    CODEGEN_DEBUG("DEBUG: LEAVING %s\n", __func__);
     #endif
     return inst_list;
 }
@@ -296,7 +296,7 @@ ListNode_t *codegen_while(struct Statement *stmt, ListNode_t *inst_list, CodeGen
 ListNode_t *codegen_for(struct Statement *stmt, ListNode_t *inst_list, CodeGenContext *ctx, SymTab_t *symtab)
 {
     #ifdef DEBUG_CODEGEN
-    fprintf(stderr, "DEBUG: ENTERING %s\n", __func__);
+    CODEGEN_DEBUG("DEBUG: ENTERING %s\n", __func__);
     #endif
     assert(stmt != NULL);
     assert(stmt->type == STMT_FOR);
@@ -351,7 +351,7 @@ ListNode_t *codegen_for(struct Statement *stmt, ListNode_t *inst_list, CodeGenCo
     free(update_expr);
     free(update_stmt);
     #ifdef DEBUG_CODEGEN
-    fprintf(stderr, "DEBUG: LEAVING %s\n", __func__);
+    CODEGEN_DEBUG("DEBUG: LEAVING %s\n", __func__);
     #endif
     return inst_list;
 }

--- a/GPC/CodeGenerator/Intel_x86-64/expr_tree/expr_tree.c
+++ b/GPC/CodeGenerator/Intel_x86-64/expr_tree/expr_tree.c
@@ -19,7 +19,7 @@
 #include "../../../Parser/List/List.h"
 #include "../../../Parser/ParseTree/tree.h"
 #include "../../../Parser/ParseTree/tree_types.h"
-#include "Grammar.tab.h"
+#include "../../../Parser/ParseTree/type_tags.h"
 
 /* Helper functions */
 ListNode_t *gencode_sign_term(expr_node_t *node, ListNode_t *inst_list, CodeGenContext *ctx, Register_t *target_reg);
@@ -341,7 +341,7 @@ ListNode_t *gencode_case0(expr_node_t *node, ListNode_t *inst_list, CodeGenConte
     inst_list = gencode_leaf_var(expr, inst_list, buf_leaf, 30);
 
 #ifdef DEBUG_CODEGEN
-    fprintf(stderr, "DEBUG: Loading value %s into register %s\n", buf_leaf, target_reg->bit_32);
+    CODEGEN_DEBUG("DEBUG: Loading value %s into register %s\n", buf_leaf, target_reg->bit_32);
 #endif
 
     snprintf(buffer, 50, "\tmovl\t%s, %s\n", buf_leaf, target_reg->bit_32);
@@ -472,11 +472,11 @@ ListNode_t *gencode_leaf_var(struct Expression *expr, ListNode_t *inst_list,
     {
         case EXPR_VAR_ID:
             #ifdef DEBUG_CODEGEN
-            fprintf(stderr, "DEBUG: gencode_leaf_var: id = %s\n", expr->expr_data.id);
+            CODEGEN_DEBUG("DEBUG: gencode_leaf_var: id = %s\n", expr->expr_data.id);
             #endif
             stack_node = find_label(expr->expr_data.id);
             #ifdef DEBUG_CODEGEN
-            fprintf(stderr, "DEBUG: gencode_leaf_var: stack_node = %p\n", stack_node);
+            CODEGEN_DEBUG("DEBUG: gencode_leaf_var: stack_node = %p\n", stack_node);
             #endif
 
             if(stack_node != NULL)
@@ -569,7 +569,7 @@ ListNode_t *gencode_op(struct Expression *expr, char *left, char *right,
             else if(type == SLASH || type == DIV)
             {
                 #ifdef DEBUG_CODEGEN
-                fprintf(stderr, "DEBUG: gencode_op: left = %s, right = %s\n", left, right);
+                CODEGEN_DEBUG("DEBUG: gencode_op: left = %s, right = %s\n", left, right);
                 #endif
                 // left is the dividend, right is the divisor
                 snprintf(buffer, 50, "\tpushq\t%%rax\n");

--- a/GPC/CodeGenerator/Intel_x86-64/expr_tree/expr_tree.h
+++ b/GPC/CodeGenerator/Intel_x86-64/expr_tree/expr_tree.h
@@ -13,7 +13,7 @@
 #include "../stackmng/stackmng.h"
 #include "../../../Parser/ParseTree/tree.h"
 #include "../../../Parser/ParseTree/tree_types.h"
-#include "Grammar.tab.h"
+#include "../../../Parser/ParseTree/type_tags.h"
 
 
 typedef struct expr_node expr_node_t;

--- a/GPC/CodeGenerator/Intel_x86-64/stackmng/stackmng.c
+++ b/GPC/CodeGenerator/Intel_x86-64/stackmng/stackmng.c
@@ -158,7 +158,7 @@ StackNode_t *add_l_t(char *label)
     }
 
     #ifdef DEBUG_CODEGEN
-        fprintf(stderr, "DEBUG: Added %s to t_offset %d\n", label, offset);
+        CODEGEN_DEBUG("DEBUG: Added %s to t_offset %d\n", label, offset);
     #endif
 
     return new_node;
@@ -195,7 +195,7 @@ StackNode_t *add_l_x(char *label)
     }
 
     #ifdef DEBUG_CODEGEN
-        fprintf(stderr, "DEBUG: Added %s to x_offset %d\n", new_node->label, new_node->offset);
+        CODEGEN_DEBUG("DEBUG: Added %s to x_offset %d\n", new_node->label, new_node->offset);
     #endif
 
     return new_node;
@@ -232,7 +232,7 @@ StackNode_t *add_l_z(char *label)
     }
 
     #ifdef DEBUG_CODEGEN
-        fprintf(stderr, "DEBUG: Added %s to z_offset %d\n", label, offset);
+        CODEGEN_DEBUG("DEBUG: Added %s to z_offset %d\n", label, offset);
     #endif
 
     return new_node;

--- a/GPC/Optimizer/optimizer.c
+++ b/GPC/Optimizer/optimizer.c
@@ -23,7 +23,7 @@
 #include "../Parser/ParseTree/tree_types.h"
 #include "../Parser/SemanticCheck/SymTab/SymTab.h"
 #include "../Parser/SemanticCheck/HashTable/HashTable.h"
-#include "Grammar.tab.h"
+#include "../Parser/ParseTree/type_tags.h"
 
 void optimize_prog(SymTab_t *symtab, Tree_t *prog);
 void optimize_subprog(SymTab_t *symtab, Tree_t *sub);

--- a/GPC/Parser/LexAndYacc/lex.yy.l
+++ b/GPC/Parser/LexAndYacc/lex.yy.l
@@ -10,7 +10,7 @@
     #include "ErrVars.h"
     #include "tree.h"
     #include "List.h"
-    #include "Grammar.tab.h"
+    #include "../ParseTree/type_tags.h"
 
     char asm_buffer[1024];
     int if_stack[100];

--- a/GPC/Parser/ParsePascal.c
+++ b/GPC/Parser/ParsePascal.c
@@ -12,7 +12,7 @@
 #include "ParseTree/tree_types.h"
 #include "List/List.h"
 #include "SemanticCheck/SemCheck.h"
-#include "Grammar.tab.h"
+#include "ParseTree/type_tags.h"
 
 extern FILE *yyin;
 extern int yyparse();

--- a/GPC/Parser/ParseTree/from_cparser.c
+++ b/GPC/Parser/ParseTree/from_cparser.c
@@ -1,0 +1,776 @@
+#include <assert.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <strings.h>
+
+#include "from_cparser.h"
+
+#include "../List/List.h"
+#include "tree.h"
+#include "tree_types.h"
+#include "type_tags.h"
+#include "pascal_parser.h"
+
+static char *dup_symbol(ast_t *node) {
+    while (node != NULL) {
+        if (node->sym != NULL && node->sym->name != NULL)
+            return strdup(node->sym->name);
+        node = node->child;
+    }
+    return NULL;
+}
+
+static ListNode_t *append_node(ListNode_t **head, void *value, enum ListType type) {
+    ListNode_t *node = CreateListNode(value, type);
+    if (*head == NULL) {
+        *head = node;
+    } else {
+        PushListNodeBack(*head, node);
+    }
+    return node;
+}
+
+static void extend_list(ListNode_t **dest, ListNode_t *src) {
+    if (src == NULL) {
+        return;
+    }
+    if (*dest == NULL) {
+        *dest = src;
+        return;
+    }
+    ListNode_t *cur = *dest;
+    while (cur->next != NULL) {
+        cur = cur->next;
+    }
+    cur->next = src;
+}
+
+static ast_t *unwrap_pascal_node(ast_t *node) {
+    ast_t *cur = node;
+    while (cur != NULL) {
+        switch (cur->typ) {
+        case PASCAL_T_NONE:
+        case PASCAL_T_THEN:
+        case PASCAL_T_ELSE:
+        case PASCAL_T_DO:
+            if (cur->child != NULL) {
+                cur = cur->child;
+                continue;
+            }
+            break;
+        default:
+            break;
+        }
+        break;
+    }
+    return cur;
+}
+
+static int map_type_name(const char *name, char **type_id_out) {
+    if (name == NULL) {
+        return UNKNOWN_TYPE;
+    }
+    if (strcasecmp(name, "integer") == 0) {
+        return INT_TYPE;
+    }
+    if (strcasecmp(name, "longint") == 0) {
+        return LONGINT_TYPE;
+    }
+    if (strcasecmp(name, "real") == 0) {
+        return REAL_TYPE;
+    }
+    if (strcasecmp(name, "string") == 0) {
+        return STRING_TYPE;
+    }
+    if (strcasecmp(name, "single") == 0) {
+        return REAL_TYPE;
+    }
+    if (type_id_out != NULL) {
+        *type_id_out = strdup(name);
+    }
+    return UNKNOWN_TYPE;
+}
+
+static int convert_type_spec(ast_t *type_spec, char **type_id_out) {
+    if (type_id_out != NULL) {
+        *type_id_out = NULL;
+    }
+    if (type_spec == NULL) {
+        return UNKNOWN_TYPE;
+    }
+    ast_t *child = type_spec->child;
+    if (child != NULL && child->typ == PASCAL_T_IDENTIFIER) {
+        char *dup = dup_symbol(child);
+        int result = map_type_name(dup, type_id_out);
+        if (result == UNKNOWN_TYPE && type_id_out != NULL && *type_id_out == NULL) {
+            *type_id_out = dup;
+        } else {
+            free(dup);
+        }
+        return result;
+    }
+    return UNKNOWN_TYPE;
+}
+
+static ListNode_t *convert_identifier_list(ast_t **cursor) {
+    ListNode_t *ids = NULL;
+    ast_t *cur = *cursor;
+    while (cur != NULL && cur->typ == PASCAL_T_IDENTIFIER) {
+        char *dup = dup_symbol(cur);
+        append_node(&ids, dup, LIST_STRING);
+        cur = cur->next;
+    }
+    *cursor = cur;
+    return ids;
+}
+
+static char *pop_last_identifier(ListNode_t **ids) {
+    if (ids == NULL || *ids == NULL)
+        return NULL;
+
+    ListNode_t *prev = NULL;
+    ListNode_t *cur = *ids;
+    while (cur->next != NULL) {
+        prev = cur;
+        cur = cur->next;
+    }
+
+    char *value = (char *)cur->cur;
+    if (prev != NULL)
+        prev->next = NULL;
+    else
+        *ids = NULL;
+
+    free(cur);
+    return value;
+}
+
+static Tree_t *convert_param(ast_t *param_node) {
+    ast_t *cur = param_node->child;
+    int is_var_param = 0;
+
+    if (cur != NULL && cur->typ == PASCAL_T_IDENTIFIER && cur->sym != NULL) {
+        if (strcasecmp(cur->sym->name, "var") == 0) {
+            is_var_param = 1;
+            cur = cur->next;
+        } else if (strcasecmp(cur->sym->name, "const") == 0) {
+            cur = cur->next;
+        }
+    }
+
+    ListNode_t *ids = convert_identifier_list(&cur);
+    if (ids == NULL) {
+        fprintf(stderr, "ERROR: parameter missing identifier list.\n");
+        return NULL;
+    }
+
+    char *type_id = NULL;
+    int var_type = UNKNOWN_TYPE;
+    if (cur != NULL && cur->typ == PASCAL_T_TYPE_SPEC) {
+        var_type = convert_type_spec(cur, &type_id);
+        cur = cur->next;
+    } else {
+        char *type_name = pop_last_identifier(&ids);
+        if (type_name != NULL) {
+            var_type = map_type_name(type_name, &type_id);
+            if (var_type == UNKNOWN_TYPE && type_id == NULL) {
+                type_id = type_name;
+            } else {
+                free(type_name);
+            }
+        }
+    }
+
+    Tree_t *param = mk_vardecl(param_node->line, ids, var_type, type_id, is_var_param);
+    return param;
+}
+
+static ListNode_t *convert_param_list(ast_t **cursor) {
+    ListNode_t *params = NULL;
+    ast_t *cur = *cursor;
+
+    while (cur != NULL && cur->typ == PASCAL_T_PARAM) {
+        Tree_t *param = convert_param(cur);
+        if (param != NULL) {
+            append_node(&params, param, LIST_TREE);
+        }
+        cur = cur->next;
+    }
+
+    *cursor = cur;
+    return params;
+}
+
+static Tree_t *convert_var_decl(ast_t *decl_node) {
+    ast_t *cur = decl_node->child;
+
+    ListNode_t *ids = convert_identifier_list(&cur);
+    if (ids == NULL) {
+        fprintf(stderr, "ERROR: variable declaration missing identifier list.\n");
+        return NULL;
+    }
+
+    char *type_id = NULL;
+    int var_type = UNKNOWN_TYPE;
+
+    if (cur != NULL && cur->typ == PASCAL_T_TYPE_SPEC) {
+        var_type = convert_type_spec(cur, &type_id);
+        cur = cur->next;
+    } else {
+        char *type_name = pop_last_identifier(&ids);
+        if (type_name != NULL) {
+            var_type = map_type_name(type_name, &type_id);
+            if (var_type == UNKNOWN_TYPE && type_id == NULL) {
+                type_id = type_name;
+            } else {
+                free(type_name);
+            }
+        }
+    }
+
+    Tree_t *decl = mk_vardecl(decl_node->line, ids, var_type, type_id, 0);
+    return decl;
+}
+
+static ListNode_t *convert_var_section(ast_t *section_node) {
+    ListNode_t *decls = NULL;
+    ast_t *cur = section_node->child;
+
+    while (cur != NULL && cur->typ == PASCAL_T_VAR_DECL) {
+        Tree_t *decl = convert_var_decl(cur);
+        if (decl != NULL)
+            append_node(&decls, decl, LIST_TREE);
+        cur = cur->next;
+    }
+
+    return decls;
+}
+
+static ListNode_t *convert_expression_list(ast_t *arg_node);
+static struct Expression *convert_expression(ast_t *expr_node);
+static struct Statement *convert_statement(ast_t *stmt_node);
+static struct Statement *convert_block(ast_t *block_node);
+
+static int map_relop_tag(int tag) {
+    switch (tag) {
+    case PASCAL_T_EQ: return EQ;
+    case PASCAL_T_NE: return NE;
+    case PASCAL_T_LT: return LT;
+    case PASCAL_T_LE: return LE;
+    case PASCAL_T_GT: return GT;
+    case PASCAL_T_GE: return GE;
+    case PASCAL_T_AND: return AND;
+    case PASCAL_T_OR:  return OR;
+    default: return UNKNOWN_TYPE;
+    }
+}
+
+static int map_addop_tag(int tag) {
+    switch (tag) {
+    case PASCAL_T_ADD: return PLUS;
+    case PASCAL_T_SUB: return MINUS;
+    case PASCAL_T_OR:  return OR;
+    default: return UNKNOWN_TYPE;
+    }
+}
+
+static int map_mulop_tag(int tag) {
+    switch (tag) {
+    case PASCAL_T_MUL: return STAR;
+    case PASCAL_T_DIV: return SLASH;
+    case PASCAL_T_INTDIV: return DIV;
+    case PASCAL_T_MOD: return MOD;
+    case PASCAL_T_AND: return AND;
+    default: return UNKNOWN_TYPE;
+    }
+}
+
+static void append_asm_line(char **buffer, size_t *length, const char *line) {
+    if (line == NULL)
+        return;
+    size_t line_len = strlen(line);
+    size_t new_len = *length + line_len + 1; /* newline */
+    char *tmp = realloc(*buffer, new_len + 1);
+    if (tmp == NULL)
+        return;
+    memcpy(tmp + *length, line, line_len);
+    tmp[*length + line_len] = '\n';
+    tmp[new_len] = '\0';
+    *buffer = tmp;
+    *length = new_len;
+}
+
+static void collect_asm_lines(ast_t *node, char **buffer, size_t *length) {
+    for (ast_t *cur = node; cur != NULL && cur != ast_nil; cur = cur->next) {
+        if (cur->sym != NULL && cur->sym->name != NULL)
+            append_asm_line(buffer, length, cur->sym->name);
+        if (cur->child != NULL)
+            collect_asm_lines(cur->child, buffer, length);
+    }
+}
+
+static char *collect_asm_text(ast_t *block_node) {
+    char *buffer = NULL;
+    size_t length = 0;
+    collect_asm_lines(block_node, &buffer, &length);
+    return buffer;
+}
+
+static struct Expression *convert_factor(ast_t *expr_node) {
+    expr_node = unwrap_pascal_node(expr_node);
+    if (expr_node == NULL) {
+        return NULL;
+    }
+
+    switch (expr_node->typ) {
+    case PASCAL_T_INTEGER:
+        return mk_inum(expr_node->line, atoi(expr_node->sym->name));
+    case PASCAL_T_STRING:
+        return mk_string(expr_node->line, dup_symbol(expr_node));
+    case PASCAL_T_IDENTIFIER:
+        return mk_varid(expr_node->line, dup_symbol(expr_node));
+    case PASCAL_T_FUNC_CALL: {
+        ast_t *child = expr_node->child;
+        char *id = NULL;
+        if (child != NULL) {
+            if (child->typ == PASCAL_T_IDENTIFIER) {
+                id = dup_symbol(child);
+            } else if (child->child != NULL && child->child->typ == PASCAL_T_IDENTIFIER) {
+                id = dup_symbol(child->child);
+            }
+            child = child->next;
+        }
+        ListNode_t *args = convert_expression_list(child);
+        return mk_functioncall(expr_node->line, id, args);
+    }
+    case PASCAL_T_ARRAY_ACCESS: {
+        ast_t *array_id = expr_node->child;
+        ast_t *index_expr = array_id != NULL ? array_id->next : NULL;
+        struct Expression *index = convert_expression(index_expr);
+        return mk_arrayaccess(expr_node->line, dup_symbol(array_id), index);
+    }
+    default:
+        return NULL;
+    }
+}
+
+static struct Expression *convert_binary_expr(ast_t *node, int type) {
+    ast_t *left_node = node->child;
+    ast_t *right_node = left_node != NULL ? left_node->next : NULL;
+    struct Expression *left = convert_expression(left_node);
+    struct Expression *right = convert_expression(right_node);
+
+    switch (type) {
+    case PASCAL_T_ADD:
+    case PASCAL_T_SUB:
+    case PASCAL_T_OR:
+        return mk_addop(node->line, map_addop_tag(type), left, right);
+    case PASCAL_T_MUL:
+    case PASCAL_T_DIV:
+    case PASCAL_T_INTDIV:
+    case PASCAL_T_MOD:
+    case PASCAL_T_AND:
+        return mk_mulop(node->line, map_mulop_tag(type), left, right);
+    case PASCAL_T_EQ:
+    case PASCAL_T_NE:
+    case PASCAL_T_LT:
+    case PASCAL_T_LE:
+    case PASCAL_T_GT:
+    case PASCAL_T_GE:
+        return mk_relop(node->line, map_relop_tag(type), left, right);
+    default:
+        break;
+    }
+    return NULL;
+}
+
+static struct Expression *convert_unary_expr(ast_t *node) {
+    struct Expression *inner = convert_expression(node->child);
+    return mk_signterm(node->line, inner);
+}
+
+static struct Expression *convert_expression(ast_t *expr_node) {
+    expr_node = unwrap_pascal_node(expr_node);
+    if (expr_node == NULL)
+        return NULL;
+
+    switch (expr_node->typ) {
+    case PASCAL_T_INTEGER:
+    case PASCAL_T_STRING:
+    case PASCAL_T_IDENTIFIER:
+    case PASCAL_T_FUNC_CALL:
+    case PASCAL_T_ARRAY_ACCESS:
+        return convert_factor(expr_node);
+    case PASCAL_T_ADD:
+    case PASCAL_T_SUB:
+    case PASCAL_T_MUL:
+    case PASCAL_T_DIV:
+    case PASCAL_T_INTDIV:
+    case PASCAL_T_MOD:
+    case PASCAL_T_EQ:
+    case PASCAL_T_NE:
+    case PASCAL_T_LT:
+    case PASCAL_T_LE:
+    case PASCAL_T_GT:
+    case PASCAL_T_GE:
+    case PASCAL_T_AND:
+    case PASCAL_T_OR:
+        return convert_binary_expr(expr_node, expr_node->typ);
+    case PASCAL_T_NEG:
+    case PASCAL_T_POS:
+        return convert_unary_expr(expr_node);
+    case PASCAL_T_TUPLE:
+        return convert_expression(expr_node->child);
+    default:
+        fprintf(stderr, "ERROR: unsupported expression tag %d at line %d.\n",
+                expr_node->typ, expr_node->line);
+        break;
+    }
+
+    return NULL;
+}
+
+static ListNode_t *convert_expression_list(ast_t *arg_node) {
+    ListNode_t *args = NULL;
+    ast_t *cur = arg_node;
+
+    while (cur != NULL && cur != ast_nil) {
+        struct Expression *expr = convert_expression(unwrap_pascal_node(cur));
+        if (expr != NULL)
+            append_node(&args, expr, LIST_EXPR);
+        cur = cur->next;
+    }
+
+    return args;
+}
+
+static struct Statement *convert_assignment(ast_t *assign_node) {
+    ast_t *lhs = assign_node->child;
+    ast_t *rhs = lhs != NULL ? lhs->next : NULL;
+
+    struct Expression *left = convert_expression(lhs);
+    struct Expression *right = convert_expression(rhs);
+    return mk_varassign(assign_node->line, left, right);
+}
+
+static struct Statement *convert_proc_call(ast_t *call_node, bool implicit_identifier) {
+    ast_t *child = call_node->child;
+    ast_t *args_start = NULL;
+    char *id = NULL;
+
+    if (call_node->typ == PASCAL_T_IDENTIFIER) {
+        id = dup_symbol(call_node);
+        args_start = call_node->next;
+    } else if (child != NULL) {
+        if (implicit_identifier && child->typ == PASCAL_T_IDENTIFIER) {
+            id = dup_symbol(child);
+            args_start = child->next;
+        } else {
+            if (child->typ == PASCAL_T_IDENTIFIER) {
+                id = dup_symbol(child);
+                args_start = child->next;
+            } else if (child->child != NULL && child->child->typ == PASCAL_T_IDENTIFIER) {
+                id = dup_symbol(child->child);
+                args_start = child->next;
+            }
+        }
+    }
+
+    ListNode_t *args = convert_expression_list(args_start);
+    struct Statement *call = mk_procedurecall(call_node->line, id, args);
+    return call;
+}
+
+static struct Statement *convert_statement(ast_t *stmt_node) {
+    stmt_node = unwrap_pascal_node(stmt_node);
+    if (stmt_node == NULL)
+        return NULL;
+
+    switch (stmt_node->typ) {
+    case PASCAL_T_ASSIGNMENT:
+        return convert_assignment(stmt_node);
+    case PASCAL_T_STATEMENT: {
+        ast_t *inner = unwrap_pascal_node(stmt_node->child);
+        if (inner == NULL)
+            return NULL;
+        if (inner->typ == PASCAL_T_IDENTIFIER) {
+            char *name = dup_symbol(inner);
+            if (name != NULL) {
+                bool is_assembler = strcasecmp(name, "assembler") == 0;
+                free(name);
+                if (is_assembler)
+                    return NULL;
+            }
+        }
+        if (inner->typ == PASCAL_T_IDENTIFIER || inner->typ == PASCAL_T_FUNC_CALL)
+            return convert_proc_call(inner, inner->typ == PASCAL_T_IDENTIFIER);
+        return convert_statement(inner);
+    }
+    case PASCAL_T_FUNC_CALL:
+        return convert_proc_call(stmt_node, true);
+    case PASCAL_T_ASM_BLOCK: {
+        char *code = collect_asm_text(stmt_node->child);
+        return mk_asmblock(stmt_node->line, code);
+    }
+    case PASCAL_T_BEGIN_BLOCK:
+        return convert_block(stmt_node);
+    case PASCAL_T_IF_STMT: {
+        ast_t *cond = stmt_node->child;
+        ast_t *then_wrapper = cond != NULL ? cond->next : NULL;
+        ast_t *else_wrapper = then_wrapper != NULL ? then_wrapper->next : NULL;
+
+        struct Expression *condition = convert_expression(cond);
+        struct Statement *then_stmt = convert_statement(unwrap_pascal_node(then_wrapper));
+        struct Statement *else_stmt = convert_statement(unwrap_pascal_node(else_wrapper));
+        return mk_ifthen(stmt_node->line, condition, then_stmt, else_stmt);
+    }
+    case PASCAL_T_WHILE_STMT: {
+        ast_t *cond = stmt_node->child;
+        ast_t *body = unwrap_pascal_node(cond != NULL ? cond->next : NULL);
+        struct Expression *condition = convert_expression(cond);
+        struct Statement *body_stmt = convert_statement(body);
+        return mk_while(stmt_node->line, condition, body_stmt);
+    }
+    case PASCAL_T_FOR_STMT: {
+        ast_t *var_node = unwrap_pascal_node(stmt_node->child);
+        ast_t *start_node = unwrap_pascal_node(var_node != NULL ? var_node->next : NULL);
+        ast_t *end_node = unwrap_pascal_node(start_node != NULL ? start_node->next : NULL);
+        ast_t *body_node = unwrap_pascal_node(end_node != NULL ? end_node->next : NULL);
+
+        struct Expression *var_expr = convert_expression(var_node);
+        struct Expression *start_expr = convert_expression(start_node);
+        struct Expression *end_expr = convert_expression(end_node);
+        struct Statement *body_stmt = convert_statement(body_node);
+
+        struct Statement *assign_stmt = mk_varassign(stmt_node->line, var_expr, start_expr);
+        return mk_forassign(stmt_node->line, assign_stmt, end_expr, body_stmt);
+    }
+    default:
+        break;
+    }
+
+    return NULL;
+}
+
+static ListNode_t *convert_statement_list(ast_t *stmt_list_node) {
+    ListNode_t *stmts = NULL;
+    ast_t *cur = stmt_list_node;
+
+    while (cur != NULL && cur != ast_nil) {
+        ast_t *unwrapped = unwrap_pascal_node(cur);
+        struct Statement *stmt = convert_statement(unwrapped);
+        if (stmt != NULL)
+            append_node(&stmts, stmt, LIST_STMT);
+        cur = cur->next;
+    }
+
+    return stmts;
+}
+
+static struct Statement *convert_block(ast_t *block_node) {
+    if (block_node == NULL)
+        return NULL;
+
+    ast_t *stmts = block_node->child;
+    ListNode_t *list = convert_statement_list(stmts);
+    return mk_compoundstatement(block_node->line, list);
+}
+
+static Tree_t *convert_procedure(ast_t *proc_node) {
+    ast_t *cur = proc_node->child;
+    char *id = NULL;
+
+    if (cur != NULL && cur->typ == PASCAL_T_IDENTIFIER)
+        id = dup_symbol(cur);
+
+    if (cur != NULL)
+        cur = cur->next;
+
+    ListNode_t *params = NULL;
+    if (cur != NULL && cur->typ == PASCAL_T_PARAM_LIST) {
+        ast_t *param_cursor = cur->child;
+        params = convert_param_list(&param_cursor);
+        cur = cur->next;
+    } else {
+        while (cur != NULL && cur->typ == PASCAL_T_PARAM) {
+            Tree_t *param = convert_param(cur);
+            if (param != NULL)
+                append_node(&params, param, LIST_TREE);
+            cur = cur->next;
+        }
+    }
+
+    ListNode_t *var_decls = NULL;
+    ListNode_t *nested_subs = NULL;
+    struct Statement *body = NULL;
+
+    while (cur != NULL) {
+        switch (cur->typ) {
+        case PASCAL_T_VAR_SECTION:
+            extend_list(&var_decls, convert_var_section(cur));
+            break;
+        case PASCAL_T_PROCEDURE_DECL:
+        case PASCAL_T_FUNCTION_DECL: {
+            Tree_t *sub = convert_procedure(cur);
+            if (sub != NULL)
+                append_node(&nested_subs, sub, LIST_TREE);
+            break;
+        }
+        case PASCAL_T_FUNCTION_BODY:
+        case PASCAL_T_BEGIN_BLOCK:
+            body = convert_block(cur);
+            break;
+        case PASCAL_T_ASM_BLOCK: {
+            struct Statement *stmt = convert_statement(cur);
+            ListNode_t *stmts = NULL;
+            if (stmt != NULL)
+                append_node(&stmts, stmt, LIST_STMT);
+            body = mk_compoundstatement(cur->line, stmts);
+            break;
+        }
+        default:
+            break;
+        }
+        cur = cur->next;
+    }
+
+    Tree_t *tree = mk_procedure(proc_node->line, id, params, var_decls, nested_subs, body, 0, 0);
+    return tree;
+}
+
+static Tree_t *convert_function(ast_t *func_node) {
+    ast_t *cur = func_node->child;
+    char *id = NULL;
+
+    if (cur != NULL && cur->typ == PASCAL_T_IDENTIFIER)
+        id = dup_symbol(cur);
+
+    if (cur != NULL)
+        cur = cur->next;
+
+    ListNode_t *params = NULL;
+    if (cur != NULL && cur->typ == PASCAL_T_PARAM_LIST) {
+        ast_t *param_cursor = cur->child;
+        params = convert_param_list(&param_cursor);
+        cur = cur->next;
+    } else {
+        while (cur != NULL && cur->typ == PASCAL_T_PARAM) {
+            Tree_t *param = convert_param(cur);
+            if (param != NULL)
+                append_node(&params, param, LIST_TREE);
+            cur = cur->next;
+        }
+    }
+
+    char *return_type_id = NULL;
+    int return_type = UNKNOWN_TYPE;
+
+    if (cur != NULL && cur->typ == PASCAL_T_RETURN_TYPE) {
+        return_type = convert_type_spec(cur->child, &return_type_id);
+        cur = cur->next;
+    }
+
+    ListNode_t *var_decls = NULL;
+    ListNode_t *nested_subs = NULL;
+    struct Statement *body = NULL;
+
+    while (cur != NULL) {
+        switch (cur->typ) {
+        case PASCAL_T_VAR_SECTION:
+            extend_list(&var_decls, convert_var_section(cur));
+            break;
+        case PASCAL_T_PROCEDURE_DECL:
+        case PASCAL_T_FUNCTION_DECL: {
+            Tree_t *sub = convert_procedure(cur);
+            if (sub != NULL)
+                append_node(&nested_subs, sub, LIST_TREE);
+            break;
+        }
+        case PASCAL_T_FUNCTION_BODY:
+        case PASCAL_T_BEGIN_BLOCK:
+            body = convert_block(cur);
+            break;
+        case PASCAL_T_ASM_BLOCK: {
+            struct Statement *stmt = convert_statement(cur);
+            ListNode_t *stmts = NULL;
+            if (stmt != NULL)
+                append_node(&stmts, stmt, LIST_STMT);
+            body = mk_compoundstatement(cur->line, stmts);
+            break;
+        }
+        default:
+            break;
+        }
+        cur = cur->next;
+    }
+
+    Tree_t *tree = mk_function(func_node->line, id, params, var_decls, nested_subs, body,
+                               return_type, return_type_id, 0, 0);
+    return tree;
+}
+
+Tree_t *tree_from_pascal_ast(ast_t *program_ast) {
+    if (program_ast == NULL)
+        return NULL;
+
+    ast_t *cur = program_ast;
+    if (cur->typ == PASCAL_T_NONE)
+        cur = cur->child;
+
+    if (cur == NULL || cur->typ != PASCAL_T_PROGRAM_DECL) {
+        fprintf(stderr, "ERROR: Expected program declaration at root of AST.\n");
+        return NULL;
+    }
+
+    ast_t *program_name_node = cur->child;
+    char *program_id = program_name_node != NULL ? dup_symbol(program_name_node) : strdup("main");
+
+    ListNode_t *args = NULL;
+    ListNode_t *var_decls = NULL;
+    ListNode_t *type_decls = NULL;
+    ListNode_t *subprograms = NULL;
+    struct Statement *body = NULL;
+
+    ast_t *section = program_name_node != NULL ? program_name_node->next : NULL;
+    while (section != NULL) {
+        switch (section->typ) {
+        case PASCAL_T_VAR_SECTION:
+            extend_list(&var_decls, convert_var_section(section));
+            break;
+        case PASCAL_T_TYPE_SECTION: {
+            ast_t *type_decl = section->child;
+            while (type_decl != NULL) {
+                if (type_decl->typ == PASCAL_T_TYPE_DECL) {
+                    ast_t *id_node = type_decl->child;
+                    char *id = dup_symbol(id_node);
+                    Tree_t *decl = mk_typedecl(type_decl->line, id, 0, 0);
+                    append_node(&type_decls, decl, LIST_TREE);
+                }
+                type_decl = type_decl->next;
+            }
+            break;
+        }
+        case PASCAL_T_PROCEDURE_DECL:
+        case PASCAL_T_FUNCTION_DECL: {
+            Tree_t *sub = (section->typ == PASCAL_T_PROCEDURE_DECL)
+                              ? convert_procedure(section)
+                              : convert_function(section);
+            if (sub != NULL)
+                append_node(&subprograms, sub, LIST_TREE);
+            break;
+        }
+        case PASCAL_T_BEGIN_BLOCK:
+        case PASCAL_T_MAIN_BLOCK:
+            body = convert_block(section);
+            break;
+        default:
+            break;
+        }
+        section = section->next;
+    }
+
+    Tree_t *tree = mk_program(cur->line, program_id, args, var_decls, type_decls, subprograms, body);
+    return tree;
+}

--- a/GPC/Parser/ParseTree/from_cparser.h
+++ b/GPC/Parser/ParseTree/from_cparser.h
@@ -1,0 +1,10 @@
+#ifndef FROM_CPARSER_H
+#define FROM_CPARSER_H
+
+#include "parser.h"
+#include "pascal_parser.h"
+#include "tree.h"
+
+Tree_t *tree_from_pascal_ast(ast_t *program_ast);
+
+#endif /* FROM_CPARSER_H */

--- a/GPC/Parser/ParseTree/tree.c
+++ b/GPC/Parser/ParseTree/tree.c
@@ -5,7 +5,7 @@
 
 #include "tree.h"
 #include "tree_types.h"
-#include "Grammar.tab.h"
+#include "type_tags.h"
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
@@ -428,6 +428,8 @@ void destroy_stmt(struct Statement *stmt)
 
         case STMT_PROCEDURE_CALL:
           free(stmt->stmt_data.procedure_call_data.id);
+          if (stmt->stmt_data.procedure_call_data.mangled_id != NULL)
+            free(stmt->stmt_data.procedure_call_data.mangled_id);
           destroy_list(stmt->stmt_data.procedure_call_data.expr_args);
           break;
 
@@ -676,7 +678,9 @@ struct Statement *mk_procedurecall(int line_num, char *id, ListNode_t *expr_args
     new_stmt->line_num = line_num;
     new_stmt->type = STMT_PROCEDURE_CALL;
     new_stmt->stmt_data.procedure_call_data.id = id;
+    new_stmt->stmt_data.procedure_call_data.mangled_id = NULL;
     new_stmt->stmt_data.procedure_call_data.expr_args = expr_args;
+    new_stmt->stmt_data.procedure_call_data.resolved_proc = NULL;
 
     return new_stmt;
 }
@@ -874,7 +878,9 @@ struct Expression *mk_functioncall(int line_num, char *id, ListNode_t *args)
     new_expr->line_num = line_num;
     new_expr->type = EXPR_FUNCTION_CALL;
     new_expr->expr_data.function_call_data.id = id;
+    new_expr->expr_data.function_call_data.mangled_id = NULL;
     new_expr->expr_data.function_call_data.args_expr = args;
+    new_expr->expr_data.function_call_data.resolved_func = NULL;
 
     return new_expr;
 }
@@ -900,11 +906,7 @@ struct Expression *mk_string(int line_num, char *string)
 
     new_expr->line_num = line_num;
     new_expr->type = EXPR_STRING;
-    new_expr->expr_data.string = strdup(string);
-    if(new_expr->expr_data.string == NULL) {
-        free(new_expr);
-        return NULL;
-    }
+    new_expr->expr_data.string = string;
 
     return new_expr;
 }

--- a/GPC/Parser/ParseTree/type_tags.h
+++ b/GPC/Parser/ParseTree/type_tags.h
@@ -1,0 +1,41 @@
+#ifndef TYPE_TAGS_H
+#define TYPE_TAGS_H
+
+/*
+ * Token constants required by the legacy semantic analyser and code generator.
+ * These were previously provided by the bison-generated Grammar.tab.h but the
+ * cparser integration no longer emits that header.  The numeric values only
+ * need to be unique and stable within the compiler so we define them manually
+ * here.
+ */
+
+#define UNKNOWN_TYPE        0
+#define INT_TYPE            1
+#define REAL_TYPE           2
+#define LONGINT_TYPE        3
+#define STRING_TYPE         4
+#define BUILTIN_ANY_TYPE    5
+
+/* Legacy token constants reused by the semantic analyser and code generator */
+#define BOOL                6
+#define PROCEDURE           7
+
+#define EQ                  8
+#define NE                  9
+#define LT                  10
+#define LE                  11
+#define GT                  12
+#define GE                  13
+
+#define AND                 14
+#define OR                  15
+#define NOT                 16
+
+#define PLUS                17
+#define MINUS               18
+#define STAR                19
+#define SLASH               20
+#define DIV                 21
+#define MOD                 22
+
+#endif /* TYPE_TAGS_H */

--- a/GPC/Parser/SemanticCheck/HashTable/HashTable.c
+++ b/GPC/Parser/SemanticCheck/HashTable/HashTable.c
@@ -177,6 +177,8 @@ void DestroyHashTable(HashTable_t *table)
         while(cur != NULL)
         {
             hash_node = (HashNode_t *)cur->cur;
+            if (hash_node->id != NULL)
+                free(hash_node->id);
             if(hash_node->hash_type == HASHTYPE_BUILTIN_PROCEDURE)
                 DestroyBuiltin(hash_node);
 
@@ -196,7 +198,6 @@ void DestroyBuiltin(HashNode_t *node)
     assert(node != NULL);
     assert(node->hash_type == HASHTYPE_BUILTIN_PROCEDURE);
 
-    free(node->id);
     destroy_list(node->args);
 }
 

--- a/GPC/Parser/SemanticCheck/NameMangling.c
+++ b/GPC/Parser/SemanticCheck/NameMangling.c
@@ -5,7 +5,7 @@
 #include "NameMangling.h"
 #include "../ParseTree/tree.h"
 #include "../List/List.h"
-#include "Grammar.tab.h"
+#include "../ParseTree/type_tags.h"
 #include "SemChecks/SemCheck_expr.h"
 #include "SymTab/SymTab.h"
 

--- a/GPC/Parser/SemanticCheck/SemCheck.c
+++ b/GPC/Parser/SemanticCheck/SemCheck.c
@@ -19,11 +19,11 @@
 #include "../../Optimizer/optimizer.h"
 #include "../ParseTree/tree.h"
 #include "../ParseTree/tree_types.h"
+#include "../ParseTree/type_tags.h"
 #include "./SymTab/SymTab.h"
 #include "./HashTable/HashTable.h"
 #include "SemChecks/SemCheck_stmt.h"
 #include "SemChecks/SemCheck_expr.h"
-#include "Grammar.tab.h"
 #include "NameMangling.h"
 
 /* Adds built-in functions */
@@ -119,8 +119,16 @@ int semcheck_type_decls(SymTab_t *symtab, ListNode_t *type_decls)
 /*TODO: these should be defined in pascal not in semantic analyzer */
 void semcheck_add_builtins(SymTab_t *symtab)
 {
-    AddBuiltinType(symtab, strdup("PChar"), HASHVAR_PCHAR);
-    AddBuiltinType(symtab, strdup("string"), HASHVAR_PCHAR);
+    char *pchar_name = strdup("PChar");
+    if (pchar_name != NULL) {
+        AddBuiltinType(symtab, pchar_name, HASHVAR_PCHAR);
+        free(pchar_name);
+    }
+    char *string_name = strdup("string");
+    if (string_name != NULL) {
+        AddBuiltinType(symtab, string_name, HASHVAR_PCHAR);
+        free(string_name);
+    }
 
     /* Builtins are now in stdlib.p */
 }
@@ -157,7 +165,7 @@ int semcheck_program(SymTab_t *symtab, Tree_t *tree)
         optimize(symtab, tree);
     }
 
-    PopScope(symtab);
+    /* Keep the outermost scope alive for code generation. DestroySymTab will clean it up. */
     return return_val;
 }
 

--- a/GPC/Parser/SemanticCheck/SemChecks/SemCheck_expr.c
+++ b/GPC/Parser/SemanticCheck/SemChecks/SemCheck_expr.c
@@ -20,7 +20,7 @@
 #include "../SymTab/SymTab.h"
 #include "../../ParseTree/tree.h"
 #include "../../ParseTree/tree_types.h"
-#include "Grammar.tab.h"
+#include "../../ParseTree/type_tags.h"
 
 int is_type_ir(int *type);
 int is_and_or(int *type);

--- a/GPC/Parser/SemanticCheck/SemChecks/SemCheck_stmt.c
+++ b/GPC/Parser/SemanticCheck/SemChecks/SemCheck_stmt.c
@@ -20,7 +20,7 @@
 #include "../../ParseTree/tree.h"
 #include "../../ParseTree/tree_types.h"
 #include "../../List/List.h"
-#include "Grammar.tab.h"
+#include "../../ParseTree/type_tags.h"
 
 int semcheck_stmt_main(SymTab_t *symtab, struct Statement *stmt, int max_scope_lev);
 
@@ -176,15 +176,18 @@ int semcheck_proccall(SymTab_t *symtab, struct Statement *stmt, int max_scope_le
     else if (match_count == 0)
     {
         fprintf(stderr, "Error on line %d, call to procedure %s does not match any available overload\n", stmt->line_num, proc_id);
+        DestroyList(overload_candidates);
         free(mangled_name);
         return ++return_val;
     }
     else
     {
         fprintf(stderr, "Error on line %d, call to procedure %s is ambiguous\n", stmt->line_num, proc_id);
+        DestroyList(overload_candidates);
         free(mangled_name);
         return ++return_val;
     }
+    DestroyList(overload_candidates);
     free(mangled_name);
 
     if(scope_return == -1) // Should not happen if match_count > 0

--- a/GPC/debug_deserializer.c
+++ b/GPC/debug_deserializer.c
@@ -3,7 +3,7 @@
 #include <string.h>
 #include "debug_deserializer.h"
 #include "Parser/ParseTree/tree_types.h"
-#include "Grammar.tab.h"
+#include "Parser/ParseTree/type_tags.h"
 #include "Parser/ParseTree/tree.h"
 
 struct Expression *deserialize_expression(FILE *fp) {

--- a/GPC/debug_serializer.c
+++ b/GPC/debug_serializer.c
@@ -2,7 +2,7 @@
 #include <stdlib.h>
 #include "debug_serializer.h"
 #include "Parser/ParseTree/tree_types.h"
-#include "Grammar.tab.h"
+#include "Parser/ParseTree/type_tags.h"
 
 void serialize_expression_recursive(FILE *fp, struct Expression *expr) {
     if (expr == NULL) {

--- a/GPC/main_cparser.c
+++ b/GPC/main_cparser.c
@@ -1,128 +1,377 @@
-/* 
- * GPC - Gwinn Pascal Compiler
- * Main entry point using cparser
+/*
+ * GPC - Gwinn Pascal Compiler (cparser integration)
  */
 
+#include <assert.h>
+#include <libgen.h>
+#include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <unistd.h>
+
+#ifndef PATH_MAX
+#define PATH_MAX 4096
+#endif
+
 #include "parser.h"
 #include "combinators.h"
 #include "pascal_parser.h"
 #include "pascal_declaration.h"
 
-// External ast_nil (defined in parser.c)
-extern ast_t* ast_nil;
+#include "flags.h"
+#include "Parser/ParseTree/tree.h"
+#include "Parser/ParseTree/from_cparser.h"
+#include "Parser/SemanticCheck/SemCheck.h"
+#include "CodeGenerator/Intel_x86-64/codegen.h"
+#include "stacktrace.h"
 
-void print_usage(const char* prog_name) {
-    fprintf(stderr, "Usage: %s <input.p> <output.s>\n", prog_name);
+extern ast_t *ast_nil;
+
+/* Legacy globals referenced in other components */
+Tree_t *parse_tree = NULL;
+int num_args_alloced = 0;
+int line_num = 1;
+int col_num = 1;
+char *file_to_parse = NULL;
+
+static void print_usage(const char *prog_name)
+{
+    fprintf(stderr, "Usage: %s <input.p> <output.s> [flags]\n", prog_name);
     fprintf(stderr, "  Compiles Pascal source to x86-64 assembly\n");
 }
 
-int main(int argc, char** argv) {
-    if (argc < 3) {
-        print_usage(argv[0]);
-        return 1;
+static int file_is_readable(const char *path)
+{
+    return path != NULL && access(path, R_OK) == 0;
+}
+
+static char *duplicate_path(const char *path)
+{
+    if (path == NULL)
+        return NULL;
+
+    char *dup = strdup(path);
+    if (dup == NULL)
+        fprintf(stderr, "Error: Memory allocation failed while duplicating path '%s'\n", path);
+
+    return dup;
+}
+
+static ssize_t get_executable_path(char *buffer, size_t size, const char *argv0)
+{
+#if defined(__linux__) || defined(__unix__) || defined(__APPLE__)
+    ssize_t len = readlink("/proc/self/exe", buffer, size - 1);
+    if (len >= 0)
+    {
+        buffer[len] = '\0';
+        return len;
+    }
+#endif
+
+    if (argv0 != NULL)
+    {
+        char resolved[PATH_MAX];
+        if (realpath(argv0, resolved) != NULL)
+        {
+            strncpy(buffer, resolved, size);
+            buffer[size - 1] = '\0';
+            return (ssize_t)strlen(buffer);
+        }
     }
 
-    const char* input_file = argv[1];
-    const char* output_file = argv[2];
+    return -1;
+}
 
-    // Read input file
-    FILE* file = fopen(input_file, "r");
-    if (!file) {
-        fprintf(stderr, "Error: Cannot open input file '%s'\n", input_file);
-        return 1;
+static char *resolve_stdlib_path(const char *argv0)
+{
+    const char *env = getenv("GPC_STDLIB");
+    if (file_is_readable(env))
+        return duplicate_path(env);
+
+    if (file_is_readable("GPC/stdlib.p"))
+        return duplicate_path("GPC/stdlib.p");
+
+    const char *source_root = getenv("MESON_SOURCE_ROOT");
+    if (source_root != NULL)
+    {
+        char candidate[PATH_MAX];
+        snprintf(candidate, sizeof(candidate), "%s/GPC/stdlib.p", source_root);
+        if (file_is_readable(candidate))
+            return duplicate_path(candidate);
     }
 
-    fseek(file, 0, SEEK_END);
-    long file_size = ftell(file);
-    fseek(file, 0, SEEK_SET);
+    char exe_path[PATH_MAX];
+    ssize_t len = get_executable_path(exe_path, sizeof(exe_path), argv0);
+    if (len > 0)
+    {
+        char exe_dir[PATH_MAX];
+        strncpy(exe_dir, exe_path, sizeof(exe_dir));
+        exe_dir[sizeof(exe_dir) - 1] = '\0';
 
-    char* file_content = malloc(file_size + 1);
-    if (!file_content) {
-        fprintf(stderr, "Error: Memory allocation failed\n");
-        fclose(file);
-        return 1;
+        char *dir = dirname(exe_dir);
+        if (dir != NULL)
+        {
+            const char *relative_candidates[] = {
+                "../../GPC/stdlib.p",
+                "../GPC/stdlib.p",
+                "../stdlib.p",
+            };
+
+            for (size_t i = 0; i < sizeof(relative_candidates) / sizeof(relative_candidates[0]); ++i)
+            {
+                char candidate[PATH_MAX];
+                snprintf(candidate, sizeof(candidate), "%s/%s", dir, relative_candidates[i]);
+                if (file_is_readable(candidate))
+                    return duplicate_path(candidate);
+            }
+        }
     }
 
-    size_t bytes_read = fread(file_content, 1, file_size, file);
-    file_content[bytes_read] = '\0';
-    fclose(file);
+    return NULL;
+}
 
-    // Initialize parser
-    combinator_t* parser = new_combinator();
+static void set_flags(char **optional_args, int count)
+{
+    int i = 0;
+    while (count > 0)
+    {
+        if (strcmp(optional_args[i], "-non-local") == 0)
+        {
+            fprintf(stderr, "Non-local codegen support enabled\n");
+            fprintf(stderr, "WARNING: Non-local is still in development and is very buggy!\n\n");
+            set_nonlocal_flag();
+        }
+        else if (strcmp(optional_args[i], "-O1") == 0)
+        {
+            fprintf(stderr, "O1 optimizations enabled!\n\n");
+            set_o1_flag();
+        }
+        else if (strcmp(optional_args[i], "-O2") == 0)
+        {
+            fprintf(stderr, "O2 optimizations enabled!\n\n");
+            set_o2_flag();
+        }
+        else
+        {
+            fprintf(stderr, "ERROR: Unrecognized flag: %s\n", optional_args[i]);
+            exit(1);
+        }
+
+        --count;
+        ++i;
+    }
+}
+
+static char *read_file(const char *path, size_t *out_len)
+{
+    FILE *f = fopen(path, "rb");
+    if (f == NULL)
+    {
+        fprintf(stderr, "Error: Cannot open file '%s'\n", path);
+        return NULL;
+    }
+
+    if (fseek(f, 0, SEEK_END) != 0)
+    {
+        fprintf(stderr, "Error: Failed to seek file '%s'\n", path);
+        fclose(f);
+        return NULL;
+    }
+
+    long size = ftell(f);
+    if (size < 0)
+    {
+        fprintf(stderr, "Error: Failed to determine file size for '%s'\n", path);
+        fclose(f);
+        return NULL;
+    }
+
+    if (fseek(f, 0, SEEK_SET) != 0)
+    {
+        fprintf(stderr, "Error: Failed to rewind file '%s'\n", path);
+        fclose(f);
+        return NULL;
+    }
+
+    char *buffer = malloc((size_t)size + 1);
+    if (buffer == NULL)
+    {
+        fprintf(stderr, "Error: Memory allocation failed while reading '%s'\n", path);
+        fclose(f);
+        return NULL;
+    }
+
+    size_t read = fread(buffer, 1, (size_t)size, f);
+    fclose(f);
+
+    buffer[read] = '\0';
+    if (out_len != NULL)
+        *out_len = read;
+    return buffer;
+}
+
+static void report_parse_error(const char *path, ParseError *err)
+{
+    if (err == NULL)
+        return;
+
+    fprintf(stderr, "Parse error in %s:\n", path);
+    fprintf(stderr, "  Line %d, Column %d: %s\n",
+            err->line, err->col,
+            err->message ? err->message : "unknown error");
+    if (err->unexpected)
+        fprintf(stderr, "  Unexpected: %s\n", err->unexpected);
+}
+
+static Tree_t *parse_pascal_file(const char *path)
+{
+    size_t length = 0;
+    char *buffer = read_file(path, &length);
+    if (buffer == NULL)
+        return NULL;
+
+    combinator_t *parser = new_combinator();
     init_pascal_complete_program_parser(&parser);
 
-    input_t* in = new_input();
-    in->buffer = file_content;
-    in->length = bytes_read;
+    input_t *input = new_input();
+    input->buffer = buffer;
+    input->length = (int)length;
 
-    // Initialize ast_nil (already defined in parser.c, just needs to be set)
-    if (ast_nil == NULL) {
+    if (ast_nil == NULL)
+    {
         ast_nil = new_ast();
         ast_nil->typ = PASCAL_T_NONE;
     }
 
-    // Parse
-    fprintf(stderr, "Parsing %s...\n", input_file);
-    ParseResult result = parse(in, parser);
+    file_to_parse = (char *)path;
 
-    if (!result.is_success) {
-        fprintf(stderr, "Parse error:\n");
-        if (result.value.error) {
-            fprintf(stderr, "  Line %d, Column %d: %s\n",
-                    result.value.error->line,
-                    result.value.error->col,
-                    result.value.error->message);
-            if (result.value.error->unexpected) {
-                fprintf(stderr, "  Unexpected: %s\n", result.value.error->unexpected);
-            }
+    ParseResult result = parse(input, parser);
+    Tree_t *tree = NULL;
+    if (!result.is_success)
+    {
+        report_parse_error(path, result.value.error);
+        if (result.value.error != NULL)
             free_error(result.value.error);
+    }
+    else
+    {
+        if (input->start < input->length)
+        {
+            fprintf(stderr,
+                    "Warning: Parser did not consume entire input for %s (at position %d of %d)\n",
+                    path, input->start, input->length);
         }
-        free(file_content);
-        free(in);
-        free_combinator(parser);
-        free_ast(ast_nil);
-        return 1;
-    }
 
-    if (in->start < in->length) {
-        fprintf(stderr, "Warning: Parser did not consume entire input (at position %d of %d)\n",
-                in->start, in->length);
-    }
-
-    fprintf(stderr, "Parsing successful!\n");
-    
-    // TODO: Implement semantic checking
-    fprintf(stderr, "Semantic checking not yet implemented\n");
-    
-    // TODO: Implement code generation
-    fprintf(stderr, "Code generation not yet implemented\n");
-    
-    // For now, just write a placeholder output
-    FILE* out = fopen(output_file, "w");
-    if (!out) {
-        fprintf(stderr, "Error: Cannot open output file '%s'\n", output_file);
+        tree = tree_from_pascal_ast(result.value.ast);
+        if (tree == NULL)
+        {
+            fprintf(stderr, "Error: Failed to convert AST for '%s' to legacy parse tree.\n", path);
+        }
         free_ast(result.value.ast);
-        free(file_content);
-        free(in);
-        free_combinator(parser);
-        free_ast(ast_nil);
+    }
+
+    free(buffer);
+    free(input);
+    file_to_parse = NULL;
+    free_combinator(parser);
+    return tree;
+}
+
+int main(int argc, char **argv)
+{
+    install_stack_trace_handler();
+
+    if (argc < 3)
+    {
+        print_usage(argv[0]);
         return 1;
     }
-    
-    fprintf(out, "# Generated by GPC with cparser\n");
-    fprintf(out, "# TODO: Implement code generation\n");
-    fclose(out);
 
-    // Cleanup
-    free_ast(result.value.ast);
-    free(file_content);
-    free(in);
-    free_combinator(parser);
-    free_ast(ast_nil);
+    const char *input_file = argv[1];
+    const char *output_file = argv[2];
 
-    fprintf(stderr, "Output written to %s\n", output_file);
-    return 0;
+    int optional_count = argc - 3;
+    if (optional_count > 0)
+        set_flags(argv + 3, optional_count);
+
+    char *stdlib_path = resolve_stdlib_path(argv[0]);
+    if (stdlib_path == NULL)
+    {
+        fprintf(stderr, "Error: Unable to locate stdlib.p. Set GPC_STDLIB or run from the project root.\n");
+        return 1;
+    }
+
+    Tree_t *prelude_tree = parse_pascal_file(stdlib_path);
+    if (prelude_tree == NULL)
+    {
+        free(stdlib_path);
+        return 1;
+    }
+
+    Tree_t *user_tree = parse_pascal_file(input_file);
+    if (user_tree == NULL)
+    {
+        destroy_tree(prelude_tree);
+        free(stdlib_path);
+        return 1;
+    }
+
+    ListNode_t *prelude_subs = prelude_tree->tree_data.program_data.subprograms;
+    ListNode_t *user_subs = user_tree->tree_data.program_data.subprograms;
+    if (prelude_subs != NULL)
+    {
+        ListNode_t *last = prelude_subs;
+        while (last->next != NULL)
+            last = last->next;
+        last->next = user_subs;
+        user_tree->tree_data.program_data.subprograms = prelude_subs;
+        prelude_tree->tree_data.program_data.subprograms = NULL;
+    }
+
+    int sem_result = 0;
+    SymTab_t *symtab = start_semcheck(user_tree, &sem_result);
+    int exit_code = 0;
+
+    if (sem_result <= 0)
+    {
+        fprintf(stderr, "Generating code to file: %s\n", output_file);
+
+        CodeGenContext ctx;
+        ctx.output_file = fopen(output_file, "w");
+        if (ctx.output_file == NULL)
+        {
+            fprintf(stderr, "ERROR: Failed to open output file: %s\n", output_file);
+            DestroySymTab(symtab);
+            destroy_tree(prelude_tree);
+            destroy_tree(user_tree);
+            return 1;
+        }
+        ctx.label_counter = 1;
+        ctx.write_label_counter = 1;
+
+        codegen(user_tree, input_file, &ctx, symtab);
+        fclose(ctx.output_file);
+    }
+    else
+    {
+        fprintf(stderr, "Semantic analysis failed with %d error(s).\n", sem_result);
+        exit_code = sem_result;
+    }
+
+    DestroySymTab(symtab);
+    destroy_tree(prelude_tree);
+    destroy_tree(user_tree);
+    free(stdlib_path);
+
+    if (ast_nil != NULL)
+    {
+        free(ast_nil);
+        ast_nil = NULL;
+    }
+
+    if (sem_result > 0)
+        return exit_code > 0 ? exit_code : 1;
+
+    return exit_code;
 }

--- a/GPC/meson.build
+++ b/GPC/meson.build
@@ -1,70 +1,5 @@
 
 compiler = meson.get_compiler('c')
-flex = find_program('flex')
-bison = find_program('bison')
-
-bison_gen = generator(bison,
-  output: ['@BASENAME@.tab.c', '@BASENAME@.tab.h'],
-  arguments: ['-d', '-o', '@OUTPUT0@', '--defines=@OUTPUT1@', '@INPUT@'])
-
-flex_gen = generator(flex,
-  output: '@BASENAME@.c',
-  arguments: ['-o', '@OUTPUT@', '@INPUT@'])
-
-bison_generated = bison_gen.process('Parser/LexAndYacc/Grammar.y')
-flex_generated = flex_gen.process('Parser/LexAndYacc/lex.yy.l')
-
-# Original GPC sources (legacy flex/bison version) - disabled for now
-# gpc_sources = [
-#   'main.c',
-#   'flags.c',
-#   'Parser/ParsePascal.c',
-#   'Parser/List/List.c',
-#   'Parser/ParseTree/tree.c',
-#   'Parser/SemanticCheck/SemCheck.c',
-#   'Parser/SemanticCheck/HashTable/HashTable.c',
-#   'Parser/SemanticCheck/SymTab/SymTab.c',
-#   'Parser/SemanticCheck/NameMangling.c',
-#   'Parser/SemanticCheck/SemChecks/SemCheck_stmt.c',
-#   'Parser/SemanticCheck/SemChecks/SemCheck_expr.c',
-#   'CodeGenerator/Intel_x86-64/codegen.c',
-#   'CodeGenerator/Intel_x86-64/codegen_statement.c',
-#   'CodeGenerator/Intel_x86-64/codegen_expression.c',
-#   'CodeGenerator/Intel_x86-64/codegen_builtins.c',
-#   'CodeGenerator/Intel_x86-64/stackmng/stackmng.c',
-#   'CodeGenerator/Intel_x86-64/expr_tree/expr_tree.c',
-#   'Optimizer/optimizer.c',
-#   'stacktrace.c'
-# ]
-# 
-# gpc_sources += bison_generated
-# gpc_sources += flex_generated
-# 
-# inc_dirs = include_directories(
-#   '.',
-#   'Parser',
-#   'Parser/LexAndYacc',
-#   'Parser/ParseTree',
-#   'Parser/List',
-#   'Parser/SemanticCheck/HashTable',
-#   'Parser/SemanticCheck/SymTab',
-#   'Parser/SemanticCheck',
-#   'CodeGenerator/Intel_x86-64',
-#   'Optimizer'
-# )
-# 
-# # Build legacy GPC executable (for reference/comparison)
-# gpc_exe = executable('gpc-legacy', gpc_sources,
-#   include_directories: inc_dirs,
-#   dependencies: [
-#     compiler.find_library('m', required: false),
-#     compiler.find_library('fl', required: false),
-#     compiler.find_library('unwind', required: false),
-#     compiler.find_library('unwind-x86_64', required: false),
-#     compiler.find_library('dl', required: false),
-#     compiler.find_library('pthread', required: false),
-#   ]
-# )
 
 inc_dirs = include_directories(
   '.',
@@ -79,9 +14,26 @@ inc_dirs = include_directories(
   'Optimizer'
 )
 
-# New GPC executable using cparser
 gpc_cparser_sources = [
   'main_cparser.c',
+  'flags.c',
+  'Parser/ParseTree/from_cparser.c',
+  'Parser/List/List.c',
+  'Parser/ParseTree/tree.c',
+  'Parser/SemanticCheck/SemCheck.c',
+  'Parser/SemanticCheck/HashTable/HashTable.c',
+  'Parser/SemanticCheck/SymTab/SymTab.c',
+  'Parser/SemanticCheck/NameMangling.c',
+  'Parser/SemanticCheck/SemChecks/SemCheck_stmt.c',
+  'Parser/SemanticCheck/SemChecks/SemCheck_expr.c',
+  'CodeGenerator/Intel_x86-64/codegen.c',
+  'CodeGenerator/Intel_x86-64/codegen_statement.c',
+  'CodeGenerator/Intel_x86-64/codegen_expression.c',
+  'CodeGenerator/Intel_x86-64/codegen_builtins.c',
+  'CodeGenerator/Intel_x86-64/stackmng/stackmng.c',
+  'CodeGenerator/Intel_x86-64/expr_tree/expr_tree.c',
+  'Optimizer/optimizer.c',
+  'stacktrace.c',
 ]
 
 gpc_cparser_exe = executable('gpc', gpc_cparser_sources,

--- a/GPC/stacktrace.c
+++ b/GPC/stacktrace.c
@@ -1,4 +1,11 @@
 #define _GNU_SOURCE
+#if defined(__has_include)
+#  if __has_include(<libunwind.h>)
+#    define HAVE_LIBUNWIND 1
+#  endif
+#endif
+
+#ifdef HAVE_LIBUNWIND
 #include <libunwind.h>
 #include <signal.h>
 #include <stdio.h>
@@ -45,3 +52,18 @@ void install_stack_trace_handler(void) {
     sigaction(SIGFPE, &sa, NULL);
     sigaction(SIGABRT, &sa, NULL);
 }
+
+#else
+
+#include <signal.h>
+
+#include "stacktrace.h"
+
+void install_stack_trace_handler(void) {
+    /* libunwind not available; no-op handler */
+    signal(SIGSEGV, SIG_DFL);
+    signal(SIGFPE, SIG_DFL);
+    signal(SIGABRT, SIG_DFL);
+}
+
+#endif

--- a/debug_harness/CodeGenerator/Intel_x86-64/codegen.c
+++ b/debug_harness/CodeGenerator/Intel_x86-64/codegen.c
@@ -20,7 +20,7 @@
 #include "../../Parser/List/List.h"
 #include "../../Parser/ParseTree/tree.h"
 #include "../../Parser/ParseTree/tree_types.h"
-#include "Grammar.tab.h"
+#include "../../Parser/ParseTree/type_tags.h"
 
 /* Platform detection */
 #if defined(__linux__) || defined(__unix__)
@@ -203,6 +203,7 @@ void codegen_program_header(char *fname, CodeGenContext *ctx)
 void codegen_program_footer(CodeGenContext *ctx)
 {
 #if PLATFORM_LINUX
+    fprintf(ctx->output_file, "\t.section\t.note.GNU-stack,\"\",@progbits\n");
 #else
     fprintf(ctx->output_file, ".ident\t\"GPC: 0.0.0\"\n");
 #endif

--- a/debug_harness/CodeGenerator/Intel_x86-64/codegen_expression.c
+++ b/debug_harness/CodeGenerator/Intel_x86-64/codegen_expression.c
@@ -16,7 +16,7 @@
 #include "../../Parser/List/List.h"
 #include "../../Parser/ParseTree/tree.h"
 #include "../../Parser/ParseTree/tree_types.h"
-#include "Grammar.tab.h"
+#include "../../Parser/ParseTree/type_tags.h"
 #include "../../Parser/SemanticCheck/HashTable/HashTable.h"
 
 

--- a/debug_harness/CodeGenerator/Intel_x86-64/codegen_statement.c
+++ b/debug_harness/CodeGenerator/Intel_x86-64/codegen_statement.c
@@ -12,7 +12,7 @@
 #include "../../Parser/List/List.h"
 #include "../../Parser/ParseTree/tree.h"
 #include "../../Parser/ParseTree/tree_types.h"
-#include "Grammar.tab.h"
+#include "../../Parser/ParseTree/type_tags.h"
 #include "../../Parser/SemanticCheck/SymTab/SymTab.h"
 #include "../../Parser/SemanticCheck/HashTable/HashTable.h"
 

--- a/debug_harness/CodeGenerator/Intel_x86-64/expr_tree/expr_tree.c
+++ b/debug_harness/CodeGenerator/Intel_x86-64/expr_tree/expr_tree.c
@@ -19,7 +19,7 @@
 #include "../../../Parser/List/List.h"
 #include "../../../Parser/ParseTree/tree.h"
 #include "../../../Parser/ParseTree/tree_types.h"
-#include "Grammar.tab.h"
+#include "../../../Parser/ParseTree/type_tags.h"
 
 /* Helper functions */
 ListNode_t *gencode_sign_term(expr_node_t *node, ListNode_t *inst_list, CodeGenContext *ctx, Register_t *target_reg);

--- a/debug_harness/CodeGenerator/Intel_x86-64/expr_tree/expr_tree.h
+++ b/debug_harness/CodeGenerator/Intel_x86-64/expr_tree/expr_tree.h
@@ -13,7 +13,7 @@
 #include "../stackmng/stackmng.h"
 #include "../../../Parser/ParseTree/tree.h"
 #include "../../../Parser/ParseTree/tree_types.h"
-#include "Grammar.tab.h"
+#include "../../../Parser/ParseTree/type_tags.h"
 
 
 typedef struct expr_node expr_node_t;

--- a/debug_harness/Optimizer/optimizer.c
+++ b/debug_harness/Optimizer/optimizer.c
@@ -23,7 +23,7 @@
 #include "../Parser/ParseTree/tree_types.h"
 #include "../Parser/SemanticCheck/SymTab/SymTab.h"
 #include "../Parser/SemanticCheck/HashTable/HashTable.h"
-#include "Grammar.tab.h"
+#include "../Parser/ParseTree/type_tags.h"
 
 void optimize_prog(SymTab_t *symtab, Tree_t *prog);
 void optimize_subprog(SymTab_t *symtab, Tree_t *sub);

--- a/debug_harness/Parser/LexAndYacc/lex.yy.l
+++ b/debug_harness/Parser/LexAndYacc/lex.yy.l
@@ -10,7 +10,7 @@
     #include "ErrVars.h"
     #include "tree.h"
     #include "List.h"
-    #include "Grammar.tab.h"
+    #include "../ParseTree/type_tags.h"
 
     char asm_buffer[1024];
     int if_stack[100];

--- a/debug_harness/Parser/ParsePascal.c
+++ b/debug_harness/Parser/ParsePascal.c
@@ -11,7 +11,7 @@
 #include "ParseTree/tree_types.h"
 #include "List/List.h"
 #include "SemanticCheck/SemCheck.h"
-#include "Grammar.tab.h"
+#include "ParseTree/type_tags.h"
 
 extern FILE *yyin;
 extern int yyparse();

--- a/debug_harness/Parser/ParseTree/tree.c
+++ b/debug_harness/Parser/ParseTree/tree.c
@@ -5,7 +5,7 @@
 
 #include "tree.h"
 #include "tree_types.h"
-#include "Grammar.tab.h"
+#include "type_tags.h"
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
@@ -426,6 +426,8 @@ void destroy_stmt(struct Statement *stmt)
 
         case STMT_PROCEDURE_CALL:
           free(stmt->stmt_data.procedure_call_data.id);
+          if (stmt->stmt_data.procedure_call_data.mangled_id != NULL)
+            free(stmt->stmt_data.procedure_call_data.mangled_id);
           destroy_list(stmt->stmt_data.procedure_call_data.expr_args);
           break;
 
@@ -665,7 +667,9 @@ struct Statement *mk_procedurecall(int line_num, char *id, ListNode_t *expr_args
     new_stmt->line_num = line_num;
     new_stmt->type = STMT_PROCEDURE_CALL;
     new_stmt->stmt_data.procedure_call_data.id = id;
+    new_stmt->stmt_data.procedure_call_data.mangled_id = NULL;
     new_stmt->stmt_data.procedure_call_data.expr_args = expr_args;
+    new_stmt->stmt_data.procedure_call_data.resolved_proc = NULL;
 
     return new_stmt;
 }
@@ -850,7 +854,9 @@ struct Expression *mk_functioncall(int line_num, char *id, ListNode_t *args)
     new_expr->line_num = line_num;
     new_expr->type = EXPR_FUNCTION_CALL;
     new_expr->expr_data.function_call_data.id = id;
+    new_expr->expr_data.function_call_data.mangled_id = NULL;
     new_expr->expr_data.function_call_data.args_expr = args;
+    new_expr->expr_data.function_call_data.resolved_func = NULL;
 
     return new_expr;
 }
@@ -874,11 +880,7 @@ struct Expression *mk_string(int line_num, char *string)
 
     new_expr->line_num = line_num;
     new_expr->type = EXPR_STRING;
-    new_expr->expr_data.string = strdup(string);
-    if(new_expr->expr_data.string == NULL) {
-        free(new_expr);
-        return NULL;
-    }
+    new_expr->expr_data.string = string;
 
     return new_expr;
 }

--- a/debug_harness/Parser/ParseTree/type_tags.h
+++ b/debug_harness/Parser/ParseTree/type_tags.h
@@ -1,0 +1,41 @@
+#ifndef TYPE_TAGS_H
+#define TYPE_TAGS_H
+
+/*
+ * Token constants required by the legacy semantic analyser and code generator.
+ * These were previously provided by the bison-generated Grammar.tab.h but the
+ * cparser integration no longer emits that header.  The numeric values only
+ * need to be unique and stable within the compiler so we define them manually
+ * here.
+ */
+
+#define UNKNOWN_TYPE        0
+#define INT_TYPE            1
+#define REAL_TYPE           2
+#define LONGINT_TYPE        3
+#define STRING_TYPE         4
+#define BUILTIN_ANY_TYPE    5
+
+/* Legacy token constants reused by the semantic analyser and code generator */
+#define BOOL                6
+#define PROCEDURE           7
+
+#define EQ                  8
+#define NE                  9
+#define LT                  10
+#define LE                  11
+#define GT                  12
+#define GE                  13
+
+#define AND                 14
+#define OR                  15
+#define NOT                 16
+
+#define PLUS                17
+#define MINUS               18
+#define STAR                19
+#define SLASH               20
+#define DIV                 21
+#define MOD                 22
+
+#endif /* TYPE_TAGS_H */

--- a/debug_harness/Parser/SemanticCheck/NameMangling.c
+++ b/debug_harness/Parser/SemanticCheck/NameMangling.c
@@ -4,7 +4,7 @@
 #include "NameMangling.h"
 #include "../ParseTree/tree.h"
 #include "../List/List.h"
-#include "Grammar.tab.h"
+#include "../ParseTree/type_tags.h"
 #include "SemChecks/SemCheck_expr.h"
 #include "SymTab/SymTab.h"
 

--- a/debug_harness/Parser/SemanticCheck/SemCheck.c
+++ b/debug_harness/Parser/SemanticCheck/SemCheck.c
@@ -23,7 +23,7 @@
 #include "./HashTable/HashTable.h"
 #include "SemChecks/SemCheck_stmt.h"
 #include "SemChecks/SemCheck_expr.h"
-#include "Grammar.tab.h"
+#include "../ParseTree/type_tags.h"
 #include "NameMangling.h"
 
 /* Adds built-in functions */
@@ -118,8 +118,16 @@ void semcheck_add_builtins(SymTab_t *symtab)
     char *id;
     ListNode_t *args, *arg_ids;
 
-    AddBuiltinType(symtab, strdup("PChar"), HASHVAR_PCHAR);
-    AddBuiltinType(symtab, strdup("string"), HASHVAR_PCHAR);
+    char *pchar_name = strdup("PChar");
+    if (pchar_name != NULL) {
+        AddBuiltinType(symtab, pchar_name, HASHVAR_PCHAR);
+        free(pchar_name);
+    }
+    char *string_name = strdup("string");
+    if (string_name != NULL) {
+        AddBuiltinType(symtab, string_name, HASHVAR_PCHAR);
+        free(string_name);
+    }
 
     /* Builtins are now in stdlib.p */
 }

--- a/debug_harness/Parser/SemanticCheck/SemChecks/SemCheck_expr.c
+++ b/debug_harness/Parser/SemanticCheck/SemChecks/SemCheck_expr.c
@@ -20,7 +20,7 @@
 #include "../SymTab/SymTab.h"
 #include "../../ParseTree/tree.h"
 #include "../../ParseTree/tree_types.h"
-#include "Grammar.tab.h"
+#include "../../ParseTree/type_tags.h"
 
 int is_type_ir(int *type);
 int is_and_or(int *type);

--- a/debug_harness/Parser/SemanticCheck/SemChecks/SemCheck_stmt.c
+++ b/debug_harness/Parser/SemanticCheck/SemChecks/SemCheck_stmt.c
@@ -20,7 +20,7 @@
 #include "../../ParseTree/tree.h"
 #include "../../ParseTree/tree_types.h"
 #include "../../List/List.h"
-#include "Grammar.tab.h"
+#include "../../ParseTree/type_tags.h"
 
 int semcheck_stmt_main(SymTab_t *symtab, struct Statement *stmt, int max_scope_lev);
 

--- a/debug_harness/debug_deserializer.c
+++ b/debug_harness/debug_deserializer.c
@@ -3,7 +3,7 @@
 #include <string.h>
 #include "debug_deserializer.h"
 #include "Parser/ParseTree/tree_types.h"
-#include "Grammar.tab.h"
+#include "Parser/ParseTree/type_tags.h"
 #include "Parser/ParseTree/tree.h"
 
 struct Expression *deserialize_expression(FILE *fp) {

--- a/debug_harness/debug_serializer.c
+++ b/debug_harness/debug_serializer.c
@@ -2,7 +2,7 @@
 #include <stdlib.h>
 #include "debug_serializer.h"
 #include "Parser/ParseTree/tree_types.h"
-#include "Grammar.tab.h"
+#include "Parser/ParseTree/type_tags.h"
 
 void serialize_expression_recursive(FILE *fp, struct Expression *expr) {
     if (expr == NULL) {


### PR DESCRIPTION
## Summary
- harden the parser combinator teardown so recursive walks don't double-free shared nodes and lazy placeholders stay valid until all references release
- fix the choice combinator backtracking and teach the Pascal range type loader to reuse the expression parser without losing the bound expressions
- clean up semantic bookkeeping for builtin types and mangled identifiers so teardown frees the ownership it acquires

## Testing
- meson test -C build
- valgrind --leak-check=full ./build/GPC/gpc tests/test_cases/helloworld.p /tmp/helloworld.s
- ./build/GPC/gpc /tmp/convex_hull_task.p /tmp/convex_hull_task.s


------
https://chatgpt.com/codex/tasks/task_e_68fd6af6c21c832aac3c9570b4f41c4f