### PR TITLE
Add Pascal break statement and builtin runtime functions

### DIFF
--- a/GPC/CodeGenerator/Intel_x86-64/codegen.h
+++ b/GPC/CodeGenerator/Intel_x86-64/codegen.h
@@ -131,6 +131,11 @@ static inline int codegen_target_is_windows(void)
     This struct holds all the state that was previously global,
     allowing for a more modular and re-entrant design.
 */
+typedef struct LoopExitLabel {
+    char *label;
+    struct LoopExitLabel *previous;
+} LoopExitLabel;
+
 typedef struct {
     int label_counter;
     int write_label_counter;
@@ -138,6 +143,7 @@ typedef struct {
     SymTab_t *symtab;
     gpc_target_abi_t target_abi;
     int had_error;
+    LoopExitLabel *loop_exit_stack;
 } CodeGenContext;
 
 /* Generates a label */

--- a/GPC/Parser/ParseTree/from_cparser.c
+++ b/GPC/Parser/ParseTree/from_cparser.c
@@ -1050,6 +1050,8 @@ static struct Statement *convert_statement(ast_t *stmt_node) {
         char *code = collect_asm_text(stmt_node->child);
         return mk_asmblock(stmt_node->line, code);
     }
+    case PASCAL_T_BREAK_STMT:
+        return mk_break(stmt_node->line);
     case PASCAL_T_BEGIN_BLOCK:
         return convert_block(stmt_node);
     case PASCAL_T_IF_STMT: {

--- a/GPC/Parser/ParseTree/tree.c
+++ b/GPC/Parser/ParseTree/tree.c
@@ -389,6 +389,10 @@ void stmt_print(struct Statement *stmt, FILE *f, int num_indent)
           stmt_print(stmt->stmt_data.for_data.do_for, f, num_indent+1);
           break;
 
+        case STMT_BREAK:
+          fprintf(f, "[BREAK]\n");
+          break;
+
           case STMT_ASM_BLOCK:
             fprintf(f, "[ASM_BLOCK]:\n");
             print_indent(f, num_indent+1);
@@ -685,13 +689,16 @@ void destroy_stmt(struct Statement *stmt)
           destroy_stmt(stmt->stmt_data.for_data.do_for);
           break;
 
+        case STMT_BREAK:
+          break;
+
         case STMT_ASM_BLOCK:
           free(stmt->stmt_data.asm_block_data.code);
           break;
 
-          default:
-            fprintf(stderr, "BAD TYPE IN stmt_print!\n");
-            exit(1);
+        default:
+          fprintf(stderr, "BAD TYPE IN destroy_stmt!\n");
+          exit(1);
     }
     free(stmt);
 }
@@ -1168,6 +1175,17 @@ struct Statement *mk_asmblock(int line_num, char *code)
     new_stmt->line_num = line_num;
     new_stmt->type = STMT_ASM_BLOCK;
     new_stmt->stmt_data.asm_block_data.code = code;
+
+    return new_stmt;
+}
+
+struct Statement *mk_break(int line_num)
+{
+    struct Statement *new_stmt = (struct Statement *)malloc(sizeof(struct Statement));
+    assert(new_stmt != NULL);
+
+    new_stmt->line_num = line_num;
+    new_stmt->type = STMT_BREAK;
 
     return new_stmt;
 }

--- a/GPC/Parser/ParseTree/tree.h
+++ b/GPC/Parser/ParseTree/tree.h
@@ -205,6 +205,8 @@ struct Statement *mk_forvar(int line_num, struct Expression *for_var, struct Exp
 
 struct Statement *mk_asmblock(int line_num, char *code);
 
+struct Statement *mk_break(int line_num);
+
 /* Expression routines */
 struct Expression *mk_relop(int line_num, int type, struct Expression *left,
                                 struct Expression *right);

--- a/GPC/Parser/ParseTree/tree_types.h
+++ b/GPC/Parser/ParseTree/tree_types.h
@@ -8,10 +8,12 @@
 
 #include "../List/List.h"
 
+struct HashNode;
+
 /* Enums for readability with types */
 enum StmtType{STMT_VAR_ASSIGN, STMT_PROCEDURE_CALL, STMT_COMPOUND_STATEMENT,
     STMT_IF_THEN, STMT_WHILE, STMT_REPEAT, STMT_FOR, STMT_FOR_VAR, STMT_FOR_ASSIGN_VAR,
-    STMT_ASM_BLOCK};
+    STMT_BREAK, STMT_ASM_BLOCK};
 
 enum TypeDeclKind { TYPE_DECL_RANGE, TYPE_DECL_RECORD, TYPE_DECL_ALIAS };
 
