### PR TITLE
Add full set expression codegen and tests

### DIFF
--- a/GPC/CodeGenerator/Intel_x86-64/codegen.c
+++ b/GPC/CodeGenerator/Intel_x86-64/codegen.c
@@ -555,7 +555,9 @@ void codegen_function_locals(ListNode_t *local_decl, CodeGenContext *ctx, SymTab
                     if (type_node != NULL)
                         var_kind = type_node->var_type;
 
-                    if (var_kind == HASHVAR_LONGINT || var_kind == HASHVAR_REAL ||
+                    if (var_kind == HASHVAR_SET)
+                        alloc_size = GPC_SET_BYTES;
+                    else if (var_kind == HASHVAR_LONGINT || var_kind == HASHVAR_REAL ||
                         var_kind == HASHVAR_PCHAR || var_kind == HASHVAR_POINTER)
                         alloc_size = 8;
                     else

--- a/GPC/CodeGenerator/Intel_x86-64/codegen.h
+++ b/GPC/CodeGenerator/Intel_x86-64/codegen.h
@@ -110,6 +110,7 @@ extern int g_stack_home_space_bytes;
 #endif
 #define MAX_ARGS 3
 #define REQUIRED_OFFSET 16
+#define GPC_SET_BYTES 32
 
 static inline int codegen_target_is_windows(void)
 {

--- a/GPC/CodeGenerator/Intel_x86-64/codegen_expression.h
+++ b/GPC/CodeGenerator/Intel_x86-64/codegen_expression.h
@@ -27,6 +27,11 @@ ListNode_t *codegen_pointer_deref_leaf(struct Expression *expr, ListNode_t *inst
 ListNode_t *codegen_addressof_leaf(struct Expression *expr, ListNode_t *inst_list,
     CodeGenContext *ctx, Register_t *target_reg);
 
+ListNode_t *codegen_eval_set_expression(struct Expression *expr, ListNode_t *inst_list,
+    CodeGenContext *ctx, Register_t **out_reg);
+ListNode_t *codegen_emit_set_assign(ListNode_t *inst_list, CodeGenContext *ctx,
+    Register_t *dest_reg, Register_t *src_reg);
+
 /* (DEPRECATED) */
 ListNode_t *codegen_expr_varid(struct Expression *, ListNode_t *, CodeGenContext *ctx);
 ListNode_t *codegen_expr_inum(struct Expression *, ListNode_t *, CodeGenContext *ctx);

--- a/GPC/CodeGenerator/Intel_x86-64/stackmng/stackmng.c
+++ b/GPC/CodeGenerator/Intel_x86-64/stackmng/stackmng.c
@@ -142,6 +142,38 @@ StackNode_t *add_l_t(char *label)
     return new_node;
 }
 
+StackNode_t *add_temp_bytes(char *label, int size)
+{
+    assert(global_stackmng != NULL);
+    assert(global_stackmng->cur_scope != NULL);
+    assert(label != NULL);
+
+    if (size <= 0)
+        size = (int)sizeof(void *);
+
+    StackScope_t *cur_scope = global_stackmng->cur_scope;
+    int alignment = (int)sizeof(void *);
+    if (alignment < DOUBLEWORD)
+        alignment = DOUBLEWORD;
+
+    cur_scope->t_offset = align_up(cur_scope->t_offset, alignment);
+    cur_scope->t_offset = align_up(cur_scope->t_offset, size);
+    cur_scope->t_offset += size;
+
+    int offset = current_stack_home_space() +
+        cur_scope->z_offset + cur_scope->x_offset + cur_scope->t_offset;
+
+    StackNode_t *new_node = init_stack_node(offset, label, size);
+
+    if (cur_scope->t == NULL)
+        cur_scope->t = CreateListNode(new_node, LIST_UNSPECIFIED);
+    else
+        cur_scope->t = PushListNodeBack(cur_scope->t,
+            CreateListNode(new_node, LIST_UNSPECIFIED));
+
+    return new_node;
+}
+
 /* Adds storage to x */
 StackNode_t *add_l_x(char *label, int size)
 {

--- a/GPC/CodeGenerator/Intel_x86-64/stackmng/stackmng.h
+++ b/GPC/CodeGenerator/Intel_x86-64/stackmng/stackmng.h
@@ -50,6 +50,7 @@ int get_needed_stack_space();
 void push_stackscope();
 void pop_stackscope();
 StackNode_t *add_l_t(char *);
+StackNode_t *add_temp_bytes(char *label, int size);
 StackNode_t *add_l_x(char *, int size);
 StackNode_t *add_l_z(char *);
 StackNode_t *add_q_z(char *);

--- a/GPC/Parser/List/List.h
+++ b/GPC/Parser/List/List.h
@@ -12,7 +12,7 @@
 
 /* Careful with using LIST_UNSPECIFIED. Can cause errors on switch statements */
 enum ListType{LIST_TREE, LIST_STMT, LIST_EXPR, LIST_STRING,
-              LIST_RECORD_FIELD, LIST_CASE_BRANCH, LIST_UNSPECIFIED};
+              LIST_RECORD_FIELD, LIST_CASE_BRANCH, LIST_SET_ELEMENT, LIST_UNSPECIFIED};
 
 /* Our linked list of tree type nodes */
 typedef struct List ListNode_t;

--- a/GPC/Parser/ParseTree/tree.h
+++ b/GPC/Parser/ParseTree/tree.h
@@ -251,5 +251,12 @@ struct Expression *mk_bool(int line_num, int value);
 struct Expression *mk_typecast(int line_num, int target_type, char *target_type_id,
     struct Expression *expr);
 
+struct SetElement *mk_set_element(struct Expression *start, struct Expression *end);
+struct Expression *mk_set(int line_num, ListNode_t *elements);
+struct Expression *mk_set_binary(int line_num, int op_type, struct Expression *left,
+    struct Expression *right);
+struct Expression *mk_set_in(int line_num, struct Expression *element,
+    struct Expression *set_expr);
+
 
 #endif

--- a/GPC/Parser/ParseTree/tree_types.h
+++ b/GPC/Parser/ParseTree/tree_types.h
@@ -188,7 +188,16 @@ enum ExprType {
     EXPR_BOOL,
     EXPR_POINTER_DEREF,
     EXPR_ADDR,
-    EXPR_TYPECAST
+    EXPR_TYPECAST,
+    EXPR_SET,
+    EXPR_SET_BINARY,
+    EXPR_IN
+};
+
+struct SetElement
+{
+    struct Expression *start_expr;
+    struct Expression *end_expr; /* NULL when representing a single element */
 };
 
 /* An expression subtree */
@@ -279,6 +288,27 @@ struct Expression
             char *target_type_id;
             struct Expression *expr;
         } typecast_data;
+
+        /* Set constructor */
+        struct SetConstructor
+        {
+            ListNode_t *elements; /* List of SetElement */
+        } set_data;
+
+        /* Set binary operation */
+        struct SetBinary
+        {
+            int op_type;
+            struct Expression *left;
+            struct Expression *right;
+        } set_binary_data;
+
+        /* Set membership */
+        struct SetMembership
+        {
+            struct Expression *element;
+            struct Expression *set_expr;
+        } set_in_data;
     } expr_data;
     struct Expression *field_width;
     struct Expression *field_precision;

--- a/GPC/Parser/ParseTree/type_tags.h
+++ b/GPC/Parser/ParseTree/type_tags.h
@@ -50,4 +50,9 @@
 #define ROL                 26
 #define ROR                 27
 
+#define SET_OP_UNION        33
+#define SET_OP_INTERSECT    34
+#define SET_OP_DIFF         35
+#define SET_OP_SYMDIFF      36
+
 #endif /* TYPE_TAGS_H */

--- a/tests/test_cases/set_operations.expected
+++ b/tests/test_cases/set_operations.expected
@@ -1,0 +1,3 @@
+union-has-4
+intersection-has-4
+constructor-has-2

--- a/tests/test_cases/set_operations.p
+++ b/tests/test_cases/set_operations.p
@@ -1,0 +1,28 @@
+program SetOperations;
+var
+  odds: set of 1..10;
+  evens: set of 1..10;
+  mix: set of 1..10;
+  result: set of 1..10;
+begin
+  odds := [1, 3, 5, 7, 9];
+  evens := [2, 4, 6, 8, 10];
+  mix := [3, 4, 5];
+
+  result := odds + mix;
+  if 4 in result then
+    writeln('union-has-4')
+  else
+    writeln('union-missing-4');
+
+  result := mix * evens;
+  if 4 in result then
+    writeln('intersection-has-4')
+  else
+    writeln('intersection-missing-4');
+
+  if 2 in [1, 2, 3] then
+    writeln('constructor-has-2')
+  else
+    writeln('constructor-missing-2');
+end.


### PR DESCRIPTION
## Summary
- implement code generation helpers for set constructors, operations, membership, and assignments on x86-64
- support non-local set variables and set-valued arguments in the expression/statement emitters
- add a regression test exercising set union, intersection, and constructor membership

## Testing
- ninja -C build
- ninja -C build test

------
https://chatgpt.com/codex/tasks/task_e_69027e506df0832aa9e3c9e768c796cb