### PR TITLE
Improve parser error diagnostics and add dialogue regression

### DIFF
--- a/GPC/Parser/pascal_frontend.c
+++ b/GPC/Parser/pascal_frontend.c
@@ -400,4 +400,23 @@ void pascal_print_parse_error(const char *path, const ParseError *err)
             err->message ? err->message : "unknown error");
     if (err->unexpected)
         fprintf(stderr, "  Unexpected: %s\n", err->unexpected);
+    if (err->context && err->context[0] != '\0')
+    {
+        fprintf(stderr, "  Context:\n");
+        const char *cursor = err->context;
+        while (*cursor != '\0')
+        {
+            const char *newline = strchr(cursor, '\n');
+            if (newline != NULL)
+            {
+                fprintf(stderr, "    %.*s\n", (int)(newline - cursor), cursor);
+                cursor = newline + 1;
+            }
+            else
+            {
+                fprintf(stderr, "    %s\n", cursor);
+                break;
+            }
+        }
+    }
 }

--- a/cparser/examples/pascal_parser/pascal_expression.c
+++ b/cparser/examples/pascal_parser/pascal_expression.c
@@ -307,6 +307,19 @@ static ParseResult char_fn(input_t* in, void* args, char* parser_name) {
         return make_failure_v2(in, parser_name, strdup("Expected closing single quote"), NULL);
     }
 
+    // If the next character is another single quote, this is part of a
+    // Pascal string literal that uses doubled quotes for escaping. Treat this
+    // as a failure so the string parser can consume the complete literal.
+    InputState peek_state;
+    save_input_state(in, &peek_state);
+    char next_char = read1(in);
+    restore_input_state(in, &peek_state);
+    if (next_char == '\'') {
+        restore_input_state(in, &state);
+        return make_failure_with_state(in, &state, parser_name,
+            strdup("Character literal cannot contain doubled quotes"), NULL);
+    }
+
     // Create AST node with the character value
     char text[2];
     text[0] = char_value;

--- a/cparser/examples/pascal_parser/pascal_tests.c
+++ b/cparser/examples/pascal_parser/pascal_tests.c
@@ -563,6 +563,24 @@ void test_pascal_string_literal(void) {
     free(input);
 }
 
