### PR TITLE
Improve Pascal const parsing and case handling

### DIFF
--- a/GPC/CodeGenerator/Intel_x86-64/codegen_expression.c
+++ b/GPC/CodeGenerator/Intel_x86-64/codegen_expression.c
@@ -633,6 +633,20 @@ ListNode_t *codegen_expr(struct Expression *expr, ListNode_t *inst_list, CodeGen
     }
 }
 
+ListNode_t *codegen_expr_with_result(struct Expression *expr, ListNode_t *inst_list,
+    CodeGenContext *ctx, Register_t **out_reg)
+{
+    #ifdef DEBUG_CODEGEN
+    CODEGEN_DEBUG("DEBUG: ENTERING %s\n", __func__);
+    #endif
+    assert(out_reg != NULL);
+    inst_list = codegen_expr_tree_value(expr, inst_list, ctx, out_reg);
+    #ifdef DEBUG_CODEGEN
+    CODEGEN_DEBUG("DEBUG: LEAVING %s\n", __func__);
+    #endif
+    return inst_list;
+}
+
 
 ListNode_t *codegen_array_element_address(struct Expression *expr, ListNode_t *inst_list, CodeGenContext *ctx, Register_t **out_reg)
 {

--- a/GPC/CodeGenerator/Intel_x86-64/codegen_expression.h
+++ b/GPC/CodeGenerator/Intel_x86-64/codegen_expression.h
@@ -14,6 +14,7 @@ ListNode_t *codegen_simple_relop(struct Expression *, ListNode_t *,
     CodeGenContext *ctx, int *);
 
 ListNode_t *codegen_expr(struct Expression *, ListNode_t *, CodeGenContext *ctx);
+ListNode_t *codegen_expr_with_result(struct Expression *, ListNode_t *, CodeGenContext *ctx, Register_t **out_reg);
 ListNode_t *codegen_array_access(struct Expression *, ListNode_t *, CodeGenContext *, Register_t *);
 ListNode_t *codegen_array_element_address(struct Expression *, ListNode_t *, CodeGenContext *, Register_t **);
 ListNode_t *codegen_record_access(struct Expression *, ListNode_t *, CodeGenContext *, Register_t *);

--- a/cparser/examples/pascal_parser/snippets/complex_const_declaration.pas
+++ b/cparser/examples/pascal_parser/snippets/complex_const_declaration.pas
@@ -1,0 +1,7 @@
+program ConstExprTest;
+const
+  MaxValue = (1 + 2) * 3;
+  TypedConst: array[0..1] of Integer = (1, 2);
+  Derived = MaxValue - TypedConst[0];
+begin
+end.


### PR DESCRIPTION
## Summary
- replace the ad-hoc constant value parsers with the full expression parser so typed constants accept complex expressions
- expand Pascal parser tests to cover field casts, pointer dereference chains, and complex constant declarations
- update x86-64 case-statement code generation to reuse the selector value and compare against complex labels

## Testing
- meson test -C build 'pascal parser unit tests'

------
https://chatgpt.com/codex/tasks/task_e_690295db84c8832a903c949f355c98df