### PR TITLE
Support chained array and record accesses

### DIFF
--- a/GPC/CodeGenerator/Intel_x86-64/codegen_expression.c
+++ b/GPC/CodeGenerator/Intel_x86-64/codegen_expression.c
@@ -285,7 +285,31 @@ static int codegen_sizeof_record(CodeGenContext *ctx, struct RecordType *record,
         struct RecordField *field = (struct RecordField *)cur->cur;
         long long field_size = 0;
 
-        if (field->nested_record != NULL)
+        if (field->is_array)
+        {
+            long long element_size = 0;
+            struct RecordType *element_record = NULL;
+            const char *element_type_id = field->array_element_type_id;
+            if (element_type_id != NULL && ctx != NULL && ctx->symtab != NULL)
+            {
+                HashNode_t *node = NULL;
+                if (FindIdent(&node, ctx->symtab, (char *)element_type_id) >= 0 && node != NULL &&
+                    node->record_type != NULL)
+                    element_record = node->record_type;
+            }
+
+            if (codegen_sizeof_type(ctx, field->array_element_type, element_type_id,
+                    element_record, &element_size, depth + 1) != 0)
+                return 1;
+
+            long long count = (long long)field->array_upper_bound -
+                (long long)field->array_lower_bound + 1;
+            if (count < 0)
+                count = 0;
+
+            field_size = element_size * count;
+        }
+        else if (field->nested_record != NULL)
         {
             if (codegen_sizeof_record(ctx, field->nested_record, &field_size, depth + 1) != 0)
                 return 1;
@@ -308,6 +332,12 @@ int codegen_sizeof_record_type(CodeGenContext *ctx, struct RecordType *record,
     long long *size_out)
 {
     return codegen_sizeof_record(ctx, record, size_out, 0);
+}
+
+int codegen_sizeof_type_reference(CodeGenContext *ctx, int type_tag,
+    const char *type_id, struct RecordType *record_type, long long *size_out)
+{
+    return codegen_sizeof_type(ctx, type_tag, type_id, record_type, size_out, 0);
 }
 
 static int codegen_sizeof_alias(CodeGenContext *ctx, struct TypeAlias *alias,
@@ -1161,178 +1191,118 @@ ListNode_t *codegen_expr_with_result(struct Expression *expr, ListNode_t *inst_l
 }
 
 
-ListNode_t *codegen_array_element_address(struct Expression *expr, ListNode_t *inst_list, CodeGenContext *ctx, Register_t **out_reg)
+ListNode_t *codegen_array_element_address(struct Expression *expr, ListNode_t *inst_list,
+    CodeGenContext *ctx, Register_t **out_reg)
 {
     assert(expr != NULL);
     assert(expr->type == EXPR_ARRAY_ACCESS);
     assert(ctx != NULL);
     assert(out_reg != NULL);
 
-    const char *array_id = expr->expr_data.array_access_data.id;
-    if (array_id == NULL)
-    {
-        codegen_report_error(ctx, "ERROR: Missing array identifier in access expression.");
-        return inst_list;
-    }
-
-    inst_list = codegen_expr(expr->expr_data.array_access_data.array_expr, inst_list, ctx);
-    if (codegen_had_error(ctx))
-        return inst_list;
-    Register_t *index_reg = codegen_try_get_reg(&inst_list, ctx, "array index");
-    if (index_reg == NULL)
+    struct Expression *base_expr = expr->expr_data.array_access_data.array_expr;
+    struct Expression *index_expr = expr->expr_data.array_access_data.index_expr;
+    if (base_expr == NULL || index_expr == NULL)
         return inst_list;
 
-    StackNode_t *array_node = find_label((char *)array_id);
-    if (array_node == NULL || array_node->is_array == 0)
+    Register_t *index_reg = NULL;
+    inst_list = codegen_expr_tree_value(index_expr, inst_list, ctx, &index_reg);
+    if (codegen_had_error(ctx) || index_reg == NULL)
+        return inst_list;
+
+    Register_t *base_reg = NULL;
+    inst_list = codegen_address_for_expr(base_expr, inst_list, ctx, &base_reg);
+    if (codegen_had_error(ctx) || base_reg == NULL)
     {
-        codegen_report_error(ctx,
-            "ERROR: Array %s not found on stack (non-local arrays unsupported).", array_id);
         free_reg(get_reg_stack(), index_reg);
         return inst_list;
     }
 
-    int element_size = array_node->element_size;
-    if (element_size <= 0)
-        element_size = DOUBLEWORD;
-
-    int lower_bound = array_node->array_lower_bound;
-    char buffer[128];
-
-    if (array_node->is_dynamic || array_node->is_static)
+    int base_is_dynamic_array = 0;
+    int base_is_static_array = 0;
+    const char *static_array_label = NULL;
+    if (base_expr->type == EXPR_VAR_ID)
     {
-        const char *base_usage = array_node->is_dynamic ? "dynamic array base" : "static array base";
-        Register_t *base_reg = codegen_try_get_reg(&inst_list, ctx, base_usage);
-        if (base_reg == NULL)
+        StackNode_t *array_node = find_label(base_expr->expr_data.id);
+        if (array_node != NULL && array_node->is_dynamic)
+            base_is_dynamic_array = 1;
+        if (array_node != NULL && array_node->is_static && array_node->static_label != NULL)
         {
-            free_reg(get_reg_stack(), index_reg);
-            return inst_list;
+            base_is_static_array = 1;
+            static_array_label = array_node->static_label;
         }
+    }
 
-        if (array_node->is_dynamic)
-        {
-            snprintf(buffer, sizeof(buffer), "\tmovq\t-%d(%%rbp), %s\n", array_node->offset, base_reg->bit_64);
-            inst_list = add_inst(inst_list, buffer);
-        }
-        else if (array_node->static_label != NULL)
-        {
-            snprintf(buffer, sizeof(buffer), "\tleaq\t%s(%%rip), %s\n", array_node->static_label, base_reg->bit_64);
-            inst_list = add_inst(inst_list, buffer);
-        }
+    long long lower_bound = expr->array_lower_bound;
+    int element_size = expr->array_element_size;
+    if (element_size <= 0)
+        element_size = CODEGEN_POINTER_SIZE_BYTES;
+
+    int index_is_long = (index_expr->resolved_type == LONGINT_TYPE);
+    char buffer[128];
+    if (lower_bound > 0)
+    {
+        if (index_is_long)
+            snprintf(buffer, sizeof(buffer), "\tsubq\t$%lld, %s\n", lower_bound, index_reg->bit_64);
         else
-        {
-            codegen_report_error(ctx, "ERROR: Static array %s is missing storage label.", array_id);
-            free_reg(get_reg_stack(), base_reg);
-            free_reg(get_reg_stack(), index_reg);
-            return inst_list;
-        }
+            snprintf(buffer, sizeof(buffer), "\tsubl\t$%lld, %s\n", lower_bound, index_reg->bit_32);
+        inst_list = add_inst(inst_list, buffer);
+    }
+    else if (lower_bound < 0)
+    {
+        if (index_is_long)
+            snprintf(buffer, sizeof(buffer), "\taddq\t$%lld, %s\n", -lower_bound, index_reg->bit_64);
+        else
+            snprintf(buffer, sizeof(buffer), "\taddl\t$%lld, %s\n", -lower_bound, index_reg->bit_32);
+        inst_list = add_inst(inst_list, buffer);
+    }
 
-        if (lower_bound > 0)
-        {
-            snprintf(buffer, sizeof(buffer), "\tsubl\t$%d, %s\n", lower_bound, index_reg->bit_32);
-            inst_list = add_inst(inst_list, buffer);
-        }
-        else if (lower_bound < 0)
-        {
-            snprintf(buffer, sizeof(buffer), "\taddl\t$%d, %s\n", -lower_bound, index_reg->bit_32);
-            inst_list = add_inst(inst_list, buffer);
-        }
-
+    if (!index_is_long)
         inst_list = codegen_sign_extend32_to64(inst_list, index_reg->bit_32, index_reg->bit_64);
 
-        int scaled_sizes[] = {1, 2, 4, 8};
-        int can_scale = 0;
-        for (size_t i = 0; i < sizeof(scaled_sizes) / sizeof(scaled_sizes[0]); ++i)
+    static const int scaled_sizes[] = {1, 2, 4, 8};
+    int can_scale = 0;
+    for (size_t i = 0; i < sizeof(scaled_sizes) / sizeof(scaled_sizes[0]); ++i)
+    {
+        if (element_size == scaled_sizes[i])
         {
-            if (element_size == scaled_sizes[i])
-            {
-                can_scale = 1;
-                break;
-            }
+            can_scale = 1;
+            break;
         }
+    }
 
-        if (can_scale)
-        {
-            snprintf(buffer, sizeof(buffer), "\tleaq\t(%s,%s,%d), %s\n", base_reg->bit_64, index_reg->bit_64, element_size, index_reg->bit_64);
-            inst_list = add_inst(inst_list, buffer);
-        }
-        else
-        {
-            if (element_size != 1)
-            {
-                snprintf(buffer, sizeof(buffer), "\timulq\t$%d, %s\n", element_size, index_reg->bit_64);
-                inst_list = add_inst(inst_list, buffer);
-            }
+    if (base_is_static_array)
+    {
+        snprintf(buffer, sizeof(buffer), "\tleaq\t%s(%%rip), %s\n", static_array_label,
+            base_reg->bit_64);
+        inst_list = add_inst(inst_list, buffer);
+    }
+    else if (base_is_dynamic_array)
+    {
+        snprintf(buffer, sizeof(buffer), "\tmovq\t(%s), %s\n", base_reg->bit_64, base_reg->bit_64);
+        inst_list = add_inst(inst_list, buffer);
+    }
 
-            StackNode_t *offset_temp = find_in_temp("array_index_offset");
-            if (offset_temp == NULL)
-                offset_temp = add_l_t("array_index_offset");
-
-            snprintf(buffer, sizeof(buffer), "\tmovq\t%s, -%d(%%rbp)\n", index_reg->bit_64, offset_temp->offset);
-            inst_list = add_inst(inst_list, buffer);
-
-            snprintf(buffer, sizeof(buffer), "\tmovq\t%s, %s\n", base_reg->bit_64, index_reg->bit_64);
-            inst_list = add_inst(inst_list, buffer);
-
-            snprintf(buffer, sizeof(buffer), "\taddq\t-%d(%%rbp), %s\n", offset_temp->offset, index_reg->bit_64);
-            inst_list = add_inst(inst_list, buffer);
-        }
-
-        free_reg(get_reg_stack(), base_reg);
+    if (can_scale)
+    {
+        snprintf(buffer, sizeof(buffer), "\tleaq\t(%s,%s,%d), %s\n",
+            base_reg->bit_64, index_reg->bit_64, element_size, index_reg->bit_64);
+        inst_list = add_inst(inst_list, buffer);
     }
     else
     {
-        if (lower_bound > 0)
+        if (element_size != 1)
         {
-            snprintf(buffer, sizeof(buffer), "\tsubl\t$%d, %s\n", lower_bound, index_reg->bit_32);
-            inst_list = add_inst(inst_list, buffer);
-        }
-        else if (lower_bound < 0)
-        {
-            snprintf(buffer, sizeof(buffer), "\taddl\t$%d, %s\n", -lower_bound, index_reg->bit_32);
+            snprintf(buffer, sizeof(buffer), "\timulq\t$%d, %s\n", element_size,
+                index_reg->bit_64);
             inst_list = add_inst(inst_list, buffer);
         }
 
-        int scaled_sizes[] = {1, 2, 4, 8};
-        int can_scale = 0;
-        for (size_t i = 0; i < sizeof(scaled_sizes) / sizeof(scaled_sizes[0]); ++i)
-        {
-            if (element_size == scaled_sizes[i])
-            {
-                can_scale = 1;
-                break;
-            }
-        }
-
-        inst_list = codegen_sign_extend32_to64(inst_list, index_reg->bit_32, index_reg->bit_64);
-
-        if (can_scale)
-        {
-            snprintf(buffer, sizeof(buffer), "\tleaq\t-%d(%%rbp,%s,%d), %s\n", array_node->offset, index_reg->bit_64, element_size, index_reg->bit_64);
-            inst_list = add_inst(inst_list, buffer);
-        }
-        else
-        {
-            if (element_size != 1)
-            {
-                snprintf(buffer, sizeof(buffer), "\timulq\t$%d, %s\n", element_size, index_reg->bit_64);
-                inst_list = add_inst(inst_list, buffer);
-            }
-
-            StackNode_t *offset_temp = find_in_temp("array_index_offset");
-            if (offset_temp == NULL)
-                offset_temp = add_l_t("array_index_offset");
-
-            snprintf(buffer, sizeof(buffer), "\tmovq\t%s, -%d(%%rbp)\n", index_reg->bit_64, offset_temp->offset);
-            inst_list = add_inst(inst_list, buffer);
-
-            snprintf(buffer, sizeof(buffer), "\tleaq\t-%d(%%rbp), %s\n", array_node->offset, index_reg->bit_64);
-            inst_list = add_inst(inst_list, buffer);
-
-            snprintf(buffer, sizeof(buffer), "\taddq\t-%d(%%rbp), %s\n", offset_temp->offset, index_reg->bit_64);
-            inst_list = add_inst(inst_list, buffer);
-        }
+        snprintf(buffer, sizeof(buffer), "\taddq\t%s, %s\n", base_reg->bit_64,
+            index_reg->bit_64);
+        inst_list = add_inst(inst_list, buffer);
     }
 
+    free_reg(get_reg_stack(), base_reg);
     *out_reg = index_reg;
     return inst_list;
 }

--- a/GPC/CodeGenerator/Intel_x86-64/codegen_expression.h
+++ b/GPC/CodeGenerator/Intel_x86-64/codegen_expression.h
@@ -29,6 +29,8 @@ int codegen_sizeof_record_type(CodeGenContext *ctx, struct RecordType *record,
     long long *size_out);
 int codegen_sizeof_pointer_target(CodeGenContext *ctx, struct Expression *pointer_expr,
     long long *size_out);
+int codegen_sizeof_type_reference(CodeGenContext *ctx, int type_tag,
+    const char *type_id, struct RecordType *record_type, long long *size_out);
 
 ListNode_t *codegen_sign_extend32_to64(ListNode_t *inst_list, const char *src_reg32, const char *dst_reg64);
 ListNode_t *codegen_zero_extend32_to64(ListNode_t *inst_list, const char *src_reg32, const char *dst_reg32);

--- a/GPC/Parser/ParseTree/tree.c
+++ b/GPC/Parser/ParseTree/tree.c
@@ -68,6 +68,17 @@ static void print_record_field(struct RecordField *field, FILE *f, int num_inden
         fprintf(f, " type=%s", field->type_id);
     else
         fprintf(f, " type=%d", field->type);
+    if (field->is_array)
+    {
+        fprintf(f, " array=[%lld..%lld]",
+            field->array_lower_bound, field->array_upper_bound);
+        if (field->array_element_type_id != NULL)
+            fprintf(f, " elem=%s", field->array_element_type_id);
+        else
+            fprintf(f, " elem=%d", field->array_element_type);
+        if (field->is_open_array)
+            fprintf(f, " open=1");
+    }
     fprintf(f, "]\n");
 
     if (field->nested_record != NULL)
@@ -87,6 +98,8 @@ static void destroy_record_field(struct RecordField *field)
         free(field->name);
     if (field->type_id != NULL)
         free(field->type_id);
+    if (field->array_element_type_id != NULL)
+        free(field->array_element_type_id);
     destroy_record_type(field->nested_record);
     free(field);
 }
@@ -560,12 +573,19 @@ void expr_print(struct Expression *expr, FILE *f, int num_indent)
           break;
 
         case EXPR_ARRAY_ACCESS:
-          fprintf(f, "[ARRAY_ACC:%s]\n", expr->expr_data.array_access_data.id);
+          fprintf(f, "[ARRAY_ACC]\n");
           ++num_indent;
+
+          if (expr->expr_data.array_access_data.array_expr != NULL)
+          {
+              print_indent(f, num_indent);
+              fprintf(f, "[ARRAY]:\n");
+              expr_print(expr->expr_data.array_access_data.array_expr, f, num_indent+1);
+          }
 
           print_indent(f, num_indent);
           fprintf(f, "[INDEX]:\n");
-          expr_print(expr->expr_data.array_access_data.array_expr, f, num_indent+1);
+          expr_print(expr->expr_data.array_access_data.index_expr, f, num_indent+1);
           break;
 
         case EXPR_RECORD_ACCESS:
@@ -970,8 +990,10 @@ void destroy_expr(struct Expression *expr)
           break;
 
         case EXPR_ARRAY_ACCESS:
-          free(expr->expr_data.array_access_data.id);
-          destroy_expr(expr->expr_data.array_access_data.array_expr);
+          if (expr->expr_data.array_access_data.array_expr != NULL)
+              destroy_expr(expr->expr_data.array_access_data.array_expr);
+          if (expr->expr_data.array_access_data.index_expr != NULL)
+              destroy_expr(expr->expr_data.array_access_data.index_expr);
           break;
 
         case EXPR_RECORD_ACCESS:
@@ -1044,6 +1066,11 @@ void destroy_expr(struct Expression *expr)
         free(expr->pointer_subtype_id);
         expr->pointer_subtype_id = NULL;
     }
+    if (expr->array_element_type_id != NULL)
+    {
+        free(expr->array_element_type_id);
+        expr->array_element_type_id = NULL;
+    }
     free(expr);
 }
 
@@ -1077,6 +1104,12 @@ struct RecordType *clone_record_type(const struct RecordType *record_type)
         field_clone->type = field->type;
         field_clone->type_id = field->type_id != NULL ? strdup(field->type_id) : NULL;
         field_clone->nested_record = clone_record_type(field->nested_record);
+        field_clone->is_array = field->is_array;
+        field_clone->array_lower_bound = field->array_lower_bound;
+        field_clone->array_upper_bound = field->array_upper_bound;
+        field_clone->array_element_type = field->array_element_type;
+        field_clone->array_element_type_id = field->array_element_type_id != NULL ? strdup(field->array_element_type_id) : NULL;
+        field_clone->is_open_array = field->is_open_array;
 
         ListNode_t *node = CreateListNode(field_clone, LIST_RECORD_FIELD);
         if (clone->fields == NULL)
@@ -1592,6 +1625,12 @@ static void init_expression(struct Expression *expr, int line_num, enum ExprType
     expr->pointer_subtype = UNKNOWN_TYPE;
     expr->pointer_subtype_id = NULL;
     expr->record_type = NULL;
+    expr->is_array_expr = 0;
+    expr->array_lower_bound = 0;
+    expr->array_upper_bound = 0;
+    expr->array_element_size = 0;
+    expr->array_element_type = UNKNOWN_TYPE;
+    expr->array_element_type_id = NULL;
 }
 
 struct Expression *mk_relop(int line_num, int type, struct Expression *left,
@@ -1663,15 +1702,15 @@ struct Expression *mk_varid(int line_num, char *id)
     return new_expr;
 }
 
-struct Expression *mk_arrayaccess(int line_num, char *id, struct Expression *index_expr)
+struct Expression *mk_arrayaccess(int line_num, struct Expression *array_expr, struct Expression *index_expr)
 {
     struct Expression *new_expr;
     new_expr = (struct Expression *)malloc(sizeof(struct Expression));
     assert(new_expr != NULL);
 
     init_expression(new_expr, line_num, EXPR_ARRAY_ACCESS);
-    new_expr->expr_data.array_access_data.id = id;
-    new_expr->expr_data.array_access_data.array_expr = index_expr;
+    new_expr->expr_data.array_access_data.array_expr = array_expr;
+    new_expr->expr_data.array_access_data.index_expr = index_expr;
 
     return new_expr;
 }

--- a/GPC/Parser/ParseTree/tree.h
+++ b/GPC/Parser/ParseTree/tree.h
@@ -245,7 +245,7 @@ struct Expression *mk_mulop(int line_num, int type, struct Expression *left, str
 
 struct Expression *mk_varid(int line_num, char *id);
 
-struct Expression *mk_arrayaccess(int line_num, char *id, struct Expression *index_expr);
+struct Expression *mk_arrayaccess(int line_num, struct Expression *array_expr, struct Expression *index_expr);
 
 struct Expression *mk_recordaccess(int line_num, struct Expression *record_expr, char *field_id);
 

--- a/GPC/Parser/ParseTree/tree_types.h
+++ b/GPC/Parser/ParseTree/tree_types.h
@@ -48,6 +48,12 @@ struct RecordField
     int type;
     char *type_id;
     struct RecordType *nested_record;
+    int is_array;
+    long long array_lower_bound;
+    long long array_upper_bound;
+    int array_element_type;
+    char *array_element_type_id;
+    int is_open_array;
 };
 
 struct RecordType
@@ -238,8 +244,8 @@ struct Expression
         /* An indexed array */
         struct ArrayAccess
         {
-            char *id;
             struct Expression *array_expr;
+            struct Expression *index_expr;
         } array_access_data;
 
         /* Record field access */
@@ -305,6 +311,12 @@ struct Expression
     int pointer_subtype;
     char *pointer_subtype_id;
     struct RecordType *record_type;
+    int is_array_expr;
+    long long array_lower_bound;
+    long long array_upper_bound;
+    int array_element_size;
+    int array_element_type;
+    char *array_element_type_id;
 };
 
 struct SetElement

