### PR TITLE
Fix conversion of record array field accesses

### DIFF
--- a/tests/test_cases/record_array_field.expected
+++ b/tests/test_cases/record_array_field.expected
@@ -1,0 +1,1 @@
+The grade is: 95

--- a/tests/test_cases/record_array_field.p
+++ b/tests/test_cases/record_array_field.p
@@ -1,0 +1,16 @@
+program RecordArrayField;
+
+type
+  TStudent = record
+    StudentID: integer;
+    Grades: array[1..5] of integer;
+  end;
+
+var
+  student1: TStudent;
+
+begin
+  student1.StudentID := 42;
+  student1.Grades[3] := 95;
+  writeln('The grade is: ', student1.Grades[3]);
+end.


### PR DESCRIPTION
## Summary
- ensure record member conversion preserves nested array accesses so codegen receives correct element lookups
- add a regression program that writes to and reads from an array field inside a record

## Testing
- meson test -C builddir --print-errorlogs

------
https://chatgpt.com/codex/tasks/task_e_69061dbbce74832a892981ecbe11dd7b