### PR TITLE
Allow CLI parser to handle Pascal programs

### DIFF
--- a/cparser/examples/pascal_parser/pascal_tests.c
+++ b/cparser/examples/pascal_parser/pascal_tests.c
@@ -2552,6 +2552,45 @@ void test_pascal_record_member_access_program(void) {
     free(input);
 }
 
+void test_pascal_record_member_access_complete_program(void) {
+    combinator_t* p = new_combinator();
+    init_pascal_complete_program_parser(&p);
+
+    input_t* input = new_input();
+    const char* program =
+        "program RecordMemberAccess;\n"
+        "type\n"
+        "  Point = record\n"
+        "    x: Integer;\n"
+        "    y: Integer;\n"
+        "  end;\n"
+        "var\n"
+        "  p: Point;\n"
+        "begin\n"
+        "  p.x := 10;\n"
+        "  p.y := 32;\n"
+        "  writeln(p.x + p.y);\n"
+        "  p.x := p.y - 2;\n"
+        "  writeln(p.x);\n"
+        "end.\n";
+    input->buffer = strdup(program);
+    input->length = strlen(program);
+
+    ParseResult res = parse(input, p);
+    TEST_ASSERT(res.is_success);
+    if (res.is_success) {
+        ast_t* member_node = find_first_node_of_type(res.value.ast, PASCAL_T_MEMBER_ACCESS);
+        TEST_ASSERT(member_node != NULL);
+        free_ast(res.value.ast);
+    } else {
+        free_error(res.value.error);
+    }
+
+    free_combinator(p);
+    free(input->buffer);
+    free(input);
+}
+
 void test_fpc_style_unit_parsing(void) {
     combinator_t* p = new_combinator();
     init_pascal_unit_parser(&p);
@@ -2930,6 +2969,7 @@ TEST_LIST = {
     { "test_pascal_set_operations_program", test_pascal_set_operations_program },
     { "test_pascal_pointer_operations_program", test_pascal_pointer_operations_program },
     { "test_pascal_record_member_access_program", test_pascal_record_member_access_program },
+    { "test_pascal_record_member_access_complete_program", test_pascal_record_member_access_complete_program },
     { "test_pascal_var_section", test_pascal_var_section },
     { "test_pascal_unit_with_dotted_name", test_pascal_unit_with_dotted_name },
     { "test_pascal_uses_with_dotted_unit", test_pascal_uses_with_dotted_unit },


### PR DESCRIPTION
## Summary
- detect whether the CLI input is a unit or a program before selecting the parser
- add a regression test covering record member access inside a complete Pascal program

## Testing
- build/pascal_parser_cli tmp_record.p
- build/pascal_tests test_pascal_record_member_access_complete_program

------
https://chatgpt.com/codex/tasks/task_e_69023cd7a4ac832aba7a6227e297e60e