### PR TITLE
Add Crt unit with basic text color support

### DIFF
--- a/GPC/Units/crt.p
+++ b/GPC/Units/crt.p
@@ -1,0 +1,33 @@
+unit Crt;
+
+interface
+
+procedure ClrScr;
+procedure TextColor(color: integer);
+procedure ReadLn;
+
+implementation
+
+procedure ClrScr;
+begin
+    asm
+        call gpc_clrscr
+    end;
+end;
+
+procedure TextColor(color: integer);
+begin
+    asm
+        movl %edi, %edi
+        call gpc_textcolor
+    end;
+end;
+
+procedure ReadLn;
+begin
+    asm
+        call gpc_readln
+    end;
+end;
+
+end.

--- a/GPC/runtime.c
+++ b/GPC/runtime.c
@@ -20,6 +20,61 @@ static int gpc_vprintf_impl(const char *format, va_list args) {
     return vprintf(format, args);
 }
 
+static int gpc_normalize_color(int color)
+{
+    int normalized = color % 16;
+    if (normalized < 0)
+        normalized += 16;
+    return normalized;
+}
+
+static int gpc_lookup_ansi_color(int color)
+{
+    static const int ansi_codes[16] = {
+        30, /* black */
+        34, /* blue */
+        32, /* green */
+        36, /* cyan */
+        31, /* red */
+        35, /* magenta */
+        33, /* brown */
+        37, /* lightgray */
+        90, /* darkgray */
+        94, /* lightblue */
+        92, /* lightgreen */
+        96, /* lightcyan */
+        91, /* lightred */
+        95, /* lightmagenta */
+        93, /* yellow */
+        97, /* white */
+    };
+
+    return ansi_codes[gpc_normalize_color(color)];
+}
+
+void gpc_clrscr(void)
+{
+    fputs("\033[2J\033[H", stdout);
+    fflush(stdout);
+}
+
+void gpc_textcolor(int color)
+{
+    int ansi_code = gpc_lookup_ansi_color(color);
+    fprintf(stdout, "\033[%dm", ansi_code);
+    fflush(stdout);
+}
+
+void gpc_readln(void)
+{
+    int ch;
+    do {
+        ch = getchar();
+        if (ch == EOF)
+            break;
+    } while (ch != '\n');
+}
+
 static inline double gpc_bits_to_double(int64_t bits)
 {
     double value;

--- a/tests/do_not_run_me_directly_but_through_meson.py
+++ b/tests/do_not_run_me_directly_but_through_meson.py
@@ -1172,6 +1172,48 @@ class TestCompiler(unittest.TestCase):
         self.assertEqual(lines[1].strip(), "1")
         self.assertEqual(process.returncode, 0)
 
+    def test_crt_unit_colour_list(self):
+        """Ensures the Crt unit provides basic screen helpers."""
+        input_file, asm_file, executable_file = self._get_test_paths("crt_colour_list")
+
+        run_compiler(input_file, asm_file)
+        self.compile_executable(asm_file, executable_file)
+
+        try:
+            process = subprocess.run(
+                [executable_file],
+                capture_output=True,
+                text=True,
+                input="\n",
+                timeout=EXEC_TIMEOUT,
+            )
+        except subprocess.TimeoutExpired:
+            self.fail("crt_colour_list execution timed out")
+            return
+
+        expected_output = (
+            "\x1b[2J\x1b[H"
+            "\x1b[30m0\n"
+            "\x1b[34m1\n"
+            "\x1b[32m2\n"
+            "\x1b[36m3\n"
+            "\x1b[31m4\n"
+            "\x1b[35m5\n"
+            "\x1b[33m6\n"
+            "\x1b[37m7\n"
+            "\x1b[90m8\n"
+            "\x1b[94m9\n"
+            "\x1b[92m10\n"
+            "\x1b[96m11\n"
+            "\x1b[91m12\n"
+            "\x1b[95m13\n"
+            "\x1b[93m14\n"
+            "\x1b[97m15\n"
+        )
+
+        self.assertEqual(process.returncode, 0)
+        self.assertEqual(process.stdout, expected_output)
+
     def test_set_of_enum_typed_constant_unit(self):
         """Ensures a unit with a set-of-enum typed constant compiles and runs."""
         input_file = os.path.join(TEST_CASES_DIR, "set_of_enum_typed_constant_demo.p")

--- a/tests/test_cases/crt_colour_list.p
+++ b/tests/test_cases/crt_colour_list.p
@@ -1,0 +1,16 @@
+program crt_colour_list;
+
+uses Crt;
+
+var
+    counter: integer;
+
+begin
+    ClrScr;
+    for counter := 0 to 15 do
+    begin
+        TextColor(counter);
+        writeln(counter);
+    end;
+    Crt.ReadLn;
+end.


### PR DESCRIPTION
## Summary
- add a Crt unit that exposes ClrScr, TextColor, and ReadLn wrappers for the runtime
- teach the runtime to clear the screen, change text colour, and consume newline input via new helpers
- add a regression test and sample program that exercises the 16 colour palette

## Testing
- meson test -C builddir

------
https://chatgpt.com/codex/tasks/task_e_6905e8f31d24832aae1e765afc759c7f

## Summary by Sourcery

Add basic CRT support by implementing runtime helpers for clearing the screen, setting text color, and reading a line, and expose them through a new Crt unit.

New Features:
- Implement gpc_clrscr, gpc_textcolor, and gpc_readln runtime functions with ANSI color lookup and normalization
- Add a new Crt unit exposing ClrScr, TextColor, and ReadLn procedures

Tests:
- Add a regression test and example program to verify the 16-color palette output