### PR TITLE
Implement packrat memoization in parser combinators

### DIFF
--- a/cparser/parser.h
+++ b/cparser/parser.h
@@ -18,6 +18,7 @@ typedef struct ast_t ast_t;
 typedef struct combinator_t combinator_t;
 typedef struct input_t input_t;
 typedef struct ParseResult ParseResult;
+typedef struct memo_table memo_table_t;
 
 // AST node types
 typedef unsigned int tag_t;
@@ -48,6 +49,7 @@ struct input_t {
    int start;
    int line;
    int col;
+   memo_table_t* memo;
 };
 
 // --- Parse Result & Error Structs ---
@@ -93,6 +95,7 @@ struct combinator_t {
     void * args;
     void * extra_to_free;
     char* name;
+    size_t memo_id;
 };
 
 // For flatMap


### PR DESCRIPTION
## Summary
- add a memoization table keyed by combinator identifiers and input position to cache parse results and final input states
- track memoization state on inputs and combinators, cloning ASTs/errors so cached results remain valid on reuse
- preserve AST source locations when copying nodes to keep metadata intact for memoized parses

## Testing
- meson test -C builddir

------
https://chatgpt.com/codex/tasks/task_e_69068fc70cb4832ab0137865ac0dcc2e