### PR TITLE
Add Pascal class AST plumbing

### DIFF
--- a/GPC/Parser/List/List.h
+++ b/GPC/Parser/List/List.h
@@ -13,7 +13,7 @@
 /* Careful with using LIST_UNSPECIFIED. Can cause errors on switch statements */
 enum ListType{LIST_TREE, LIST_STMT, LIST_EXPR, LIST_STRING,
               LIST_RECORD_FIELD, LIST_CASE_BRANCH, LIST_SET_ELEMENT,
-              LIST_VARIANT_PART, LIST_VARIANT_BRANCH,
+              LIST_VARIANT_PART, LIST_VARIANT_BRANCH, LIST_CLASS_MEMBER,
               LIST_UNSPECIFIED};
 
 /* Our linked list of tree type nodes */

--- a/GPC/Parser/ParseTree/tree.h
+++ b/GPC/Parser/ParseTree/tree.h
@@ -71,6 +71,7 @@ typedef struct Tree
                 } range;
                 struct RecordType *record;
                 struct TypeAlias alias;
+                struct ClassType *class_type;
             } info;
         } type_decl_data;
 
@@ -177,6 +178,7 @@ Tree_t *mk_unit(int line_num, char *id, ListNode_t *interface_uses,
 Tree_t *mk_typedecl(int line_num, char *id, int start, int end);
 Tree_t *mk_typealiasdecl(int line_num, char *id, int is_array, int actual_type, char *type_id, int start, int end);
 Tree_t *mk_record_type(int line_num, char *id, struct RecordType *record_type);
+Tree_t *mk_class_type(int line_num, char *id, struct ClassType *class_type);
 
 Tree_t *mk_procedure(int line_num, char *id, ListNode_t *args, ListNode_t *const_decl,
     ListNode_t *var_decl, ListNode_t *subprograms, struct Statement *compound_statement,

--- a/GPC/Parser/ParseTree/tree_types.h
+++ b/GPC/Parser/ParseTree/tree_types.h
@@ -14,7 +14,28 @@ enum StmtType{STMT_VAR_ASSIGN, STMT_PROCEDURE_CALL, STMT_COMPOUND_STATEMENT,
     STMT_ASM_BLOCK, STMT_EXIT, STMT_BREAK, STMT_CASE, STMT_WITH, STMT_TRY_FINALLY,
     STMT_TRY_EXCEPT, STMT_RAISE, STMT_INHERITED};
 
-enum TypeDeclKind { TYPE_DECL_RANGE, TYPE_DECL_RECORD, TYPE_DECL_ALIAS };
+enum TypeDeclKind { TYPE_DECL_RANGE, TYPE_DECL_RECORD, TYPE_DECL_ALIAS, TYPE_DECL_CLASS };
+
+enum ClassVisibility
+{
+    CLASS_VISIBILITY_DEFAULT,
+    CLASS_VISIBILITY_PRIVATE,
+    CLASS_VISIBILITY_PUBLIC,
+    CLASS_VISIBILITY_PROTECTED,
+    CLASS_VISIBILITY_PUBLISHED
+};
+
+enum ClassMemberKind
+{
+    CLASS_MEMBER_FIELD,
+    CLASS_MEMBER_METHOD,
+    CLASS_MEMBER_PROPERTY
+};
+
+struct ClassMethod;
+struct ClassProperty;
+struct ClassMember;
+struct ClassType;
 
 struct TypeAlias
 {
@@ -59,6 +80,46 @@ struct RecordField
 struct RecordType
 {
     ListNode_t *fields;
+};
+
+struct ClassMethod
+{
+    char *name;
+    int is_class_method;
+    int is_constructor;
+    int is_destructor;
+    int is_function;
+    int return_type;
+    char *return_type_id;
+    ListNode_t *params; /* List of Tree_t* variable declarations */
+    int is_override;
+};
+
+struct ClassProperty
+{
+    char *name;
+    char *type_id;
+    char *read_accessor;
+    char *write_accessor;
+};
+
+struct ClassMember
+{
+    enum ClassMemberKind kind;
+    enum ClassVisibility visibility;
+    union
+    {
+        struct RecordField *field;
+        struct ClassMethod *method;
+        struct ClassProperty *property;
+    } info;
+};
+
+struct ClassType
+{
+    char *ancestor_id;
+    ListNode_t *members; /* List of ClassMember */
+    struct RecordType *record; /* Field layout for compatibility with records */
 };
 
 struct VariantBranch

--- a/GPC/Parser/SemanticCheck/SemCheck.c
+++ b/GPC/Parser/SemanticCheck/SemCheck.c
@@ -313,6 +313,11 @@ int semcheck_type_decls(SymTab_t *symtab, ListNode_t *type_decls)
                 var_type = HASHVAR_RECORD;
                 record_info = tree->tree_data.type_decl_data.info.record;
                 break;
+            case TYPE_DECL_CLASS:
+                var_type = HASHVAR_RECORD;
+                if (tree->tree_data.type_decl_data.info.class_type != NULL)
+                    record_info = tree->tree_data.type_decl_data.info.class_type->record;
+                break;
             case TYPE_DECL_ALIAS:
             {
                 alias_info = &tree->tree_data.type_decl_data.info.alias;


### PR DESCRIPTION
## Summary
- add class-oriented tree structures and list handling, including printing, destruction, and cloning helpers
- extend the cparser conversion pipeline and semantic checks to build class members, properties, and fields
- teach the Pascal parser to emit class member AST nodes with visibility, override, and class method flags

## Testing
- meson test -C builddir

------
https://chatgpt.com/codex/tasks/task_e_69061397bc54832ab0dd9b2561e945b3