### PR TITLE
Fix record array field access parsing

### DIFF
--- a/tests/test_cases/record_array_field_access.expected
+++ b/tests/test_cases/record_array_field_access.expected
@@ -1,0 +1,1 @@
+The grade is: 95

--- a/tests/test_cases/record_array_field_access.p
+++ b/tests/test_cases/record_array_field_access.p
@@ -1,0 +1,15 @@
+program TestArrayInRecord;
+
+type
+  TStudent = record
+    StudentID: integer;
+    Grades: array[1..5] of integer;
+  end;
+
+var
+  student1: TStudent;
+
+begin
+  student1.Grades[3] := 95;
+  writeln('The grade is: ', student1.Grades[3]);
+end.


### PR DESCRIPTION
## Summary
- allow member suffixes in the expression suffix parser so array accesses on record fields produce the correct AST
- add a regression program that assigns to and reads from an array stored inside a record

## Testing
- meson test -C builddir

------
https://chatgpt.com/codex/tasks/task_e_69061dbbce74832a892981ecbe11dd7b