--- a/tests/test_cases/test_chained_lvalue.p
+++ b/tests/test_cases/test_chained_lvalue.p
@@ -1,0 +1,14 @@
+program TestChainedAccess;
+type
+  TElementRecord = record
+    Name: array[1..10] of integer;
+  end;
+  TRecordArray = array[1..5] of TElementRecord;
+var
+  RecordCollection: TRecordArray;
+  value: integer;
+begin
+  RecordCollection[2].Name[1] := 65;
+  value := RecordCollection[2].Name[1];
+  writeln(value);
+end.

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1108,6 +1108,26 @@ class TestCompiler(unittest.TestCase):
         self.assertEqual(result.stdout, expected_output)
         self.assertEqual(result.returncode, 0)
 
+    def test_chained_lvalue_access(self):
+        """Ensures chained array and record field accesses execute correctly."""
+        input_file = os.path.join(TEST_CASES_DIR, "test_chained_lvalue.p")
+        asm_file = os.path.join(TEST_OUTPUT_DIR, "test_chained_lvalue.s")
+        executable_file = os.path.join(TEST_OUTPUT_DIR, "test_chained_lvalue")
+
+        run_compiler(input_file, asm_file)
+        self.compile_executable(asm_file, executable_file)
+
+        result = subprocess.run(
+            [executable_file],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=EXEC_TIMEOUT,
+        )
+
+        self.assertEqual(result.stdout, "65\n")
+        self.assertEqual(result.returncode, 0)
+
     def test_record_reference_features(self):
         """Exercises record assignment, address-of, and var parameter support."""
         input_file = os.path.join(TEST_CASES_DIR, "record_reference_features.p")


### PR DESCRIPTION
## Summary
- propagate array metadata through expression structures and parser conversions so nested record fields retain index information
- teach the semantic checker to recurse on array bases (including pointer and record fields) and surface element typing metadata
- generalize array element code generation to use arbitrary l-values while computing element sizes from symbol data
- add a regression program and runner coverage that exercises RecordCollection[2].Name[1]

## Testing
- meson compile -C build
- meson test -C build

------
https://chatgpt.com/codex/tasks/task_e_69052d26f264832a835865b6c37aea5e

## Summary by Sourcery

Support nested array and record field accesses by carrying array bounds and element typing metadata through parsing, semantic analysis, and code generation, and validate with a new test case

New Features:
- Enable chained array and record field accesses across nested expressions

Enhancements:
- Propagate array metadata through parser, semantic checker, and expression clones
- Generalize array element code generation to compute offsets from expression metadata and arbitrary l-values
- Introduce codegen_sizeof_type_reference helper for computing element sizes

Tests:
- Add regression test and Pascal program to verify chained l-value accesses