### PR TITLE
Fix longint array assignments to store full 64-bit values

### DIFF
--- a/GPC/CodeGenerator/Intel_x86-64/codegen_statement.c
+++ b/GPC/CodeGenerator/Intel_x86-64/codegen_statement.c
@@ -915,8 +915,8 @@ ListNode_t *codegen_var_assignment(struct Statement *stmt, ListNode_t *inst_list
         int use_qword = codegen_type_uses_qword(var_expr->resolved_type);
         if (use_qword)
         {
-            // Sign-extend 32-bit values to 64-bit for longint arrays
-            if (var_expr->resolved_type == LONGINT_TYPE && assign_expr->resolved_type != LONGINT_TYPE)
+            int value_is_qword = codegen_type_uses_qword(assign_expr->resolved_type);
+            if (!value_is_qword)
                 inst_list = codegen_sign_extend32_to64(inst_list, value_reg->bit_32, value_reg->bit_64);
             snprintf(buffer, 50, "\tmovq\t%s, (%s)\n", value_reg->bit_64, addr_reload->bit_64);
         }


### PR DESCRIPTION
## Summary
- ensure array element assignments use 64-bit stores when the element type requires it
- sign-extend 32-bit expression results before writing to 64-bit array slots

## Testing
- python3 tests/test_runner.py

------
https://chatgpt.com/codex/tasks/task_e_6902781367b4832a901623b1e8be8b98

## Summary by Sourcery

Bug Fixes:
- Fix longint array assignments to use generic width check and sign-extend 32-bit values before 64-bit store