### PR TITLE
Handle recursive array bases in semantics and codegen

### DIFF
--- a/GPC/Parser/ParseTree/from_cparser.c
+++ b/GPC/Parser/ParseTree/from_cparser.c
@@ -444,9 +444,10 @@ static struct RecordType *convert_record_type(ast_t *record_node) {
 
         char *field_type_id = NULL;
         struct RecordType *nested_record = NULL;
+        TypeInfo field_info = {0};
         int field_type = UNKNOWN_TYPE;
         if (cursor != NULL)
-            field_type = convert_type_spec(cursor, &field_type_id, &nested_record, NULL);
+            field_type = convert_type_spec(cursor, &field_type_id, &nested_record, &field_info);
         else if (names != NULL)
         {
             char *candidate = pop_last_identifier(&names);
@@ -490,6 +491,13 @@ static struct RecordType *convert_record_type(ast_t *record_node) {
                 field_desc->type = field_type;
                 field_desc->type_id = type_id_copy;
                 field_desc->nested_record = nested_copy;
+                field_desc->is_array = field_info.is_array;
+                field_desc->array_start = field_info.start;
+                field_desc->array_end = field_info.end;
+                field_desc->array_element_type = field_info.element_type;
+                field_desc->array_element_type_id = field_info.element_type_id;
+                field_desc->array_is_open = field_info.is_open_array;
+                field_info.element_type_id = NULL;
                 list_builder_append(&fields_builder, field_desc, LIST_RECORD_FIELD);
             } else {
                 if (field_name != NULL)
@@ -508,6 +516,7 @@ static struct RecordType *convert_record_type(ast_t *record_node) {
             free(field_type_id);
         if (nested_record != NULL)
             destroy_record_type(nested_record);
+        destroy_type_info_contents(&field_info);
     }
 
     struct RecordType *record = (struct RecordType *)malloc(sizeof(struct RecordType));

--- a/GPC/Parser/ParseTree/tree_types.h
+++ b/GPC/Parser/ParseTree/tree_types.h
@@ -48,6 +48,12 @@ struct RecordField
     int type;
     char *type_id;
     struct RecordType *nested_record;
+    int is_array;
+    int array_start;
+    int array_end;
+    int array_element_type;
+    char *array_element_type_id;
+    int array_is_open;
 };
 
 struct RecordType
@@ -305,6 +311,14 @@ struct Expression
     int pointer_subtype;
     char *pointer_subtype_id;
     struct RecordType *record_type;
+    int is_array_expr;
+    int array_element_type;
+    char *array_element_type_id;
+    int array_lower_bound;
+    int array_upper_bound;
+    int array_element_size;
+    int array_is_dynamic;
+    struct RecordType *array_element_record_type;
 };
 
 struct SetElement


### PR DESCRIPTION
## Summary
- recurse through array base expressions in semantic analysis and populate array metadata for chained accesses
- update array element address generation to compute base pointers from nested expressions and semantic metadata
- allow single-character string literals to coerce to char assignments and permit chars in write/writeln checks

## Testing
- meson compile -C build
- build/GPC/gpc tests/test_cases/test_chained_lvalue.p tests/output/test.s --dump-ast=tests/output/refactored.ast

------
https://chatgpt.com/codex/tasks/task_e_69053af4fd0c832a9f246b0a8b9591b7

## Summary by Sourcery

Handle nested array semantics and code generation, and add char coercions for single-character strings

New Features:
- Propagate array metadata through nested and chained array expressions in semantic analysis
- Generate element addresses for both static and dynamic nested arrays in x86-64 codegen using semantic metadata
- Allow single-character string literals to coerce to char in assignments and accept char types in write/write checks

Enhancements:
- Add utility functions to clear, set, and clone array information in expressions and record fields
- Extend the AST and parse tree structures to include array properties for record fields and expressions
- Refactor assignment type checking to support char/string coercion without breaking existing numeric promotions