### PR TITLE
Fix record size for ShortString and String types in codegen

### DIFF
--- a/KGPC/CodeGenerator/Intel_x86-64/codegen_expression.c
+++ b/KGPC/CodeGenerator/Intel_x86-64/codegen_expression.c
@@ -4195,6 +4195,17 @@ int codegen_get_record_size(CodeGenContext *ctx, struct Expression *expr,
     KgpcType *expr_type = expr_get_kgpc_type(expr);
     if (expr_type != NULL)
     {
+        if (kgpc_type_is_shortstring(expr_type))
+        {
+            *size_out = 256;
+            return 0;
+        }
+        if (kgpc_type_is_string(expr_type))
+        {
+            /* AnsiString/UnicodeString are pointer-sized */
+            *size_out = CODEGEN_POINTER_SIZE_BYTES;
+            return 0;
+        }
         if (kgpc_type_is_record(expr_type))
             return codegen_sizeof_record(ctx, expr_type->info.record_info, size_out, 0);
         if (kgpc_type_is_pointer(expr_type) && expr_type->info.points_to != NULL &&


### PR DESCRIPTION
## Summary
- `codegen_get_record_size` failed for ShortString fields (resolved kgpc type was ShortString but `expr_get_type_tag` didn't return SHORTSTRING_TYPE)
- AnsiString expressions also hit the error path since they're not records
- Fix: check `kgpc_type_is_shortstring` and `kgpc_type_is_string` on the resolved type early

Eliminates 4+2 errors in pp.pas codegen (down from 18 to 12).

## Test plan
- [x] All compiler tests pass
- [x] pp.pas codegen: 0 "Unable to determine size for record expression" errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Handle ShortString and String expression types when computing record sizes during code generation.

Bug Fixes:
- Fix failure to determine record size for ShortString-typed expressions in code generation.
- Avoid erroneous "record" size errors for AnsiString/UnicodeString expressions by treating them as pointer-sized.