### PR TITLE
Handle width-sensitive arguments and longint division

### DIFF
--- a/GPC/CodeGenerator/Intel_x86-64/codegen.c
+++ b/GPC/CodeGenerator/Intel_x86-64/codegen.c
@@ -415,27 +415,9 @@ void codegen_stack_space(CodeGenContext *ctx)
     needed_space = get_full_stack_offset();
     assert(needed_space >= 0);
 
-    if (codegen_target_is_windows())
+    if(needed_space != 0)
     {
-        // On Windows, after pushing %rbp, the stack is 8 bytes off 16-byte alignment
-        // We need to make sure the total stack space allocated is (16 * N) - 8
-        // So that RSP is 16-byte aligned before calls
-        int aligned_space = 0;
-        if (needed_space > 0)
-        {
-            aligned_space = ((needed_space + 8 + 15) / 16) * 16 - 8;
-        }
-        if (aligned_space > 0)
-        {
-            fprintf(ctx->output_file, "\tsubq\t$%d, %%rsp\n", aligned_space);
-        }
-    }
-    else
-    {
-        if(needed_space != 0)
-        {
-            fprintf(ctx->output_file, "\tsubq\t$%d, %%rsp\n", needed_space);
-        }
+        fprintf(ctx->output_file, "\tsubq\t$%d, %%rsp\n", needed_space);
     }
     #ifdef DEBUG_CODEGEN
     CODEGEN_DEBUG("DEBUG: LEAVING %s\n", __func__);

--- a/tests/test_cases/division_widths.p
+++ b/tests/test_cases/division_widths.p
@@ -1,0 +1,15 @@
+Program division_widths;
+var
+  a, b, c: Integer;
+  la, lb, q: Longint;
+begin
+  a := 42;
+  b := -7;
+  c := a div b;
+  writeln(c);
+
+  la := 9223372036854775800;
+  lb := -3;
+  q := la div lb;
+  writeln(q);
+end.

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1233,6 +1233,9 @@ class TestCompiler(unittest.TestCase):
         expected_output_lines = [
             "Schreib wie viele Zahlen wollen sie eintippen, danach schreiben Sie die Zahlen.\n",
             "         gerade       ungerade       Positive       Negative\n",
+            "              4              3              4             -7\n",
+            "              0             -7              3               \n",
+            "             12                             0               \n",
             "Gerade Zahlen\n",
             "4 0 12 \n",
             "Ungerade Zahlen\n",
@@ -1280,6 +1283,27 @@ class TestCompiler(unittest.TestCase):
                 except subprocess.TimeoutExpired:
                     self.fail("Test execution timed out.")
 
+    def test_division_widths(self):
+        """Ensure integer division spills are reused for 32-bit and 64-bit operands."""
+
+        input_file = "tests/test_cases/division_widths.p"
+        asm_file = os.path.join(TEST_OUTPUT_DIR, "division_widths.s")
+        executable_file = os.path.join(TEST_OUTPUT_DIR, "division_widths")
+
+        run_compiler(input_file, asm_file)
+        self.compile_executable(asm_file, executable_file)
+
+        process = subprocess.run(
+            [executable_file],
+            capture_output=True,
+            text=True,
+            timeout=EXEC_TIMEOUT,
+        )
+
+        expected_output = "-6\n-3074457345618258600\n"
+
+        self.assertEqual(process.stdout, expected_output)
+        self.assertEqual(process.returncode, 0)
 
 
 def _load_suite():


### PR DESCRIPTION
## Summary
- ensure argument register moves track each expression's width so spills use matching movl/movq sequences and register aliases
- sign-extend 32-bit results when storing into 64-bit locals and document the shared division spill used by the expression tree
- update Zahlen expectations and add a regression test covering both 32-bit and 64-bit integer division via a new Pascal case

## Testing
- meson test -C build

------
https://chatgpt.com/codex/tasks/task_e_6903f6d27e54832a88532ad315e7e6cd

## Summary by Sourcery

Implement width-aware register moves and spilling across code generation, ensuring proper movl/movq usage, 32-bit to 64-bit sign-extension, and shared division quotient spills; simplify Windows shadow-space handling; and add regression tests for Zahl and division scenarios

Bug Fixes:
- Sign-extend 32-bit results when storing into 64-bit locals to preserve correctness

Enhancements:
- Refactor argument passing to track expression widths and select movl/movq or 32/64-bit registers accordingly
- Extract emit_load_from_stack helper and adjust binary operations to spill and reload left-hand values by width
- Reuse a shared temporary for integer-division quotients to avoid growing the stack frame
- Revise for-loop code generation to spill loop bounds, compare with sign-extension, and handle 32/64-bit cases
- Simplify Windows x64 shadow-space allocation by reserving it upfront and removing per-call adjustments

Tests:
- Update Zahlen program expectations and add regression test for mixed-width integer division