### PR TITLE
Fix record array field access conversion

### DIFF
--- a/tests/test_cases/record_array_field.expected
+++ b/tests/test_cases/record_array_field.expected
@@ -1,0 +1,1 @@
+The grade is: 95

--- a/tests/test_cases/record_array_field.p
+++ b/tests/test_cases/record_array_field.p
@@ -1,0 +1,16 @@
+program RecordArrayField;
+
+type
+  TStudent = record
+    StudentID: integer;
+    Grades: array[1..5] of integer;
+  end;
+
+var
+  student1: TStudent;
+
+begin
+  student1.StudentID := 42;
+  student1.Grades[3] := 95;
+  writeln('The grade is: ', student1.Grades[3]);
+end.


### PR DESCRIPTION
## Summary
- update the Pascal AST conversion to keep array access when visiting record fields and preserve field width metadata
- add a helper that rewrites nested expressions so record field references become proper member accesses
- add a regression program that assigns and prints a record array element

## Testing
- meson test -C builddir

------
https://chatgpt.com/codex/tasks/task_e_69061dbbce74832a892981ecbe11dd7b