### PR TITLE
Fix variable/type name collision breaking record field access

### DIFF
--- a/KGPC/Parser/SemanticCheck/SemChecks/SemCheck_Expr_Types.c
+++ b/KGPC/Parser/SemanticCheck/SemChecks/SemCheck_Expr_Types.c
@@ -2357,7 +2357,7 @@ skip_scoped_enum_resolution:
          * collides with a type (HMODULE) would be misresolved as a scoped
          * enum qualifier instead of a record/class field access. */
         if (!unit_is_qualifier &&
-            !(find_result && unit_check != NULL &&
+            !(find_result &&
               (unit_check->hash_type == HASHTYPE_VAR ||
                unit_check->hash_type == HASHTYPE_ARRAY ||
                unit_check->hash_type == HASHTYPE_FUNCTION_RETURN)))


### PR DESCRIPTION
## Summary
- Fix semcheck scoped enum resolution path hijacking record field access when a local variable name collides case-insensitively with a type name (e.g., `hmodule : tmodule` vs imported `HMODULE` type)
- Guard `semcheck_find_preferred_type_node()` — skip type lookup if identifier already resolved as a variable

## Test plan
- [ ] `meson test -C build` — all compiler tests pass
- [ ] `meson test -C build-fpc "FPC RTL tests"` — all 223 pass
- [ ] pp.pas compilation errors reduced from 9 to 4

Fixes #498

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Avoid resolving record field access through scoped enum type lookup when the base identifier already refers to a variable, array, or function return value.