### PR TITLE
Fix operator overload dispatch for record types

### DIFF
--- a/KGPC/Parser/SemanticCheck/HashTable/HashTable.c
+++ b/KGPC/Parser/SemanticCheck/HashTable/HashTable.c
@@ -465,6 +465,109 @@ HashNode_t *FindIdentByPrefixInTableForUnit(HashTable_t *table, const char *pref
     return best;
 }
 
+ListNode_t *FindAllIdentsByPrefixInTable(HashTable_t *table, const char *prefix)
+{
+    assert(table != NULL);
+    assert(prefix != NULL);
+
+    char stack_buf[PASCAL_ID_STACK_MAX];
+    char *canonical_prefix = pascal_identifier_lower_buf(prefix, stack_buf, sizeof(stack_buf));
+    if (canonical_prefix == NULL)
+        return NULL;
+
+    size_t prefix_len = strlen(canonical_prefix);
+    ListNode_t *found_list = NULL;
+    ListNode_t *found_tail = NULL;
+
+    for (int i = 0; i < TABLE_SIZE; i++)
+    {
+        ListNode_t *cur = table->table[i];
+        while (cur != NULL)
+        {
+            HashNode_t *hash_node = (HashNode_t *)cur->cur;
+            if (hash_node != NULL &&
+                hash_node->canonical_id != NULL &&
+                strncmp(hash_node->canonical_id, canonical_prefix, prefix_len) == 0)
+            {
+                ListNode_t *new_node = CreateListNode(hash_node, LIST_UNSPECIFIED);
+                if (found_list == NULL)
+                {
+                    found_list = new_node;
+                    found_tail = new_node;
+                }
+                else
+                {
+                    found_tail->next = new_node;
+                    found_tail = new_node;
+                }
+            }
+            cur = cur->next;
+        }
+    }
+
+    pascal_identifier_lower_buf_free(canonical_prefix, stack_buf);
+    return found_list;
+}
+
+ListNode_t *FindAllIdentsByPrefixInTableForUnit(HashTable_t *table, const char *prefix, int caller_unit_index)
+{
+    assert(table != NULL);
+    assert(prefix != NULL);
+
+    char stack_buf[PASCAL_ID_STACK_MAX];
+    char *canonical_prefix = pascal_identifier_lower_buf(prefix, stack_buf, sizeof(stack_buf));
+    if (canonical_prefix == NULL)
+        return NULL;
+
+    size_t prefix_len = strlen(canonical_prefix);
+    ListNode_t *found_list = NULL;
+    ListNode_t *found_tail = NULL;
+
+    for (int i = 0; i < TABLE_SIZE; i++)
+    {
+        ListNode_t *cur = table->table[i];
+        while (cur != NULL)
+        {
+            HashNode_t *hash_node = (HashNode_t *)cur->cur;
+            if (hash_node != NULL &&
+                hash_node->canonical_id != NULL &&
+                strncmp(hash_node->canonical_id, canonical_prefix, prefix_len) == 0)
+            {
+                /* Check visibility: visible if same unit, or if source_unit_index==0 (program/builtin) */
+                int visible = 0;
+                if (caller_unit_index > 0 && hash_node->source_unit_index == caller_unit_index)
+                    visible = 1;
+                else if (caller_unit_index == 0 && hash_node->source_unit_index == 0)
+                    visible = 1;
+                else if (caller_unit_index > 0 && hash_node->source_unit_index > 0 &&
+                         unit_registry_is_dep(caller_unit_index, hash_node->source_unit_index))
+                    visible = 1;
+                else if (hash_node->source_unit_index == 0)
+                    visible = 1;
+
+                if (visible)
+                {
+                    ListNode_t *new_node = CreateListNode(hash_node, LIST_UNSPECIFIED);
+                    if (found_list == NULL)
+                    {
+                        found_list = new_node;
+                        found_tail = new_node;
+                    }
+                    else
+                    {
+                        found_tail->next = new_node;
+                        found_tail = new_node;
+                    }
+                }
+            }
+            cur = cur->next;
+        }
+    }
+
+    pascal_identifier_lower_buf_free(canonical_prefix, stack_buf);
+    return found_list;
+}
+
 ListNode_t *FindAllIdentsInTable(HashTable_t *table, const char *id)
 {
     ListNode_t *list, *cur;

--- a/KGPC/Parser/SemanticCheck/HashTable/HashTable.h
+++ b/KGPC/Parser/SemanticCheck/HashTable/HashTable.h
@@ -144,6 +144,12 @@ HashNode_t *FindIdentByPrefixInTableForUnit(HashTable_t *table, const char *pref
 /* Searches for any identifier starting with the given prefix. Returns first match or NULL */
 HashNode_t *FindIdentByPrefixInTable(HashTable_t *table, const char *prefix);
 
+/* Searches for all instances of identifiers starting with the given prefix in the table. Returns a list of HashNode_t* or NULL if not found */
+ListNode_t *FindAllIdentsByPrefixInTable(HashTable_t *table, const char *prefix);
+
+/* Searches for all instances of identifiers starting with the given prefix in the table, restricted to symbols visible to caller_unit_index. */
+ListNode_t *FindAllIdentsByPrefixInTableForUnit(HashTable_t *table, const char *prefix, int caller_unit_index);
+
 /* Searches for a type identifier whose name ends with ".suffix" (case-insensitive).
  * Returns the first matching HASHTYPE_TYPE node or NULL. */
 HashNode_t *FindTypeBySuffixInTable(HashTable_t *table, const char *suffix);

--- a/KGPC/Parser/SemanticCheck/SemChecks/SemCheck_Expr_Ops.c
+++ b/KGPC/Parser/SemanticCheck/SemChecks/SemCheck_Expr_Ops.c
@@ -535,93 +535,29 @@ int semcheck_relop(int *type_return,
                             snprintf(operator_method, name_len, "%s__%s", record_type_name, op_suffix);
                             
                             HashNode_t *operator_node = NULL;
-                            ListNode_t *operator_candidates = FindAllIdents(symtab, operator_method);
+                            ListNode_t *operator_candidates = FindAllIdentsByPrefix(symtab, operator_method);
                             if (operator_candidates != NULL)
                             {
-                                KgpcType *left_arg_type = expr1 != NULL ? expr1->resolved_kgpc_type : NULL;
-                                KgpcType *right_arg_type = expr2 != NULL ? expr2->resolved_kgpc_type : NULL;
-                                HashNode_t *best_exact = NULL;
-                                int best_exact_score = -1;
-                                for (ListNode_t *cur = operator_candidates; cur != NULL; cur = cur->next)
-                                {
-                                    HashNode_t *candidate = (HashNode_t *)cur->cur;
-                                    if (candidate == NULL ||
-                                        (candidate->hash_type != HASHTYPE_FUNCTION &&
-                                         candidate->hash_type != HASHTYPE_PROCEDURE) ||
-                                        candidate->type == NULL)
-                                    {
-                                        continue;
-                                    }
-
-                                    ListNode_t *params = kgpc_type_get_procedure_params(candidate->type);
-                                    if (params == NULL || params->next == NULL)
-                                        continue;
-
-                                    Tree_t *left_decl = (Tree_t *)params->cur;
-                                    Tree_t *right_decl = (Tree_t *)params->next->cur;
-                                    int owns_left = 0;
-                                    int owns_right = 0;
-                                    KgpcType *left_formal = resolve_type_from_vardecl(left_decl, symtab, &owns_left);
-                                    KgpcType *right_formal = resolve_type_from_vardecl(right_decl, symtab, &owns_right);
-
-                                    int score = 0;
-                                    int valid = 1;
-                                    if (left_formal != NULL && left_arg_type != NULL)
-                                    {
-                                        if (kgpc_type_equals(left_formal, left_arg_type))
-                                            score += 2;
-                                        else if (are_types_compatible_for_assignment(left_formal, left_arg_type, symtab))
-                                            score += 1;
-                                        else
-                                            valid = 0;
-                                    }
-                                    if (valid && right_formal != NULL && right_arg_type != NULL)
-                                    {
-                                        if (kgpc_type_equals(right_formal, right_arg_type))
-                                            score += 2;
-                                        else if (are_types_compatible_for_assignment(right_formal, right_arg_type, symtab))
-                                            score += 1;
-                                        else
-                                            valid = 0;
-                                    }
-                                    if (owns_left && left_formal != NULL)
-                                        destroy_kgpc_type(left_formal);
-                                    if (owns_right && right_formal != NULL)
-                                        destroy_kgpc_type(right_formal);
-
-                                    if (valid && score > best_exact_score)
-                                    {
-                                        best_exact = candidate;
-                                        best_exact_score = score;
-                                    }
-                                }
-                                if (best_exact != NULL)
-                                    operator_node = best_exact;
-
                                 HashNode_t *best_match = NULL;
                                 int best_rank = 0;
                                 int num_best = 0;
-                                ListNode_t *args_given = NULL;
-                                if (operator_node == NULL)
+                                ListNode_t *args_given = CreateListNode(expr1, LIST_EXPR);
+                                if (args_given != NULL)
                                 {
-                                    args_given = CreateListNode(expr1, LIST_EXPR);
-                                    if (args_given != NULL)
-                                    {
-                                        args_given->next = CreateListNode(expr2, LIST_EXPR);
-                                        int resolve_status = semcheck_resolve_overload(
-                                            &best_match,
-                                            &best_rank,
-                                            &num_best,
-                                            operator_candidates,
-                                            args_given,
-                                            symtab,
-                                            expr,
-                                            max_scope_lev,
-                                            1);
-                                        if (resolve_status == 0 && best_match != NULL)
-                                            operator_node = best_match;
-                                        DestroyList(args_given);
-                                    }
+                                    args_given->next = CreateListNode(expr2, LIST_EXPR);
+                                    int resolve_status = semcheck_resolve_overload(
+                                        &best_match,
+                                        &best_rank,
+                                        &num_best,
+                                        operator_candidates,
+                                        args_given,
+                                        symtab,
+                                        expr,
+                                        max_scope_lev,
+                                        1);
+                                    if (resolve_status == 0 && best_match != NULL)
+                                        operator_node = best_match;
+                                    DestroyList(args_given);
                                 }
                                 if (operator_node == NULL)
                                 {
@@ -638,12 +574,6 @@ int semcheck_relop(int *type_return,
                                     }
                                 }
                                 DestroyList(operator_candidates);
-                            }
-                            if (operator_node == NULL &&
-                                semcheck_find_ident_by_prefix_visible(&operator_node, symtab, operator_method) >= 0 &&
-                                operator_node != NULL)
-                            {
-                                /* fallback for return-type-disambiguated names not indexed by base id */
                             }
                             if (operator_node != NULL)
                             {
@@ -1303,6 +1233,99 @@ int semcheck_signterm(int *type_return,
     /* Checking types */
     if (*type_return == UNKNOWN_TYPE)
         return return_val;
+
+    if (*type_return == RECORD_TYPE)
+    {
+        const char *record_type_name = get_expr_type_name(sign_expr, symtab);
+        if (record_type_name != NULL)
+        {
+            const char *op_suffix = "op_sub"; /* Currently only unary minus is likely to be overloaded */
+            size_t name_len = strlen(record_type_name) + strlen(op_suffix) + 3;
+            char *operator_method = (char *)malloc(name_len);
+            if (operator_method != NULL)
+            {
+                snprintf(operator_method, name_len, "%s__%s", record_type_name, op_suffix);
+
+                HashNode_t *operator_node = NULL;
+                ListNode_t *operator_candidates = FindAllIdentsByPrefix(symtab, operator_method);
+                if (operator_candidates != NULL)
+                {
+                    HashNode_t *best_match = NULL;
+                    int best_rank = 0;
+                    int num_best = 0;
+                    ListNode_t *args_given = CreateListNode(sign_expr, LIST_EXPR);
+                    if (args_given != NULL)
+                    {
+                        int resolve_status = semcheck_resolve_overload(
+                            &best_match,
+                            &best_rank,
+                            &num_best,
+                            operator_candidates,
+                            args_given,
+                            symtab,
+                            expr,
+                            max_scope_lev,
+                            1);
+                        if (resolve_status == 0 && best_match != NULL)
+                            operator_node = best_match;
+                        DestroyList(args_given);
+                    }
+                    if (operator_node == NULL)
+                    {
+                        for (ListNode_t *cur = operator_candidates; cur != NULL; cur = cur->next)
+                        {
+                            HashNode_t *candidate = (HashNode_t *)cur->cur;
+                            if (candidate != NULL &&
+                                (candidate->hash_type == HASHTYPE_FUNCTION ||
+                                 candidate->hash_type == HASHTYPE_PROCEDURE))
+                            {
+                                operator_node = candidate;
+                                break;
+                            }
+                        }
+                    }
+                    DestroyList(operator_candidates);
+                }
+
+                if (operator_node != NULL && operator_node->type != NULL &&
+                    kgpc_type_is_procedure(operator_node->type))
+                {
+                    KgpcType *return_type = kgpc_type_get_return_type(operator_node->type);
+                    if (return_type != NULL)
+                    {
+                        *type_return = semcheck_tag_from_kgpc(return_type);
+
+                        expr->type = EXPR_FUNCTION_CALL;
+                        memset(&expr->expr_data.function_call_data, 0, sizeof(expr->expr_data.function_call_data));
+                        expr->expr_data.function_call_data.is_operator_call = 1;
+
+                        expr->expr_data.function_call_data.id = strdup(operator_method);
+                        if (operator_node->mangled_id != NULL)
+                            expr->expr_data.function_call_data.mangled_id = strdup(operator_node->mangled_id);
+                        else
+                            expr->expr_data.function_call_data.mangled_id = strdup(operator_method);
+
+                        expr->expr_data.function_call_data.args_expr = CreateListNode(sign_expr, LIST_EXPR);
+                        expr->expr_data.function_call_data.resolved_func = operator_node;
+                        expr->expr_data.function_call_data.call_hash_type = HASHTYPE_FUNCTION;
+                        expr->expr_data.function_call_data.call_kgpc_type = operator_node->type;
+                        kgpc_type_retain(operator_node->type);
+                        expr->expr_data.function_call_data.is_call_info_valid = 1;
+
+                        if (expr->resolved_kgpc_type != NULL)
+                            destroy_kgpc_type(expr->resolved_kgpc_type);
+                        expr->resolved_kgpc_type = return_type;
+                        kgpc_type_retain(return_type);
+
+                        free(operator_method);
+                        return return_val;
+                    }
+                }
+                free(operator_method);
+            }
+        }
+    }
+
     if (*type_return == POINTER_TYPE || *type_return == RECORD_TYPE)
         return return_val;
     if(!is_type_ir(type_return))
@@ -1555,7 +1578,7 @@ int semcheck_addop(int *type_return,
                     snprintf(operator_method, name_len, "%s__%s", record_type_name, op_suffix);
 
                     HashNode_t *operator_node = NULL;
-                    ListNode_t *operator_candidates = FindAllIdents(symtab, operator_method);
+                    ListNode_t *operator_candidates = FindAllIdentsByPrefix(symtab, operator_method);
                     if (kgpc_getenv("KGPC_DEBUG_ADDOP") != NULL)
                     {
                         fprintf(stderr,
@@ -1567,89 +1590,26 @@ int semcheck_addop(int *type_return,
                     }
                     if (operator_candidates != NULL)
                     {
-                        KgpcType *left_arg_type = expr1 != NULL ? expr1->resolved_kgpc_type : NULL;
-                        KgpcType *right_arg_type = expr2 != NULL ? expr2->resolved_kgpc_type : NULL;
-                        HashNode_t *best_exact = NULL;
-                        int best_exact_score = -1;
-                        for (ListNode_t *cur = operator_candidates; cur != NULL; cur = cur->next)
-                        {
-                            HashNode_t *candidate = (HashNode_t *)cur->cur;
-                            if (candidate == NULL ||
-                                (candidate->hash_type != HASHTYPE_FUNCTION &&
-                                 candidate->hash_type != HASHTYPE_PROCEDURE) ||
-                                candidate->type == NULL)
-                            {
-                                continue;
-                            }
-
-                            ListNode_t *params = kgpc_type_get_procedure_params(candidate->type);
-                            if (params == NULL || params->next == NULL)
-                                continue;
-
-                            Tree_t *left_decl = (Tree_t *)params->cur;
-                            Tree_t *right_decl = (Tree_t *)params->next->cur;
-                            int owns_left = 0;
-                            int owns_right = 0;
-                            KgpcType *left_formal = resolve_type_from_vardecl(left_decl, symtab, &owns_left);
-                            KgpcType *right_formal = resolve_type_from_vardecl(right_decl, symtab, &owns_right);
-
-                            int score = 0;
-                            int valid = 1;
-                            if (left_formal != NULL && left_arg_type != NULL)
-                            {
-                                if (kgpc_type_equals(left_formal, left_arg_type))
-                                    score += 2;
-                                else if (are_types_compatible_for_assignment(left_formal, left_arg_type, symtab))
-                                    score += 1;
-                                else
-                                    valid = 0;
-                            }
-                            if (valid && right_formal != NULL && right_arg_type != NULL)
-                            {
-                                if (kgpc_type_equals(right_formal, right_arg_type))
-                                    score += 2;
-                                else if (are_types_compatible_for_assignment(right_formal, right_arg_type, symtab))
-                                    score += 1;
-                                else
-                                    valid = 0;
-                            }
-                            if (owns_left && left_formal != NULL)
-                                destroy_kgpc_type(left_formal);
-                            if (owns_right && right_formal != NULL)
-                                destroy_kgpc_type(right_formal);
-
-                            if (valid && score > best_exact_score)
-                            {
-                                best_exact = candidate;
-                                best_exact_score = score;
-                            }
-                        }
-                        if (best_exact != NULL)
-                            operator_node = best_exact;
-
                         HashNode_t *best_match = NULL;
                         int best_rank = 0;
                         int num_best = 0;
-                        if (operator_node == NULL)
+                        ListNode_t *args_given = CreateListNode(expr1, LIST_EXPR);
+                        if (args_given != NULL)
                         {
-                            ListNode_t *args_given = CreateListNode(expr1, LIST_EXPR);
-                            if (args_given != NULL)
-                            {
-                                args_given->next = CreateListNode(expr2, LIST_EXPR);
-                                int resolve_status = semcheck_resolve_overload(
-                                    &best_match,
-                                    &best_rank,
-                                    &num_best,
-                                    operator_candidates,
-                                    args_given,
-                                    symtab,
-                                    expr,
-                                    max_scope_lev,
-                                    1);
-                                if (resolve_status == 0 && best_match != NULL)
-                                    operator_node = best_match;
-                                DestroyList(args_given);
-                            }
+                            args_given->next = CreateListNode(expr2, LIST_EXPR);
+                            int resolve_status = semcheck_resolve_overload(
+                                &best_match,
+                                &best_rank,
+                                &num_best,
+                                operator_candidates,
+                                args_given,
+                                symtab,
+                                expr,
+                                max_scope_lev,
+                                1);
+                            if (resolve_status == 0 && best_match != NULL)
+                                operator_node = best_match;
+                            DestroyList(args_given);
                         }
                         if (operator_node == NULL)
                         {
@@ -1666,49 +1626,6 @@ int semcheck_addop(int *type_return,
                             }
                         }
                         DestroyList(operator_candidates);
-                    }
-                    /* For binary operators, try exact lookup with second param type
-                     * first to distinguish from unary operators with the same name. */
-                    if (operator_node == NULL && right_type_name != NULL)
-                    {
-                        size_t exact_len = strlen(operator_method) + strlen(right_type_name) +
-                            strlen(record_type_name) + 3;
-                        char *operator_exact = (char *)malloc(exact_len);
-                        if (operator_exact != NULL)
-                        {
-                            snprintf(operator_exact, exact_len, "%s_%s_%s",
-                                operator_method, right_type_name, record_type_name);
-                            FindSymbol(&operator_node, symtab, operator_exact);
-                            free(operator_exact);
-                        }
-                    }
-                    if (operator_node == NULL &&
-                        semcheck_find_ident_by_prefix_visible(&operator_node, symtab, operator_method) >= 0 &&
-                        operator_node != NULL)
-                    {
-                        /* Verify the prefix-matched operator has the right arity
-                         * (binary operators need 2 params, not 1). */
-                        if (operator_node->type != NULL)
-                        {
-                            ListNode_t *check_params = kgpc_type_get_procedure_params(operator_node->type);
-                            int param_count = ListLength(check_params);
-                            if (param_count == 1 && expr2 != NULL)
-                            {
-                                /* Found unary but need binary — reject this match */
-                                operator_node = NULL;
-                            }
-                        }
-                    }
-                    if (operator_node == NULL)
-                    {
-                        size_t exact_len = strlen(operator_method) + strlen(record_type_name) + 2;
-                        char *operator_exact = (char *)malloc(exact_len);
-                        if (operator_exact != NULL)
-                        {
-                            snprintf(operator_exact, exact_len, "%s_%s", operator_method, record_type_name);
-                            FindSymbol(&operator_node, symtab, operator_exact);
-                            free(operator_exact);
-                        }
                     }
                     if (operator_node != NULL)
                     {
@@ -1998,13 +1915,45 @@ int semcheck_mulop(int *type_return,
                     /* Look up the operator method in the symbol table.
                      * Try exact match first, then prefix match for return-type-suffixed names. */
                     HashNode_t *operator_node = NULL;
-                    if (FindSymbol(&operator_node, symtab, operator_method) != 0 && operator_node != NULL)
+                    ListNode_t *operator_candidates = FindAllIdentsByPrefix(symtab, operator_method);
+                    if (operator_candidates != NULL)
                     {
-                        /* exact match */
-                    }
-                    else if (semcheck_find_ident_by_prefix_visible(&operator_node, symtab, operator_method) >= 0 && operator_node != NULL)
-                    {
-                        /* prefix match — return-type-disambiguated name */
+                        HashNode_t *best_match = NULL;
+                        int best_rank = 0;
+                        int num_best = 0;
+                        ListNode_t *args_given = CreateListNode(expr1, LIST_EXPR);
+                        if (args_given != NULL)
+                        {
+                            args_given->next = CreateListNode(expr2, LIST_EXPR);
+                            int resolve_status = semcheck_resolve_overload(
+                                &best_match,
+                                &best_rank,
+                                &num_best,
+                                operator_candidates,
+                                args_given,
+                                symtab,
+                                expr,
+                                max_scope_lev,
+                                1);
+                            if (resolve_status == 0 && best_match != NULL)
+                                operator_node = best_match;
+                            DestroyList(args_given);
+                        }
+                        if (operator_node == NULL)
+                        {
+                            for (ListNode_t *cur = operator_candidates; cur != NULL; cur = cur->next)
+                            {
+                                HashNode_t *candidate = (HashNode_t *)cur->cur;
+                                if (candidate != NULL &&
+                                    (candidate->hash_type == HASHTYPE_FUNCTION ||
+                                     candidate->hash_type == HASHTYPE_PROCEDURE))
+                                {
+                                    operator_node = candidate;
+                                    break;
+                                }
+                            }
+                        }
+                        DestroyList(operator_candidates);
                     }
                     if (operator_node != NULL)
                     {

--- a/KGPC/Parser/SemanticCheck/SymTab/SymTab.c
+++ b/KGPC/Parser/SemanticCheck/SymTab/SymTab.c
@@ -25,6 +25,7 @@ ScopeNode *GetOrCreateUnitScope(SymTab_t *symtab, int unit_index);  /* defined l
 /* Forward declarations for tree-walking lookups (defined at end of file) */
 static int FindIdent_Tree(HashNode_t **hash_return, SymTab_t *symtab, const char *id);
 static int FindIdentByPrefix_Tree(HashNode_t **hash_return, SymTab_t *symtab, const char *prefix);
+static ListNode_t *FindAllIdentsByPrefix_Tree(SymTab_t *symtab, const char *prefix);
 static ListNode_t *FindAllIdents_Tree(SymTab_t *symtab, const char *id);
 static ListNode_t *FindAllIdentsInNearestScope_Tree(SymTab_t *symtab, const char *id);
 static HashNode_t *FindIdentInCurrentScope_Tree(SymTab_t *symtab, const char *id);
@@ -476,6 +477,17 @@ int FindIdentByPrefix(HashNode_t **hash_return, SymTab_t *symtab, const char *pr
     return 0;
 }
 
+ListNode_t *FindAllIdentsByPrefix(SymTab_t *symtab, const char *prefix)
+{
+    assert(symtab != NULL);
+    assert(prefix != NULL);
+
+    if (symtab->current_scope != NULL)
+        return FindAllIdentsByPrefix_Tree(symtab, prefix);
+
+    return NULL;
+}
+
 ListNode_t *FindAllIdents(SymTab_t *symtab, const char *id)
 {
     assert(symtab != NULL);
@@ -763,6 +775,31 @@ static int FindIdentByPrefix_Tree(HashNode_t **hash_return, SymTab_t *symtab, co
 
     *hash_return = NULL;
     return 0;
+}
+
+/* Tree-walking FindAllIdentsByPrefix: collect all matches from all reachable scopes */
+static ListNode_t *FindAllIdentsByPrefix_Tree(SymTab_t *symtab, const char *prefix)
+{
+    ListNode_t *all = NULL;
+    ScopeNode *scope = symtab->current_scope;
+
+    while (scope != NULL)
+    {
+        all = append_list(all, FindAllIdentsByPrefixInTable(scope->table, prefix));
+
+        if (scope->num_deps > 0)
+        {
+            for (int i = 0; i < scope->num_deps; i++)
+            {
+                all = append_list(all, FindAllIdentsByPrefixInTableForUnit(
+                    scope->dep_scopes[i]->table, prefix, symtab->current_unit_index));
+            }
+        }
+
+        scope = scope->parent;
+    }
+
+    return all;
 }
 
 /* Tree-walking FindAllIdents: collect all matches from all reachable scopes */

--- a/KGPC/Parser/SemanticCheck/SymTab/SymTab.h
+++ b/KGPC/Parser/SemanticCheck/SymTab/SymTab.h
@@ -127,6 +127,9 @@ int FindSymbol(HashNode_t ** hash_return, SymTab_t *symtab, const char *id);
 /* Returns 1 if found (hash_return set to the matching node) */
 int FindIdentByPrefix(HashNode_t **hash_return, SymTab_t *symtab, const char *prefix);
 
+/* Searches for all instances of identifiers starting with the given prefix. Returns a list of HashNode_t* or NULL if not found */
+ListNode_t *FindAllIdentsByPrefix(SymTab_t *symtab, const char *prefix);
+
 /* Searches for all instances of an identifier and returns a list of HashNode_t* */
 /* Returns NULL if not found */
 ListNode_t *FindAllIdents(SymTab_t *symtab, const char *id);


### PR DESCRIPTION
This PR fixes an issue where binary subtraction on record types (specifically `Tconstexprint`) would incorrectly resolve to a unary operator overload.

The fix involves:
1. Enhancing `HashTable` and `SymTab` to support collecting all identifier matches by prefix (`FindAllIdentsByPrefix`).
2. Updating operator semantic checks (`semcheck_relop`, `semcheck_addop`, `semcheck_mulop`) to gather all candidate operator overloads and using `semcheck_resolve_overload` to pick the correct one based on arity and types.
3. Implementing support for unary operator overloading on records in `semcheck_signterm`.

This resolves the "too many arguments given" errors encountered when compiling `pp.pas` as part of the FPC bootstrap effort.

Fixes #491

---
*PR created automatically by Jules for task [6510773989275183797](https://jules.google.com/task/6510773989275183797) started by @Kreijstal*

## Summary by Sourcery

Improve operator overload resolution for record types and support unary operator overloading in expression semantic checks.

Bug Fixes:
- Fix incorrect resolution of binary record subtraction to unary operator overloads, preventing spurious argument count errors during compilation.

Enhancements:
- Add prefix-based symbol table queries that return all matching identifiers and integrate them into relational, additive, and multiplicative operator semantic checks for overload resolution.
- Refine operator overload selection to use a centralized resolution routine across relational, additive, multiplicative, and unary sign operations.