### PR TITLE
Fix memory leak in subprogram deduplication

### DIFF
--- a/KGPC/Parser/ParseTree/from_cparser.c
+++ b/KGPC/Parser/ParseTree/from_cparser.c
@@ -2629,7 +2629,10 @@ static void append_subprogram_if_unique(ListNode_t **dest, Tree_t *tree)
         return;
 
     if (subprogram_list_has_decl(*dest, tree))
+    {
+        destroy_tree(tree);
         return;
+    }
 
     append_subprogram_node(dest, tree);
 }


### PR DESCRIPTION
Fixed a memory leak in the KGPC compiler's parser where duplicate subprogram declarations were not being properly deallocated during AST construction. Added a call to `destroy_tree` in `append_subprogram_if_unique` when a duplicate is detected. verified the fix using AddressSanitizer.

---
*PR created automatically by Jules for task [17867750492194161532](https://jules.google.com/task/17867750492194161532) started by @Kreijstal*

## Summary by Sourcery

Bug Fixes:
- Deallocate parse trees for duplicate subprogram declarations instead of leaving them leaked during AST construction.