### PR TITLE
Support character ranges in case labels

### DIFF
--- a/tests/test_cases/case_char_range.expected
+++ b/tests/test_cases/case_char_range.expected
@@ -1,0 +1,2 @@
+numeric
+other

--- a/tests/test_cases/case_char_range.p
+++ b/tests/test_cases/case_char_range.p
@@ -1,0 +1,18 @@
+program CaseCharRange;
+var
+  ch: char;
+begin
+  ch := '5';
+  case ch of
+    '-', '0'..'9': writeln('numeric');
+  else
+    writeln('other');
+  end;
+
+  ch := 'A';
+  case ch of
+    '-', '0'..'9': writeln('numeric');
+  else
+    writeln('other');
+  end;
+end.


### PR DESCRIPTION
## Summary
- expand the parse-tree conversion to enumerate case label ranges and normalize single-character literals to char codes
- add a regression test that exercises case statements with character range labels

## Testing
- meson test -C builddir

------
https://chatgpt.com/codex/tasks/task_e_690657e7821c832a853f7a61cd75460c