### PR TITLE
Allow pointer types to use built-in keywords

### DIFF
--- a/cparser/examples/pascal_parser/pascal_keywords.c
+++ b/cparser/examples/pascal_parser/pascal_keywords.c
@@ -14,6 +14,8 @@ const char* pascal_reserved_keywords[] = {
     "repeat", "until", "case", "of", "var", "const", "type",
     "and", "or", "not", "xor", "div", "mod", "in", "nil", "true", "false",
     "array", "record", "set", "packed",
+    // Built-in type keywords
+    "integer", "real", "boolean", "char", "string", "byte", "word", "longint",
     // Exception handling keywords
     "try", "finally", "except", "raise", "on", "break",
     // Class and object-oriented keywords

--- a/cparser/examples/pascal_parser/pascal_type.c
+++ b/cparser/examples/pascal_parser/pascal_type.c
@@ -417,9 +417,15 @@ combinator_t* record_type(tag_t tag) {
 
 // Pointer type parser: ^TypeName
 combinator_t* pointer_type(tag_t tag) {
+    combinator_t* pointed_type = multi(new_combinator(), PASCAL_T_NONE,
+        type_name(PASCAL_T_IDENTIFIER),             // built-in Pascal types (integer, string, ...)
+        token(pascal_identifier(PASCAL_T_IDENTIFIER)), // user-defined type identifiers
+        NULL
+    );
+
     return seq(new_combinator(), tag,
         token(match("^")),
-        pascal_identifier(PASCAL_T_IDENTIFIER),
+        pointed_type,
         NULL
     );
 }


### PR DESCRIPTION
## Summary
- treat core Pascal type names as reserved keywords so they cannot be used as identifiers
- update the pointer type parser to accept either reserved built-in types or user-defined identifiers after the caret

## Testing
- python tests/test_runner.py TestCompiler.test_type_alias_parameters_accept_new_categories

------
https://chatgpt.com/codex/tasks/task_e_690229484c90832a812125d9bc5578a9

## Summary by Sourcery

Reserve core Pascal type names as keywords and enhance pointer type parsing to allow built-in types after the caret.

Enhancements:
- Add core Pascal types (integer, real, boolean, char, string, byte, word, longint) to the reserved keyword list
- Update pointer type parser to accept either built-in type keywords or user-defined identifiers after the caret