### PR TITLE
Implement MPInteger runtime support and unit

### DIFF
--- a/GPC/CodeGenerator/Intel_x86-64/codegen_statement.c
+++ b/GPC/CodeGenerator/Intel_x86-64/codegen_statement.c
@@ -534,7 +534,17 @@ ListNode_t *codegen_var_assignment(struct Statement *stmt, ListNode_t *inst_list
         snprintf(buffer, 50, "\tmovq\t-%d(%%rbp), %s\n", addr_temp->offset, addr_reload->bit_64);
         inst_list = add_inst(inst_list, buffer);
 
-        snprintf(buffer, 50, "\tmovl\t%s, (%s)\n", value_reg->bit_32, addr_reload->bit_64);
+        int value_type = assign_expr != NULL ? assign_expr->resolved_type : UNKNOWN_TYPE;
+        const char *value_operand = value_reg->bit_32;
+        const char *store_mnemonic = "movl";
+
+        if (value_type == LONGINT_TYPE || value_type == STRING_TYPE)
+        {
+            value_operand = value_reg->bit_64;
+            store_mnemonic = "movq";
+        }
+
+        snprintf(buffer, 50, "\t%s\t%s, (%s)\n", store_mnemonic, value_operand, addr_reload->bit_64);
         inst_list = add_inst(inst_list, buffer);
 
         free_reg(get_reg_stack(), value_reg);

--- a/GPC/CodeGenerator/Intel_x86-64/expr_tree/expr_tree.c
+++ b/GPC/CodeGenerator/Intel_x86-64/expr_tree/expr_tree.c
@@ -398,7 +398,14 @@ ListNode_t *gencode_case0(expr_node_t *node, ListNode_t *inst_list, CodeGenConte
         inst_list = codegen_pass_arguments(expr->expr_data.function_call_data.args_expr, inst_list, ctx, expr->expr_data.function_call_data.resolved_func);
         snprintf(buffer, 50, "\tcall\t%s\n", expr->expr_data.function_call_data.mangled_id);
         inst_list = add_inst(inst_list, buffer);
-        snprintf(buffer, 50, "\tmovl\t%%eax, %s\n", target_reg->bit_32);
+
+        int use_qword = (expr->resolved_type == LONGINT_TYPE ||
+            expr->resolved_type == STRING_TYPE);
+        if (use_qword)
+            snprintf(buffer, 50, "\tmovq\t%%rax, %s\n", target_reg->bit_64);
+        else
+            snprintf(buffer, 50, "\tmovl\t%%eax, %s\n", target_reg->bit_32);
+
         inst_list = add_inst(inst_list, buffer);
         return inst_list;
     }

--- a/GPC/Units/gmp.p
+++ b/GPC/Units/gmp.p
@@ -1,0 +1,98 @@
+unit gmp;
+
+interface
+
+uses
+    SysUtils;
+
+type
+    MPInteger = NativeUInt;
+
+procedure z_init(var value: MPInteger);
+procedure z_clear(var value: MPInteger);
+procedure z_set(var dest: MPInteger; const source: MPInteger);
+procedure z_set_ui(var dest: MPInteger; new_value: NativeUInt);
+procedure z_add_ui(var dest: MPInteger; addend: NativeUInt);
+function z_add(const lhs, rhs: MPInteger): MPInteger;
+procedure z_ui_pow_ui(var dest: MPInteger; base, exponent: NativeUInt);
+function z_size(const value: MPInteger): NativeUInt;
+function z_get_str(base: NativeUInt; const value: MPInteger): AnsiString;
+
+implementation
+
+procedure z_init(var value: MPInteger);
+begin
+    asm
+        call gpc_mpz_init
+    end;
+end;
+
+procedure z_clear(var value: MPInteger);
+begin
+    asm
+        call gpc_mpz_clear
+    end;
+end;
+
+procedure z_set(var dest: MPInteger; const source: MPInteger);
+begin
+    asm
+        call gpc_mpz_set
+    end;
+end;
+
+procedure z_set_ui(var dest: MPInteger; new_value: NativeUInt);
+begin
+    asm
+        call gpc_mpz_set_ui
+    end;
+end;
+
+procedure z_add_ui(var dest: MPInteger; addend: NativeUInt);
+begin
+    asm
+        call gpc_mpz_add_ui
+    end;
+end;
+
+function z_add(const lhs, rhs: MPInteger): MPInteger;
+var
+    result_handle: MPInteger;
+begin
+    asm
+        call gpc_mpz_add
+        movq %rax, -8(%rbp)
+    end;
+    z_add := result_handle;
+end;
+
+procedure z_ui_pow_ui(var dest: MPInteger; base, exponent: NativeUInt);
+begin
+    asm
+        call gpc_mpz_ui_pow_ui
+    end;
+end;
+
+function z_size(const value: MPInteger): NativeUInt;
+var
+    result_size: NativeUInt;
+begin
+    asm
+        call gpc_mpz_size
+        movq %rax, -8(%rbp)
+    end;
+    z_size := result_size;
+end;
+
+function z_get_str(base: NativeUInt; const value: MPInteger): AnsiString;
+var
+    result_ptr: AnsiString;
+begin
+    asm
+        call gpc_mpz_get_str
+        movq %rax, -8(%rbp)
+    end;
+    z_get_str := result_ptr;
+end;
+
+end.

--- a/GPC/runtime.c
+++ b/GPC/runtime.c
@@ -231,3 +231,386 @@ int64_t gpc_ord_longint(int64_t value)
 {
     return value;
 }
+
+typedef struct
+{
+    uint32_t *digits;
+    size_t length;
+    size_t capacity;
+} gpc_mpz_object_t;
+
+#define GPC_MPZ_BASE 1000000000U
+#define GPC_MPZ_BASE_DIGITS 9
+
+static gpc_mpz_object_t *gpc_mpz_from_handle(int64_t handle)
+{
+    if (handle == 0)
+        return NULL;
+
+    return (gpc_mpz_object_t *)(uintptr_t)handle;
+}
+
+static int64_t gpc_mpz_to_handle(gpc_mpz_object_t *object)
+{
+    return (int64_t)(uintptr_t)object;
+}
+
+static gpc_mpz_object_t *gpc_mpz_allocate(void)
+{
+    gpc_mpz_object_t *object = (gpc_mpz_object_t *)malloc(sizeof(gpc_mpz_object_t));
+    if (object == NULL)
+    {
+        fprintf(stderr, "Error: failed to allocate MPInteger.\n");
+        return NULL;
+    }
+
+    object->digits = NULL;
+    object->length = 0;
+    object->capacity = 0;
+    return object;
+}
+
+static void gpc_mpz_release(gpc_mpz_object_t *object)
+{
+    if (object == NULL)
+        return;
+
+    free(object->digits);
+    free(object);
+}
+
+static int gpc_mpz_reserve(gpc_mpz_object_t *object, size_t capacity)
+{
+    if (object == NULL)
+        return -1;
+
+    if (object->capacity >= capacity)
+        return 0;
+
+    size_t new_capacity = object->capacity > 0 ? object->capacity : 1;
+    while (new_capacity < capacity)
+        new_capacity *= 2;
+
+    uint32_t *new_digits = (uint32_t *)realloc(object->digits, new_capacity * sizeof(uint32_t));
+    if (new_digits == NULL)
+    {
+        fprintf(stderr, "Error: failed to allocate MPInteger digits.\n");
+        return -1;
+    }
+
+    for (size_t i = object->capacity; i < new_capacity; ++i)
+        new_digits[i] = 0;
+
+    object->digits = new_digits;
+    object->capacity = new_capacity;
+    return 0;
+}
+
+static void gpc_mpz_set_zero(gpc_mpz_object_t *object)
+{
+    if (object == NULL)
+        return;
+
+    object->length = 0;
+    if (object->digits != NULL && object->capacity > 0)
+        object->digits[0] = 0;
+}
+
+static void gpc_mpz_normalize(gpc_mpz_object_t *object)
+{
+    if (object == NULL)
+        return;
+
+    while (object->length > 0 && object->digits[object->length - 1] == 0)
+        object->length--;
+}
+
+static gpc_mpz_object_t *gpc_mpz_require(int64_t *handle_ptr)
+{
+    if (handle_ptr == NULL)
+        return NULL;
+
+    gpc_mpz_object_t *object = gpc_mpz_from_handle(*handle_ptr);
+    if (object == NULL)
+    {
+        object = gpc_mpz_allocate();
+        if (object == NULL)
+            return NULL;
+        *handle_ptr = gpc_mpz_to_handle(object);
+    }
+
+    return object;
+}
+
+void gpc_mpz_init(int64_t *handle_ptr)
+{
+    gpc_mpz_object_t *object = gpc_mpz_require(handle_ptr);
+    if (object == NULL)
+        return;
+
+    gpc_mpz_set_zero(object);
+}
+
+void gpc_mpz_clear(int64_t *handle_ptr)
+{
+    if (handle_ptr == NULL)
+        return;
+
+    gpc_mpz_object_t *object = gpc_mpz_from_handle(*handle_ptr);
+    if (object != NULL)
+    {
+        gpc_mpz_release(object);
+        *handle_ptr = 0;
+    }
+}
+
+void gpc_mpz_set(int64_t *dest_handle, int64_t src_handle)
+{
+    gpc_mpz_object_t *dest = gpc_mpz_require(dest_handle);
+    if (dest == NULL)
+        return;
+
+    gpc_mpz_object_t *src = gpc_mpz_from_handle(src_handle);
+    if (src == NULL || src->length == 0)
+    {
+        gpc_mpz_set_zero(dest);
+        return;
+    }
+
+    if (gpc_mpz_reserve(dest, src->length) != 0)
+        return;
+
+    memcpy(dest->digits, src->digits, src->length * sizeof(uint32_t));
+    dest->length = src->length;
+}
+
+void gpc_mpz_set_ui(int64_t *dest_handle, uint64_t value)
+{
+    gpc_mpz_object_t *dest = gpc_mpz_require(dest_handle);
+    if (dest == NULL)
+        return;
+
+    gpc_mpz_set_zero(dest);
+    if (value == 0)
+        return;
+
+    uint64_t remaining = value;
+    size_t needed = 0;
+    while (remaining > 0)
+    {
+        ++needed;
+        remaining /= GPC_MPZ_BASE;
+    }
+
+    if (gpc_mpz_reserve(dest, needed) != 0)
+        return;
+
+    dest->length = needed;
+    remaining = value;
+    for (size_t i = 0; i < needed; ++i)
+    {
+        dest->digits[i] = (uint32_t)(remaining % GPC_MPZ_BASE);
+        remaining /= GPC_MPZ_BASE;
+    }
+}
+
+void gpc_mpz_add_ui(int64_t *dest_handle, uint64_t addend)
+{
+    gpc_mpz_object_t *dest = gpc_mpz_require(dest_handle);
+    if (dest == NULL)
+        return;
+
+    size_t index = 0;
+    uint64_t carry = addend;
+    while (carry > 0 || index < dest->length)
+    {
+        if (index >= dest->length)
+        {
+            if (gpc_mpz_reserve(dest, index + 1) != 0)
+                return;
+            dest->digits[index] = 0;
+            dest->length = index + 1;
+        }
+
+        uint64_t sum = (uint64_t)dest->digits[index] + carry;
+        dest->digits[index] = (uint32_t)(sum % GPC_MPZ_BASE);
+        carry = sum / GPC_MPZ_BASE;
+        ++index;
+    }
+
+    if (carry > 0)
+    {
+        if (gpc_mpz_reserve(dest, dest->length + 1) != 0)
+            return;
+        dest->digits[dest->length++] = (uint32_t)carry;
+    }
+}
+
+static void gpc_mpz_mul_small(gpc_mpz_object_t *object, uint64_t factor)
+{
+    if (object == NULL)
+        return;
+
+    if (object->length == 0 || factor == 0)
+    {
+        gpc_mpz_set_zero(object);
+        if (factor == 0 && object->digits != NULL && object->capacity > 0)
+            object->digits[0] = 0;
+        return;
+    }
+
+    if (gpc_mpz_reserve(object, object->length + 1) != 0)
+        return;
+
+    uint64_t carry = 0;
+    for (size_t i = 0; i < object->length; ++i)
+    {
+        uint64_t product = (uint64_t)object->digits[i] * factor + carry;
+        object->digits[i] = (uint32_t)(product % GPC_MPZ_BASE);
+        carry = product / GPC_MPZ_BASE;
+    }
+
+    if (carry > 0)
+    {
+        object->digits[object->length++] = (uint32_t)carry;
+    }
+}
+
+int64_t gpc_mpz_add(int64_t lhs_handle, int64_t rhs_handle)
+{
+    gpc_mpz_object_t *lhs = gpc_mpz_from_handle(lhs_handle);
+    if (lhs == NULL)
+    {
+        lhs = gpc_mpz_allocate();
+        if (lhs == NULL)
+            return 0;
+        lhs_handle = gpc_mpz_to_handle(lhs);
+    }
+
+    gpc_mpz_object_t *rhs = gpc_mpz_from_handle(rhs_handle);
+    if (rhs == NULL || rhs->length == 0)
+        return gpc_mpz_to_handle(lhs);
+
+    size_t max_len = lhs->length > rhs->length ? lhs->length : rhs->length;
+    if (gpc_mpz_reserve(lhs, max_len + 1) != 0)
+        return gpc_mpz_to_handle(lhs);
+
+    if (lhs->length < max_len)
+    {
+        for (size_t i = lhs->length; i < max_len; ++i)
+            lhs->digits[i] = 0;
+        lhs->length = max_len;
+    }
+
+    uint64_t carry = 0;
+    for (size_t i = 0; i < max_len; ++i)
+    {
+        uint64_t sum = (uint64_t)lhs->digits[i] + carry;
+        if (i < rhs->length)
+            sum += rhs->digits[i];
+        lhs->digits[i] = (uint32_t)(sum % GPC_MPZ_BASE);
+        carry = sum / GPC_MPZ_BASE;
+    }
+
+    if (carry > 0)
+        lhs->digits[lhs->length++] = (uint32_t)carry;
+
+    return gpc_mpz_to_handle(lhs);
+}
+
+void gpc_mpz_ui_pow_ui(int64_t *dest_handle, uint64_t base, uint64_t exp)
+{
+    if (dest_handle == NULL)
+        return;
+
+    gpc_mpz_set_ui(dest_handle, 1);
+    gpc_mpz_object_t *dest = gpc_mpz_from_handle(*dest_handle);
+    if (dest == NULL)
+        return;
+
+    if (exp == 0)
+        return;
+
+    if (base == 0)
+    {
+        gpc_mpz_set_zero(dest);
+        return;
+    }
+
+    for (uint64_t i = 0; i < exp; ++i)
+        gpc_mpz_mul_small(dest, base);
+}
+
+uint64_t gpc_mpz_size(int64_t handle)
+{
+    gpc_mpz_object_t *object = gpc_mpz_from_handle(handle);
+    if (object == NULL)
+        return 0;
+
+    return (uint64_t)object->length;
+}
+
+static size_t gpc_mpz_decimal_digits(uint32_t value)
+{
+    size_t digits = 1;
+    while (value >= 10)
+    {
+        value /= 10;
+        ++digits;
+    }
+    return digits;
+}
+
+char *gpc_mpz_get_str(int base, int64_t handle)
+{
+    if (base < 2 || base > 36)
+        base = 10;
+
+    gpc_mpz_object_t *object = gpc_mpz_from_handle(handle);
+    if (object == NULL || object->length == 0)
+    {
+        char *zero = (char *)malloc(2);
+        if (zero == NULL)
+            return gpc_alloc_empty_string();
+        zero[0] = '0';
+        zero[1] = '\0';
+        return zero;
+    }
+
+    if (base != 10)
+    {
+        /* Fallback: unsupported base, return empty string */
+        return gpc_alloc_empty_string();
+    }
+
+    size_t last_index = object->length - 1;
+    uint32_t most_significant = object->digits[last_index];
+    size_t total_digits = gpc_mpz_decimal_digits(most_significant) + last_index * GPC_MPZ_BASE_DIGITS;
+
+    char *text = (char *)malloc(total_digits + 1);
+    if (text == NULL)
+        return gpc_alloc_empty_string();
+
+    size_t pos = 0;
+    int written = snprintf(text + pos, total_digits + 1 - pos, "%u", most_significant);
+    if (written < 0)
+    {
+        free(text);
+        return gpc_alloc_empty_string();
+    }
+    pos += (size_t)written;
+
+    while (last_index-- > 0)
+    {
+        written = snprintf(text + pos, total_digits + 1 - pos, "%09u", object->digits[last_index]);
+        if (written < 0)
+        {
+            free(text);
+            return gpc_alloc_empty_string();
+        }
+        pos += (size_t)written;
+    }
+
+    text[total_digits] = '\0';
+    return text;
+}


### PR DESCRIPTION
## Summary
- add a Pascal `gmp` unit exposing MPInteger helpers backed by the runtime
- implement custom big integer support in the runtime, covering initialization, arithmetic, powering, sizing, and decimal conversion
- update the x86-64 code generator to correctly move 64-bit results for function calls and array assignments

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_690134bbec1c832a9885dbc0148dccb1

## Summary by Sourcery

Implement native MPInteger big integer support in the runtime, expose it via a new Pascal gmp unit, and correct the x86-64 code generator to handle 64-bit moves for LONGINT and STRING types.

New Features:
- Add C runtime big integer type with initialization, arithmetic (add, multiply, power), sizing, and decimal string conversion
- Introduce gmp Pascal unit exposing MPInteger helper procedures and functions against the runtime

Bug Fixes:
- Update Intel x86-64 code generator to use 64-bit mov instructions for LONGINT and STRING assignments and function call result moves