### PR TITLE
feat(parser): Allow interspersed declarations in function bodies

### DIFF
--- a/cparser/examples/pascal_parser/pascal_declaration.c
+++ b/cparser/examples/pascal_parser/pascal_declaration.c
@@ -1042,13 +1042,6 @@ void init_pascal_complete_program_parser(combinator_t** p) {
     // Local VAR section - reuse the existing var_section parser
     combinator_t* local_var_section = var_section;
 
-    // Allow local CONST/TYPE/VAR sections before the statement body.
-    combinator_t* local_decl_sections = many(multi(new_combinator(), PASCAL_T_NONE,
-        const_section,
-        type_section,
-        local_var_section,
-        NULL));
-
     // Create a specialized function body parser that avoids circular references
     // This parser handles the most common function body patterns without full recursive complexity
 
@@ -1061,9 +1054,17 @@ void init_pascal_complete_program_parser(combinator_t** p) {
     // Forward declaration for nested functions - these will refer to working_function and working_procedure below
     combinator_t* nested_function_decl = lazy_owned(nested_proc_or_func);
 
+    // Allow local CONST/TYPE/VAR sections to be interspersed with nested functions/procedures
+    combinator_t* local_declaration_or_section = multi(new_combinator(), PASCAL_T_NONE,
+        const_section,
+        type_section,
+        local_var_section,
+        nested_function_decl,
+        NULL
+    );
+
     combinator_t* nested_function_body = seq(new_combinator(), PASCAL_T_NONE,
-        local_decl_sections,                        // zero or more local const/type/var sections
-        many(nested_function_decl),                 // zero or more nested function/procedure declarations
+        many(local_declaration_or_section),         // zero or more local decls/sections in any order
         lazy(stmt_parser),                          // begin-end block handled by statement parser
         NULL
     );

--- a/cparser/examples/pascal_parser/pascal_tests.c
+++ b/cparser/examples/pascal_parser/pascal_tests.c
@@ -4002,6 +4002,28 @@ void test_variant_record_field_attributes(void) {
     free(input);
 }
 
+void test_pascal_interspersed_declarations(void) {
+    combinator_t* p = get_program_parser();
+    input_t* input = new_input();
+    char* program = load_pascal_file("../../../../tests/test_cases/interspersed_declarations.p");
+    TEST_ASSERT(program != NULL);
+    if (!program) {
+        free(input);
+        return;
+    }
+    input->buffer = program;
+    input->length = strlen(program);
+    ParseResult res = parse(input, p);
+    TEST_ASSERT(res.is_success);
+    if (res.is_success) {
+        free_ast(res.value.ast);
+    } else {
+        free_error(res.value.error);
+    }
+    free(input->buffer);
+    free(input);
+}
+
 TEST_LIST = {
     { "test_pascal_integer_parsing", test_pascal_integer_parsing },
     { "test_pascal_invalid_input", test_pascal_invalid_input },
@@ -4138,5 +4160,6 @@ TEST_LIST = {
     { "test_whitespace_around_ifdef_condition", test_whitespace_around_ifdef_condition },
     { "test_deprecated_on_const", test_deprecated_on_const },
     { "test_variant_record_field_attributes", test_variant_record_field_attributes },
+    { "test_pascal_interspersed_declarations", test_pascal_interspersed_declarations },
     { NULL, NULL }
 };

--- a/tests/test_cases/interspersed_declarations.p
+++ b/tests/test_cases/interspersed_declarations.p
@@ -1,0 +1,21 @@
+program TestInterspersed;
+
+procedure Outer;
+  procedure Nested;
+  begin
+    { Nested procedure body }
+  end;
+
+  const
+    MyConst = 10;
+
+  var
+    MyVar: integer;
+
+begin
+  { Outer procedure body }
+end;
+
+begin
+  { Main program body }
+end.


### PR DESCRIPTION
The Pascal grammar was modified to correctly handle `const` and `var` declaration blocks appearing after procedure and function definitions within the same scope.

Previously, the parser enforced a strict order, requiring all `const`, `type`, and `var` sections to precede any nested `procedure` or `function` definitions. This has been corrected by creating a new combinator that allows these different declaration types to be interspersed, which aligns with the correct Pascal syntax.

A new test case has been added to verify this behavior.

## Summary by Sourcery

Allow mixing of local const, type, var sections and nested declarations in Pascal function/procedure bodies by introducing a new combinator and update the parser accordingly. Add a test case to ensure correct parsing of interspersed declarations.

New Features:
- Allow interspersed const, type, var, and nested procedure/function declarations within Pascal function/procedure bodies

Enhancements:
- Replace the strict declaration ordering with a unified combinator (local_declaration_or_section) to parse mixed declarations and nested functions

Tests:
- Add test_pascal_interspersed_declarations to verify parsing of interspersed declarations