### PR TITLE
Refactor procedure type handling in semantic checker

### DIFF
--- a/GPC/Parser/ParseTree/from_cparser.c
+++ b/GPC/Parser/ParseTree/from_cparser.c
@@ -1571,6 +1571,10 @@ static Tree_t *convert_type_decl(ast_t *type_decl_node) {
         }
     }
 
+    GpcType *gpc_type = NULL;
+    if (spec_node != NULL)
+        gpc_type = convert_type_spec_to_gpctype(spec_node, NULL);
+
     Tree_t *decl = NULL;
     if (record_type != NULL) {
         decl = mk_record_type(type_decl_node->line, id, record_type);
@@ -1584,6 +1588,11 @@ static Tree_t *convert_type_decl(ast_t *type_decl_node) {
     } else {
         decl = mk_typedecl(type_decl_node->line, id, 0, 0);
     }
+
+    if (decl != NULL)
+        decl->tree_data.type_decl_data.gpc_type = gpc_type;
+    else if (gpc_type != NULL)
+        destroy_gpc_type(gpc_type);
 
     if (decl != NULL && decl->type == TREE_TYPE_DECL &&
         decl->tree_data.type_decl_data.kind == TYPE_DECL_ALIAS) {

--- a/GPC/Parser/ParseTree/tree.c
+++ b/GPC/Parser/ParseTree/tree.c
@@ -6,6 +6,7 @@
 #include "tree.h"
 #include "tree_types.h"
 #include "type_tags.h"
+#include "GpcType.h"
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
@@ -909,6 +910,11 @@ void destroy_tree(Tree_t *tree)
 
         case TREE_TYPE_DECL:
             free(tree->tree_data.type_decl_data.id);
+            if (tree->tree_data.type_decl_data.gpc_type != NULL)
+            {
+                destroy_gpc_type(tree->tree_data.type_decl_data.gpc_type);
+                tree->tree_data.type_decl_data.gpc_type = NULL;
+            }
             if (tree->tree_data.type_decl_data.kind == TYPE_DECL_RECORD)
                 destroy_record_type(tree->tree_data.type_decl_data.info.record);
             else if (tree->tree_data.type_decl_data.kind == TYPE_DECL_ALIAS)
@@ -1391,6 +1397,7 @@ Tree_t *mk_typedecl(int line_num, char *id, int start, int end)
     new_tree->type = TREE_TYPE_DECL;
     new_tree->tree_data.type_decl_data.id = id;
     new_tree->tree_data.type_decl_data.kind = TYPE_DECL_RANGE;
+    new_tree->tree_data.type_decl_data.gpc_type = NULL;
     new_tree->tree_data.type_decl_data.info.range.start = start;
     new_tree->tree_data.type_decl_data.info.range.end = end;
 
@@ -1408,6 +1415,7 @@ Tree_t *mk_record_type(int line_num, char *id, struct RecordType *record_type)
     new_tree->type = TREE_TYPE_DECL;
     new_tree->tree_data.type_decl_data.id = id;
     new_tree->tree_data.type_decl_data.kind = TYPE_DECL_RECORD;
+    new_tree->tree_data.type_decl_data.gpc_type = NULL;
     new_tree->tree_data.type_decl_data.info.record = record_type;
 
     return new_tree;
@@ -1495,6 +1503,7 @@ Tree_t *mk_typealiasdecl(int line_num, char *id, int is_array, int actual_type, 
     new_tree->type = TREE_TYPE_DECL;
     new_tree->tree_data.type_decl_data.id = id;
     new_tree->tree_data.type_decl_data.kind = TYPE_DECL_ALIAS;
+    new_tree->tree_data.type_decl_data.gpc_type = NULL;
 
     struct TypeAlias *alias = &new_tree->tree_data.type_decl_data.info.alias;
     alias->base_type = is_array ? UNKNOWN_TYPE : actual_type;

--- a/GPC/Parser/ParseTree/tree.h
+++ b/GPC/Parser/ParseTree/tree.h
@@ -9,6 +9,8 @@
 
 #include "../List/List.h"
 #include "tree_types.h"
+
+struct GpcType;
 #include <stdio.h>
 
 /******* Trees and statement types ********/
@@ -62,6 +64,7 @@ typedef struct Tree
         {
             char *id;
             enum TypeDeclKind kind;
+            struct GpcType *gpc_type;
             union
             {
                 struct

--- a/GPC/Parser/SemanticCheck/HashTable/HashTable.c
+++ b/GPC/Parser/SemanticCheck/HashTable/HashTable.c
@@ -161,6 +161,7 @@ int AddIdentToTable_Legacy(HashTable_t *table, char *id, char *mangled_id, enum 
         assert(hash_node != NULL);
         hash_node->hash_type = hash_type;
         hash_node->var_type = var_type;
+        hash_node->type = NULL;
         hash_node->id = strdup(id);
         if (hash_node->id == NULL)
         {
@@ -213,6 +214,7 @@ int AddIdentToTable_Legacy(HashTable_t *table, char *id, char *mangled_id, enum 
         assert(hash_node != NULL);
         hash_node->hash_type = hash_type;
         hash_node->var_type = var_type;
+        hash_node->type = NULL;
         hash_node->id = strdup(id);
         if (hash_node->id == NULL)
         {

--- a/GPC/Parser/SemanticCheck/SemChecks/SemCheck_stmt.c
+++ b/GPC/Parser/SemanticCheck/SemChecks/SemCheck_stmt.c
@@ -22,6 +22,7 @@
 #include "../../ParseTree/tree_types.h"
 #include "../../List/List.h"
 #include "../../ParseTree/type_tags.h"
+#include "../../ParseTree/GpcType.h"
 #include "../../../identifier_utils.h"
 
 static int semcheck_loop_depth = 0;
@@ -39,6 +40,9 @@ int semcheck_for(SymTab_t *symtab, struct Statement *stmt, int max_scope_lev);
 int semcheck_for_assign(SymTab_t *symtab, struct Statement *for_assign, int max_scope_lev);
 
 static int semcheck_statement_list_nodes(SymTab_t *symtab, ListNode_t *stmts, int max_scope_lev);
+static GpcType *semcheck_resolve_expression_gpc_type(SymTab_t *symtab, struct Expression *expr);
+static int semcheck_call_with_proc_var(SymTab_t *symtab, struct Statement *stmt, HashNode_t *proc_node,
+    int max_scope_lev);
 
 static int var_type_to_expr_type(enum VarType var_type)
 {
@@ -84,6 +88,107 @@ static int types_numeric_compatible(int lhs, int rhs)
         return 1;
 
     return 0;
+}
+
+static GpcType *semcheck_resolve_expression_gpc_type(SymTab_t *symtab, struct Expression *expr)
+{
+    if (symtab == NULL || expr == NULL)
+        return NULL;
+
+    switch (expr->type)
+    {
+        case EXPR_VAR_ID:
+        {
+            HashNode_t *node = NULL;
+            if (FindIdent(&node, symtab, expr->expr_data.id) != -1 && node != NULL)
+                return node->type;
+            break;
+        }
+        case EXPR_FUNCTION_CALL:
+        {
+            if (expr->expr_data.function_call_data.resolved_func != NULL)
+                return expr->expr_data.function_call_data.resolved_func->type;
+
+            HashNode_t *node = NULL;
+            if (expr->expr_data.function_call_data.id != NULL &&
+                FindIdent(&node, symtab, expr->expr_data.function_call_data.id) != -1 && node != NULL)
+                return node->type;
+            break;
+        }
+        default:
+            break;
+    }
+
+    return NULL;
+}
+
+static int semcheck_call_with_proc_var(SymTab_t *symtab, struct Statement *stmt, HashNode_t *proc_node,
+    int max_scope_lev)
+{
+    (void)max_scope_lev;
+    if (proc_node == NULL || proc_node->type == NULL ||
+        proc_node->type->kind != TYPE_KIND_PROCEDURE)
+        return 0;
+
+    int return_val = 0;
+    ListNode_t *formal_params = proc_node->type->info.proc_info.params;
+    ListNode_t *args_given = stmt->stmt_data.procedure_call_data.expr_args;
+    int arg_index = 0;
+
+    while (formal_params != NULL && args_given != NULL)
+    {
+        ++arg_index;
+        assert(formal_params->type == LIST_TREE);
+        assert(args_given->type == LIST_EXPR);
+
+        Tree_t *param_decl = (Tree_t *)formal_params->cur;
+        struct Expression *arg_expr = (struct Expression *)args_given->cur;
+
+        int arg_type = UNKNOWN_TYPE;
+        return_val += semcheck_expr_main(&arg_type, symtab, arg_expr, INT_MAX, NO_MUTATE);
+
+        if (param_decl != NULL && param_decl->type == TREE_VAR_DECL)
+        {
+            int expected_type = param_decl->tree_data.var_decl_data.type;
+            if ((expected_type == -1 || expected_type == UNKNOWN_TYPE) &&
+                param_decl->tree_data.var_decl_data.type_id != NULL)
+            {
+                HashNode_t *type_node = NULL;
+                if (FindIdent(&type_node, symtab, param_decl->tree_data.var_decl_data.type_id) != -1 && type_node != NULL)
+                    expected_type = var_type_to_expr_type(type_node->var_type);
+            }
+
+            if (expected_type != BUILTIN_ANY_TYPE &&
+                arg_type != expected_type &&
+                !types_numeric_compatible(expected_type, arg_type))
+            {
+                fprintf(stderr,
+                    "Error on line %d, on procedure call %s, argument %d: Type mismatch!\n\n",
+                    stmt->line_num,
+                    stmt->stmt_data.procedure_call_data.id,
+                    arg_index);
+                ++return_val;
+            }
+        }
+
+        formal_params = formal_params->next;
+        args_given = args_given->next;
+    }
+
+    if (formal_params == NULL && args_given != NULL)
+    {
+        fprintf(stderr, "Error on line %d, on procedure call %s, too many arguments given!\n\n",
+            stmt->line_num, stmt->stmt_data.procedure_call_data.id);
+        ++return_val;
+    }
+    else if (formal_params != NULL && args_given == NULL)
+    {
+        fprintf(stderr, "Error on line %d, on procedure call %s, not enough arguments given!\n\n",
+            stmt->line_num, stmt->stmt_data.procedure_call_data.id);
+        ++return_val;
+    }
+
+    return return_val;
 }
 
 typedef int (*builtin_semcheck_handler_t)(SymTab_t *, struct Statement *, int);
@@ -726,42 +831,68 @@ int semcheck_varassign(SymTab_t *symtab, struct Statement *stmt, int max_scope_l
     return_val += semcheck_expr_main(&type_first, symtab, var, max_scope_lev, MUTATE);
     return_val += semcheck_expr_main(&type_second, symtab, expr, INT_MAX, NO_MUTATE);
 
-    int coerced_rhs_type = type_second;
-    int types_compatible = (type_first == type_second);
+    GpcType *lhs_gpctype = semcheck_resolve_expression_gpc_type(symtab, var);
+    GpcType *rhs_gpctype = semcheck_resolve_expression_gpc_type(symtab, expr);
+    int handled_by_gpctype = 0;
 
-    if (!types_compatible)
+    if (lhs_gpctype != NULL && rhs_gpctype != NULL &&
+        (lhs_gpctype->kind == TYPE_KIND_PROCEDURE || rhs_gpctype->kind == TYPE_KIND_PROCEDURE))
     {
-        if ((type_first == LONGINT_TYPE && type_second == INT_TYPE) ||
-            (type_first == INT_TYPE && type_second == LONGINT_TYPE))
+        handled_by_gpctype = 1;
+        if (!are_types_compatible_for_assignment(lhs_gpctype, rhs_gpctype, symtab))
         {
-            types_compatible = 1;
-        }
-        else if (type_first == CHAR_TYPE && type_second == STRING_TYPE &&
-            expr != NULL && expr->type == EXPR_STRING &&
-            expr->expr_data.string != NULL && strlen(expr->expr_data.string) == 1)
-        {
-            types_compatible = 1;
-            coerced_rhs_type = CHAR_TYPE;
-            expr->resolved_type = CHAR_TYPE;
+            const char *lhs_name = "<expression>";
+            if (var != NULL && var->type == EXPR_VAR_ID)
+                lhs_name = var->expr_data.id;
+            fprintf(stderr,
+                "Error on line %d, incompatible types in assignment for %s (lhs: %s, rhs: %s)!\n\n",
+                stmt->line_num,
+                lhs_name,
+                gpc_type_to_string(lhs_gpctype),
+                gpc_type_to_string(rhs_gpctype));
+            ++return_val;
         }
     }
 
-    if (!types_compatible)
+    if (!handled_by_gpctype)
     {
-        const char *lhs_name = "<expression>";
-        if (var != NULL && var->type == EXPR_VAR_ID)
-            lhs_name = var->expr_data.id;
-        fprintf(stderr,
-            "Error on line %d, type mismatch in assignment statement for %s (lhs: %s, rhs: %s)!\n\n",
-            stmt->line_num,
-            lhs_name,
-            type_tag_to_name(type_first),
-            type_tag_to_name(type_second));
-        ++return_val;
-    }
-    else
-    {
-        type_second = coerced_rhs_type;
+        int coerced_rhs_type = type_second;
+        int types_compatible = (type_first == type_second);
+
+        if (!types_compatible)
+        {
+            if ((type_first == LONGINT_TYPE && type_second == INT_TYPE) ||
+                (type_first == INT_TYPE && type_second == LONGINT_TYPE))
+            {
+                types_compatible = 1;
+            }
+            else if (type_first == CHAR_TYPE && type_second == STRING_TYPE &&
+                expr != NULL && expr->type == EXPR_STRING &&
+                expr->expr_data.string != NULL && strlen(expr->expr_data.string) == 1)
+            {
+                types_compatible = 1;
+                coerced_rhs_type = CHAR_TYPE;
+                expr->resolved_type = CHAR_TYPE;
+            }
+        }
+
+        if (!types_compatible)
+        {
+            const char *lhs_name = "<expression>";
+            if (var != NULL && var->type == EXPR_VAR_ID)
+                lhs_name = var->expr_data.id;
+            fprintf(stderr,
+                "Error on line %d, type mismatch in assignment statement for %s (lhs: %s, rhs: %s)!\n\n",
+                stmt->line_num,
+                lhs_name,
+                type_tag_to_name(type_first),
+                type_tag_to_name(type_second));
+            ++return_val;
+        }
+        else
+        {
+            type_second = coerced_rhs_type;
+        }
     }
 
     return return_val;
@@ -868,6 +999,26 @@ int semcheck_proccall(SymTab_t *symtab, struct Statement *stmt, int max_scope_le
     }
     else if (match_count == 0)
     {
+        HashNode_t *proc_var = NULL;
+        int proc_scope = FindIdent(&proc_var, symtab, proc_id);
+        if (proc_scope != -1 && proc_var != NULL && proc_var->hash_type == HASHTYPE_VAR &&
+            proc_var->type != NULL && proc_var->type->kind == TYPE_KIND_PROCEDURE)
+        {
+            DestroyList(overload_candidates);
+            free(mangled_name);
+
+            proc_var->referenced += 1;
+            if (proc_scope > max_scope_lev)
+            {
+                fprintf(stderr, "Error on line %d, %s cannot be called in the current context!\n\n",
+                    stmt->line_num, proc_id);
+                return_val++;
+                return return_val;
+            }
+
+            return return_val + semcheck_call_with_proc_var(symtab, stmt, proc_var, max_scope_lev);
+        }
+
         fprintf(stderr, "Error on line %d, call to procedure %s does not match any available overload\n", stmt->line_num, proc_id);
         DestroyList(overload_candidates);
         free(mangled_name);


### PR DESCRIPTION
## Summary
- propagate `GpcType` information from type declarations into the symbol table
- add assignment and procedure-call checks that compare procedure variable signatures via `GpcType`
- initialise legacy symbol entries so old code paths continue to work with the new types

## Testing
- meson test -C builddir

------
https://chatgpt.com/codex/tasks/task_e_69069cb4c178832aa34da984422c97d3