@@ -68,7 +70,7 @@ struct Statement
             char *id;
             char *mangled_id;
             ListNode_t *expr_args;
-        struct HashNode *resolved_proc;
+            struct HashNode *resolved_proc;
         } procedure_call_data;
 
         /* Compound Statements */
@@ -181,7 +183,7 @@ struct Expression
             char *id;
             char *mangled_id;
             ListNode_t *args_expr;
-        struct HashNode *resolved_func;
+            struct HashNode *resolved_func;
         } function_call_data;
 
         /* Integer number */

--- a/GPC/Parser/SemanticCheck/SemCheck.c
+++ b/GPC/Parser/SemanticCheck/SemCheck.c
@@ -360,6 +360,12 @@ void semcheck_add_builtins(SymTab_t *symtab)
         free(move_name);
     }
 
+    char *inc_name = strdup("Inc");
+    if (inc_name != NULL) {
+        AddBuiltinProc(symtab, inc_name, NULL);
+        free(inc_name);
+    }
+
     char *sizeof_name = strdup("SizeOf");
     if (sizeof_name != NULL) {
         AddBuiltinFunction(symtab, sizeof_name, HASHVAR_LONGINT);
@@ -376,6 +382,36 @@ void semcheck_add_builtins(SymTab_t *symtab)
     if (ord_name != NULL) {
         AddBuiltinFunction(symtab, ord_name, HASHVAR_LONGINT);
         free(ord_name);
+    }
+
+    char *length_name = strdup("Length");
+    if (length_name != NULL) {
+        AddBuiltinFunction(symtab, length_name, HASHVAR_LONGINT);
+        free(length_name);
+    }
+
+    char *copy_name = strdup("Copy");
+    if (copy_name != NULL) {
+        AddBuiltinFunction(symtab, copy_name, HASHVAR_PCHAR);
+        free(copy_name);
+    }
+
+    char *inttostr_name = strdup("IntToStr");
+    if (inttostr_name != NULL) {
+        AddBuiltinFunction(symtab, inttostr_name, HASHVAR_PCHAR);
+        free(inttostr_name);
+    }
+
+    char *now_name = strdup("Now");
+    if (now_name != NULL) {
+        AddBuiltinFunction(symtab, now_name, HASHVAR_LONGINT);
+        free(now_name);
+    }
+
+    char *formatdt_name = strdup("FormatDateTime");
+    if (formatdt_name != NULL) {
+        AddBuiltinFunction(symtab, formatdt_name, HASHVAR_PCHAR);
+        free(formatdt_name);
     }
 
     /* Builtins are now in stdlib.p */

--- a/GPC/Parser/SemanticCheck/SemChecks/SemCheck_expr.c
+++ b/GPC/Parser/SemanticCheck/SemChecks/SemCheck_expr.c
@@ -1112,6 +1112,253 @@ int semcheck_arrayaccess(int *type_return,
     return return_val;
 }
 
+static int semcheck_builtin_length(int *type_return, SymTab_t *symtab,
+    struct Expression *expr, int max_scope_lev)
+{
+    if (type_return == NULL || symtab == NULL || expr == NULL)
+        return 1;
+
+    assert(expr->type == EXPR_FUNCTION_CALL);
+
+    ListNode_t *args = expr->expr_data.function_call_data.args_expr;
+    if (args == NULL || args->next != NULL)
+    {
+        fprintf(stderr, "Error on line %d, Length expects exactly one argument.\\n",
+            expr->line_num);
+        *type_return = UNKNOWN_TYPE;
+        return 1;
+    }
+
+    struct Expression *arg_expr = (struct Expression *)args->cur;
+    int arg_type = UNKNOWN_TYPE;
+    int error_count = semcheck_expr_main(&arg_type, symtab, arg_expr, max_scope_lev, NO_MUTATE);
+    if (error_count == 0 && arg_type != STRING_TYPE)
+    {
+        fprintf(stderr, "Error on line %d, Length expects a string argument.\\n",
+            expr->line_num);
+        ++error_count;
+    }
+
+    if (error_count == 0)
+    {
+        free(expr->expr_data.function_call_data.mangled_id);
+        expr->expr_data.function_call_data.mangled_id = strdup("gpc_string_length");
+        if (expr->expr_data.function_call_data.mangled_id == NULL)
+        {
+            fprintf(stderr, "Error: failed to allocate mangled name for Length.\\n");
+            *type_return = UNKNOWN_TYPE;
+            return 1;
+        }
+        expr->expr_data.function_call_data.resolved_func = NULL;
+        expr->resolved_type = LONGINT_TYPE;
+        *type_return = LONGINT_TYPE;
+        return 0;
+    }
+
+    *type_return = UNKNOWN_TYPE;
+    return error_count;
+}
+
+static int semcheck_builtin_copy(int *type_return, SymTab_t *symtab,
+    struct Expression *expr, int max_scope_lev)
+{
+    if (type_return == NULL || symtab == NULL || expr == NULL)
+        return 1;
+
+    assert(expr->type == EXPR_FUNCTION_CALL);
+
+    ListNode_t *args = expr->expr_data.function_call_data.args_expr;
+    if (args == NULL || args->next == NULL || args->next->next == NULL || args->next->next->next != NULL)
+    {
+        fprintf(stderr, "Error on line %d, Copy expects exactly three arguments.\\n",
+            expr->line_num);
+        *type_return = UNKNOWN_TYPE;
+        return 1;
+    }
+
+    struct Expression *source_expr = (struct Expression *)args->cur;
+    struct Expression *index_expr = (struct Expression *)args->next->cur;
+    struct Expression *count_expr = (struct Expression *)args->next->next->cur;
+
+    int error_count = 0;
+    int source_type = UNKNOWN_TYPE;
+    error_count += semcheck_expr_main(&source_type, symtab, source_expr, max_scope_lev, NO_MUTATE);
+    if (error_count == 0 && source_type != STRING_TYPE)
+    {
+        fprintf(stderr, "Error on line %d, Copy source must be a string.\\n", expr->line_num);
+        ++error_count;
+    }
+
+    int index_type = UNKNOWN_TYPE;
+    error_count += semcheck_expr_main(&index_type, symtab, index_expr, max_scope_lev, NO_MUTATE);
+    if (index_type != INT_TYPE && index_type != LONGINT_TYPE)
+    {
+        fprintf(stderr, "Error on line %d, Copy index must be an integer.\\n", expr->line_num);
+        ++error_count;
+    }
+
+    int count_type = UNKNOWN_TYPE;
+    error_count += semcheck_expr_main(&count_type, symtab, count_expr, max_scope_lev, NO_MUTATE);
+    if (count_type != INT_TYPE && count_type != LONGINT_TYPE)
+    {
+        fprintf(stderr, "Error on line %d, Copy count must be an integer.\\n", expr->line_num);
+        ++error_count;
+    }
+
+    if (error_count == 0)
+    {
+        free(expr->expr_data.function_call_data.mangled_id);
+        expr->expr_data.function_call_data.mangled_id = strdup("gpc_string_copy");
+        if (expr->expr_data.function_call_data.mangled_id == NULL)
+        {
+            fprintf(stderr, "Error: failed to allocate mangled name for Copy.\\n");
+            *type_return = UNKNOWN_TYPE;
+            return 1;
+        }
+        expr->expr_data.function_call_data.resolved_func = NULL;
+        expr->resolved_type = STRING_TYPE;
+        *type_return = STRING_TYPE;
+        return 0;
+    }
+
+    *type_return = UNKNOWN_TYPE;
+    return error_count;
+}
+
+static int semcheck_builtin_inttostr(int *type_return, SymTab_t *symtab,
+    struct Expression *expr, int max_scope_lev)
+{
+    if (type_return == NULL || symtab == NULL || expr == NULL)
+        return 1;
+
+    assert(expr->type == EXPR_FUNCTION_CALL);
+
+    ListNode_t *args = expr->expr_data.function_call_data.args_expr;
+    if (args == NULL || args->next != NULL)
+    {
+        fprintf(stderr, "Error on line %d, IntToStr expects exactly one argument.\\n",
+            expr->line_num);
+        *type_return = UNKNOWN_TYPE;
+        return 1;
+    }
+
+    struct Expression *value_expr = (struct Expression *)args->cur;
+    int value_type = UNKNOWN_TYPE;
+    int error_count = semcheck_expr_main(&value_type, symtab, value_expr, max_scope_lev, NO_MUTATE);
+    if (error_count == 0 && value_type != INT_TYPE && value_type != LONGINT_TYPE)
+    {
+        fprintf(stderr, "Error on line %d, IntToStr expects an integer argument.\\n",
+            expr->line_num);
+        ++error_count;
+    }
+
+    if (error_count == 0)
+    {
+        free(expr->expr_data.function_call_data.mangled_id);
+        expr->expr_data.function_call_data.mangled_id = strdup("gpc_int_to_string");
+        if (expr->expr_data.function_call_data.mangled_id == NULL)
+        {
+            fprintf(stderr, "Error: failed to allocate mangled name for IntToStr.\\n");
+            *type_return = UNKNOWN_TYPE;
+            return 1;
+        }
+        expr->expr_data.function_call_data.resolved_func = NULL;
+        expr->resolved_type = STRING_TYPE;
+        *type_return = STRING_TYPE;
+        return 0;
+    }
+
+    *type_return = UNKNOWN_TYPE;
+    return error_count;
+}
+
+static int semcheck_builtin_now(int *type_return, SymTab_t *symtab,
+    struct Expression *expr)
+{
+    if (type_return == NULL || symtab == NULL || expr == NULL)
+        return 1;
+
+    assert(expr->type == EXPR_FUNCTION_CALL);
+
+    if (expr->expr_data.function_call_data.args_expr != NULL)
+    {
+        fprintf(stderr, "Error on line %d, Now expects no arguments.\\n", expr->line_num);
+        *type_return = UNKNOWN_TYPE;
+        return 1;
+    }
+
+    free(expr->expr_data.function_call_data.mangled_id);
+    expr->expr_data.function_call_data.mangled_id = strdup("gpc_now");
+    if (expr->expr_data.function_call_data.mangled_id == NULL)
+    {
+        fprintf(stderr, "Error: failed to allocate mangled name for Now.\\n");
+        *type_return = UNKNOWN_TYPE;
+        return 1;
+    }
+
+    expr->expr_data.function_call_data.resolved_func = NULL;
+    expr->resolved_type = LONGINT_TYPE;
+    *type_return = LONGINT_TYPE;
+    return 0;
+}
+
+static int semcheck_builtin_formatdatetime(int *type_return, SymTab_t *symtab,
+    struct Expression *expr, int max_scope_lev)
+{
+    if (type_return == NULL || symtab == NULL || expr == NULL)
+        return 1;
+
+    assert(expr->type == EXPR_FUNCTION_CALL);
+
+    ListNode_t *args = expr->expr_data.function_call_data.args_expr;
+    if (args == NULL || args->next == NULL || args->next->next != NULL)
+    {
+        fprintf(stderr, "Error on line %d, FormatDateTime expects exactly two arguments.\\n",
+            expr->line_num);
+        *type_return = UNKNOWN_TYPE;
+        return 1;
+    }
+
+    struct Expression *format_expr = (struct Expression *)args->cur;
+    struct Expression *datetime_expr = (struct Expression *)args->next->cur;
+
+    int error_count = 0;
+    int format_type = UNKNOWN_TYPE;
+    error_count += semcheck_expr_main(&format_type, symtab, format_expr, max_scope_lev, NO_MUTATE);
+    if (error_count == 0 && format_type != STRING_TYPE)
+    {
+        fprintf(stderr, "Error on line %d, FormatDateTime format must be a string.\\n", expr->line_num);
+        ++error_count;
+    }
+
+    int datetime_type = UNKNOWN_TYPE;
+    error_count += semcheck_expr_main(&datetime_type, symtab, datetime_expr, max_scope_lev, NO_MUTATE);
+    if (datetime_type != INT_TYPE && datetime_type != LONGINT_TYPE)
+    {
+        fprintf(stderr, "Error on line %d, FormatDateTime datetime must be integer or longint.\\n", expr->line_num);
+        ++error_count;
+    }
+
+    if (error_count == 0)
+    {
+        free(expr->expr_data.function_call_data.mangled_id);
+        expr->expr_data.function_call_data.mangled_id = strdup("gpc_format_datetime");
+        if (expr->expr_data.function_call_data.mangled_id == NULL)
+        {
+            fprintf(stderr, "Error: failed to allocate mangled name for FormatDateTime.\\n");
+            *type_return = UNKNOWN_TYPE;
+            return 1;
+        }
+        expr->expr_data.function_call_data.resolved_func = NULL;
+        expr->resolved_type = STRING_TYPE;
+        *type_return = STRING_TYPE;
+        return 0;
+    }
+
+    *type_return = UNKNOWN_TYPE;
+    return error_count;
+}
+
 /** FUNC_CALL **/
 int semcheck_funccall(int *type_return,
     SymTab_t *symtab, struct Expression *expr, int max_scope_lev, int mutating)
@@ -1139,6 +1386,21 @@ int semcheck_funccall(int *type_return,
 
     if (id != NULL && pascal_identifier_equals(id, "Ord"))
         return semcheck_builtin_ord(type_return, symtab, expr, max_scope_lev);
+
+    if (id != NULL && pascal_identifier_equals(id, "Length"))
+        return semcheck_builtin_length(type_return, symtab, expr, max_scope_lev);
+
+    if (id != NULL && pascal_identifier_equals(id, "Copy"))
+        return semcheck_builtin_copy(type_return, symtab, expr, max_scope_lev);
+
+    if (id != NULL && pascal_identifier_equals(id, "IntToStr"))
+        return semcheck_builtin_inttostr(type_return, symtab, expr, max_scope_lev);
+
+    if (id != NULL && pascal_identifier_equals(id, "Now"))
+        return semcheck_builtin_now(type_return, symtab, expr);
+
+    if (id != NULL && pascal_identifier_equals(id, "FormatDateTime"))
+        return semcheck_builtin_formatdatetime(type_return, symtab, expr, max_scope_lev);
 
     /***** FIRST VERIFY FUNCTION IDENTIFIER *****/
 

--- a/cparser/examples/pascal_parser/pascal_keywords.c
+++ b/cparser/examples/pascal_parser/pascal_keywords.c
@@ -20,7 +20,7 @@ const char* pascal_reserved_keywords[] = {
     "class", "object", "private", "public", "protected", "published",
     "property", "inherited", "self", "constructor", "destructor",
     // Additional Pascal keywords
-    "function", "procedure", "program", "unit", "uses", "interface", "implementation",
+    "function", "procedure", "program", "unit", "uses", "interface", "implementation", "break",
     NULL
 };
 

--- a/cparser/examples/pascal_parser/pascal_parser.h
+++ b/cparser/examples/pascal_parser/pascal_parser.h
@@ -90,6 +90,7 @@ typedef enum {
     PASCAL_T_RAISE_STMT,
     PASCAL_T_INHERITED_STMT,
     PASCAL_T_EXIT_STMT,
+    PASCAL_T_BREAK_STMT,
     PASCAL_T_ON_CLAUSE,
     // Program structure types
     PASCAL_T_PROGRAM_DECL,

--- a/cparser/examples/pascal_parser/pascal_statement.c
+++ b/cparser/examples/pascal_parser/pascal_statement.c
@@ -276,6 +276,9 @@ void init_pascal_statement_parser(combinator_t** p) {
     // Exit statement: exit
     combinator_t* exit_stmt = token(create_keyword_parser("exit", PASCAL_T_EXIT_STMT));
 
+    // Break statement: break
+    combinator_t* break_stmt = token(create_keyword_parser("break", PASCAL_T_BREAK_STMT));
+
     // Case statement: case expression of label1: stmt1; label2: stmt2; [else stmt;] end
     // Case labels should handle constant expressions, not just simple values
     
@@ -350,6 +353,7 @@ void init_pascal_statement_parser(combinator_t** p) {
         raise_stmt,                           // raise statements
         inherited_stmt,                       // inherited statements
         exit_stmt,                            // exit statements
+        break_stmt,                           // break statements
         asm_stmt,                             // inline assembly blocks
         if_stmt,                              // if statements
         for_stmt,                             // for statements


### PR DESCRIPTION
## Summary
- teach the parser, AST, semantic analysis, and code generator about the `break` statement and loop-exit validation
- add semantic and runtime support for Pascal builtins such as `Inc`, `Length`, `Copy`, `IntToStr`, `Now`, and `FormatDateTime`
- extend the runtime and code generator to better handle dynamic arrays and builtins like `SetLength`

## Testing
- ninja -C build

------
https://chatgpt.com/codex/tasks/task_e_69013d61f6f8832aa0cedc8959514ab9