+void test_pascal_string_literal_with_quote(void) {
+    combinator_t* p = new_combinator();
+    init_pascal_expression_parser(&p);
+
+    input_t* input = new_input();
+    input->buffer = strdup("'I''m'");
+    input->length = strlen("'I''m'");
+
+    ParseResult res = parse(input, p);
+
+    TEST_ASSERT(res.is_success);
+    TEST_ASSERT(res.value.ast->typ == PASCAL_T_STRING);
+    TEST_ASSERT(strcmp(res.value.ast->sym->name, "I'm") == 0);
+
+    free_ast(res.value.ast);    free(input->buffer);
+    free(input);
+}
+
 void test_pascal_function_call_no_args(void) {
     combinator_t* p = new_combinator();
     init_pascal_expression_parser(&p);
@@ -3113,6 +3131,31 @@ void test_pascal_unitless_program(void) {
     free(input);
 }
 
+void test_pascal_dialogue_program(void) {
+    combinator_t* parser = get_program_parser();
+
+    input_t* input = new_input();
+    char* program = load_pascal_snippet("dialogue_program.pas");
+    TEST_ASSERT(program != NULL);
+    if (!program) {
+        free(input);
+        return;
+    }
+    input->buffer = program;
+    input->length = strlen(program);
+
+    ParseResult res = parse(input, parser);
+    TEST_ASSERT(res.is_success);
+    if (res.is_success) {
+        free_ast(res.value.ast);
+    } else if (res.value.error != NULL) {
+        free_error(res.value.error);
+    }
+
+    free(input->buffer);
+    free(input);
+}
+
 void test_fpc_style_unit_parsing(void) {
     combinator_t* p = get_unit_parser();
     input_t* input = new_input();
@@ -3851,6 +3894,7 @@ TEST_LIST = {
     { "test_pascal_preprocessor_comment_mixing", test_pascal_preprocessor_comment_mixing },
     { "test_pascal_function_call", test_pascal_function_call },
     { "test_pascal_string_literal", test_pascal_string_literal },
+    { "test_pascal_string_literal_with_quote", test_pascal_string_literal_with_quote },
     { "test_pascal_function_call_no_args", test_pascal_function_call_no_args },
     { "test_pascal_function_call_with_args", test_pascal_function_call_with_args },
     { "test_pascal_mod_operator", test_pascal_mod_operator },
@@ -3931,6 +3975,7 @@ TEST_LIST = {
     { "test_pascal_record_member_access_program", test_pascal_record_member_access_program },
     { "test_pascal_record_member_access_complete_program", test_pascal_record_member_access_complete_program },
     { "test_pascal_unitless_program", test_pascal_unitless_program },
+    { "test_pascal_dialogue_program", test_pascal_dialogue_program },
     { "test_pascal_var_section", test_pascal_var_section },
     { "test_pascal_unit_with_dotted_name", test_pascal_unit_with_dotted_name },
     { "test_pascal_uses_with_dotted_unit", test_pascal_uses_with_dotted_unit },

--- a/cparser/examples/pascal_parser/snippets/dialogue_program.pas
+++ b/cparser/examples/pascal_parser/snippets/dialogue_program.pas
@@ -1,0 +1,30 @@
+program dlg;
+
+uses crt;
+
+procedure talk(speaker:integer; dialogue:string);
+begin
+  textcolor(speaker);
+  if (speaker = 1) then
+      write('Shopkeeper')
+  else if (speaker = 2) then
+      write('Joe Black ');
+  write(': ');
+  textcolor(7);
+  writeln(dialogue);
+  writeln;
+end;
+
+begin
+  clrscr;
+  writeln('Fictional dialogue.');
+  writeln;
+  writeln('-----');
+  writeln;
+  talk(1,'Good morning, sir. May I help you?');
+  talk(2,'I''m looking for a girl.');
+  talk(1,'Aren''t we all?');
+  talk(2,'No, I mean she works here. Do you know Sandra?');
+  talk(1,'Of course. Let me call her.');
+  readln;
+end.

--- a/cparser/parser.h
+++ b/cparser/parser.h
@@ -54,9 +54,11 @@ struct input_t {
 typedef struct ParseError {
     int line;
     int col;
+    int offset;
     char* message;
     char* parser_name;
     char* unexpected;
+    char* context;
     struct ParseError* cause;
     ast_t* partial_ast;
 } ParseError;
@@ -168,6 +170,7 @@ void restore_input_state(input_t* in, InputState* state);
 ParseResult make_success(ast_t* ast);
 ParseResult make_failure(input_t* in, char* message);
 ParseResult make_failure_v2(input_t* in, char* parser_name, char* message, char* unexpected);
+ParseResult make_failure_with_state(input_t* in, InputState* state, char* parser_name, char* message, char* unexpected);
 ParseResult wrap_failure(input_t* in, char* message, char* parser_name, ParseResult cause);
 
 // --- Helper Function Prototypes ---

--- a/cparser/tests.c
+++ b/cparser/tests.c
@@ -285,9 +285,11 @@ static ParseError* add_context_to_error(ParseError* err) {
     ParseError* new_err = (ParseError*)safe_malloc(sizeof(ParseError));
     new_err->line = err->line;
     new_err->col = err->col;
+    new_err->offset = err->offset;
     new_err->message = strdup("In custom context");
     new_err->parser_name = NULL;
     new_err->unexpected = NULL;
+    new_err->context = err->context ? strdup(err->context) : NULL;
     new_err->cause = err;
     new_err->partial_ast = NULL;
     return new_err;


### PR DESCRIPTION
## Summary
- retain the most informative parse failure and capture line/column offsets with surrounding source context
- update primitive parsers to preserve failure positions and print contextual snippets when reporting errors
- treat doubled quotes as strings instead of chars, and add a regression test plus snippet for the dialogue program

## Testing
- meson test -C builddir

------
https://chatgpt.com/codex/tasks/task_e_6905dd588540832a8978e97105cb6f8f

## Summary by Sourcery

Improve parser error diagnostics by capturing detailed failure positions (line, column, offset) and generating contextual source snippets, selecting the most informative parse error, and propagating context through the parsing API. Update primitive parsers to use the new error state mechanism. Treat doubled single quotes as Pascal string escapes instead of character literals. Add regression tests for string literals with embedded quotes and for parsing a dialogue program snippet.

New Features:
- Generate contextual error snippets around parse failures
- Select and retain the most informative failure in multi-choice parsers
- Print error context in the Pascal frontend

Bug Fixes:
- Handle doubled single quotes as Pascal string escapes rather than character literals

Enhancements:
- Capture and propagate failure positions (line, column, offset) in error constructors
- Refactor primitive parsers to preserve input state on failure

Tests:
- Add regression test for Pascal string literals with embedded quotes
- Add regression test and snippet for parsing a dialogue program