### PR TITLE
Allow string concatenation with character operands

### DIFF
--- a/GPC/Parser/SemanticCheck/SemChecks/SemCheck_expr.c
+++ b/GPC/Parser/SemanticCheck/SemChecks/SemCheck_expr.c
@@ -2319,10 +2319,21 @@ int semcheck_addop(int *type_return,
         return return_val;
     }
 
-    if (op_type == PLUS && type_first == STRING_TYPE && type_second == STRING_TYPE)
+    if (op_type == PLUS)
     {
-        *type_return = STRING_TYPE;
-        return return_val;
+        if (type_first == STRING_TYPE && type_second == STRING_TYPE)
+        {
+            *type_return = STRING_TYPE;
+            return return_val;
+        }
+
+        if ((type_first == STRING_TYPE && type_second == CHAR_TYPE) ||
+            (type_first == CHAR_TYPE && type_second == STRING_TYPE) ||
+            (type_first == CHAR_TYPE && type_second == CHAR_TYPE))
+        {
+            *type_return = STRING_TYPE;
+            return return_val;
+        }
     }
 
     /* Checking numeric types */

--- a/GPC/runtime.c
+++ b/GPC/runtime.c
@@ -764,6 +764,18 @@ void gpc_move(void *dest, const void *src, size_t count)
     memmove(dest, src, count);
 }
 
+char *gpc_string_from_char(int value)
+{
+    char *result = (char *)malloc(2);
+    if (result == NULL)
+        return gpc_alloc_empty_string();
+
+    result[0] = (char)(unsigned char)value;
+    result[1] = '\0';
+    gpc_string_register_allocation(result);
+    return result;
+}
+
 char *gpc_string_concat(const char *lhs, const char *rhs)
 {
     if (lhs == NULL)

--- a/tests/test_cases/string_concat_char_indexing.expected
+++ b/tests/test_cases/string_concat_char_indexing.expected
@@ -1,0 +1,2 @@
+Suffix build: 2.5
+Prefix build: 31core

--- a/tests/test_cases/string_concat_char_indexing.p
+++ b/tests/test_cases/string_concat_char_indexing.p
@@ -1,0 +1,18 @@
+program string_concat_char_indexing;
+var
+  Input: string;
+  Suffix, Prefix: string;
+begin
+  Input := '123.45';
+
+  Suffix := '';
+  Suffix := Suffix + Input[2];
+  Suffix := Suffix + Input[4];
+  Suffix := Suffix + Input[6];
+  WriteLn('Suffix build: ', Suffix);
+
+  Prefix := 'core';
+  Prefix := Input[1] + Prefix;
+  Prefix := Input[3] + Prefix;
+  WriteLn('Prefix build: ', Prefix);
+end.


### PR DESCRIPTION
## Summary
- allow the semantic checker to treat PLUS expressions mixing strings and characters as string results
- convert character operands to temporary strings during code generation and preserve the original string argument
- add a runtime helper for char-to-string promotion and a regression test covering string/char concatenation

## Testing
- meson test -C builddir

------
https://chatgpt.com/codex/tasks/task_e_6906482d1144832a91d79a6ce0480e86