### PR TITLE
Fix Copy() builtin for dynamic arrays

### DIFF
--- a/KGPC/Parser/SemanticCheck/SemChecks/SemCheck_Expr_Builtins.c
+++ b/KGPC/Parser/SemanticCheck/SemChecks/SemCheck_Expr_Builtins.c
@@ -711,11 +711,12 @@ int semcheck_builtin_copy(int *type_return, SymTab_t *symtab,
     int is_wide_string = (source_kgpc_type != NULL && kgpc_type_is_wide_string(source_kgpc_type));
 
     /* Also accept dynamic arrays for Copy */
-    int is_array = (source_kgpc_type != NULL && source_kgpc_type->kind == TYPE_KIND_ARRAY);
+    int is_dynarray = (source_kgpc_type != NULL && kgpc_type_is_dynamic_array(source_kgpc_type));
+    int is_array = (source_kgpc_type != NULL && source_kgpc_type->kind == TYPE_KIND_ARRAY && !is_dynarray);
 
-    if (error_count == 0 && !kgpc_type_is_string(source_kgpc_type) && !is_shortstring && !is_array)
+    if (error_count == 0 && !kgpc_type_is_string(source_kgpc_type) && !is_shortstring && !is_dynarray)
     {
-        semcheck_error_with_context_at(expr->line_num, expr->col_num, expr->source_index, "Error on line %d, Copy expects its first argument to be a string.\n", expr->line_num);
+        semcheck_error_with_context_at(expr->line_num, expr->col_num, expr->source_index, "Error on line %d, Copy expects its first argument to be a string or dynamic array.\n", expr->line_num);
         error_count++;
     }
 
@@ -755,8 +756,8 @@ int semcheck_builtin_copy(int *type_return, SymTab_t *symtab,
     else
     {
         /* 1-argument form: Copy(S) — copy entire string/array.
-           Synthesize index=1 and count=INT_MAX. */
-        index_expr = mk_inum(expr->line_num, 1LL);
+           Synthesize index=1 (strings) or 0 (dynarray) and count=INT_MAX. */
+        index_expr = mk_inum(expr->line_num, is_dynarray ? 0LL : 1LL);
         assert(index_expr != NULL);
         semcheck_expr_set_resolved_type(index_expr, LONGINT_TYPE);
         ListNode_t *index_node = CreateListNode(index_expr, LIST_EXPR);
@@ -770,6 +771,29 @@ int semcheck_builtin_copy(int *type_return, SymTab_t *symtab,
         args->next = index_node;
     }
 
+    if (error_count == 0 && is_dynarray)
+    {
+        /* Synthesize 4th argument: element size */
+        long long elem_size = kgpc_type_get_array_element_size(source_kgpc_type);
+        struct Expression *esize_expr = mk_inum(expr->line_num, elem_size);
+        assert(esize_expr != NULL);
+        semcheck_expr_set_resolved_type(esize_expr, LONGINT_TYPE);
+        ListNode_t *esize_node = CreateListNode(esize_expr, LIST_EXPR);
+
+        /* Copy accepts 3 args + 1 synthesized: S, Index, Count, ElementSize.
+           Append to the end of args list. */
+        ListNode_t *cur = args;
+        while (cur->next != NULL) cur = cur->next;
+        cur->next = esize_node;
+
+        /* Wrap source expression with EXPR_ADDR since runtime takes descriptor pointer */
+        if (source_expr->type != EXPR_ADDR)
+        {
+            args->cur = mk_addressof(source_expr->line_num, source_expr);
+            source_expr = (struct Expression *)args->cur;
+        }
+    }
+
     if (error_count == 0)
     {
         if (expr->expr_data.function_call_data.mangled_id != NULL)
@@ -779,7 +803,8 @@ int semcheck_builtin_copy(int *type_return, SymTab_t *symtab,
         }
         /* Use ShortString-specific copy if source is a ShortString */
         const char *copy_func = is_shortstring ? "kgpc_shortstring_copy" :
-            (is_wide_string ? "kgpc_unicodestring_copy" : "kgpc_string_copy");
+            (is_wide_string ? "kgpc_unicodestring_copy" :
+            (is_dynarray ? "kgpc_dynarray_copy" : "kgpc_string_copy"));
         expr->expr_data.function_call_data.mangled_id = strdup(copy_func);
         if (expr->expr_data.function_call_data.mangled_id == NULL)
         {
@@ -788,7 +813,7 @@ int semcheck_builtin_copy(int *type_return, SymTab_t *symtab,
             return 1;
         }
         semcheck_reset_function_call_cache(expr);
-        if (is_array)
+        if (is_dynarray)
         {
             int tag = semcheck_tag_from_kgpc(source_kgpc_type);
             semcheck_expr_set_resolved_type(expr, tag);

--- a/KGPC/runtime.c
+++ b/KGPC/runtime.c
@@ -2434,6 +2434,63 @@ void kgpc_dynarray_setlength(void *descriptor_ptr, int64_t new_length, int64_t e
     descriptor->length = new_length;
 }
 
+/*
+ * Copy a segment of a dynamic array.
+ * src_descriptor_ptr: pointer to source kgpc_dynarray_descriptor_t
+ * index: 0-based start index
+ * count: number of elements to copy
+ * element_size: size of each element in bytes
+ * Returns: pointer to a new heap-allocated kgpc_dynarray_descriptor_t (temp)
+ */
+void *kgpc_dynarray_copy(const void *src_descriptor_ptr, int64_t index, int64_t count, int64_t element_size)
+{
+    if (src_descriptor_ptr == NULL || element_size <= 0)
+        return NULL;
+
+    const kgpc_dynarray_descriptor_t *src = (const kgpc_dynarray_descriptor_t *)src_descriptor_ptr;
+    int64_t src_len = src->length;
+
+    if (index < 0)
+        index = 0;
+    if (count < 0)
+        count = 0;
+
+    if (index >= src_len)
+        count = 0;
+    else if (index + count > src_len)
+        count = src_len - index;
+
+    kgpc_dynarray_descriptor_t *dest = (kgpc_dynarray_descriptor_t *)calloc(1, sizeof(kgpc_dynarray_descriptor_t));
+    if (dest == NULL)
+        return NULL;
+
+    if (count > 0)
+    {
+        size_t alloc_count = (size_t)count;
+        if (alloc_count < SIZE_MAX)
+            alloc_count += 1; /* Spare slot for off-by-one tolerance */
+
+        dest->data = calloc(alloc_count, (size_t)element_size);
+        if (dest->data != NULL)
+        {
+            memcpy(dest->data, (char *)src->data + (index * element_size), (size_t)count * (size_t)element_size);
+            dest->length = count;
+        }
+        else
+        {
+            free(dest);
+            return NULL;
+        }
+    }
+    else
+    {
+        dest->data = NULL;
+        dest->length = 0;
+    }
+
+    return dest;
+}
+
 void kgpc_write_integer(KGPCTextRec *file, int width, int64_t value)
 {
     FILE *dest = kgpc_text_output_stream(file);

--- a/tests/test_cases/copy_dynarray.p
+++ b/tests/test_cases/copy_dynarray.p
@@ -2,17 +2,25 @@
 program test_copy_dynarray;
 type
   TIntArray = array of Integer;
-
-procedure DoCopy;
 var
   a, b: TIntArray;
 begin
-  SetLength(a, 3);
-  a[0] := 10; a[1] := 20; a[2] := 30;
-  b := Copy(a);
-end;
+  setlength(a, 10);
+  a[0] := 1;
+  a[1] := 2;
+  b := copy(a, 0, 2);
+  if length(b) <> 2 then
+    halt(1);
+  if b[0] <> 1 then
+    halt(2);
+  if b[1] <> 2 then
+    halt(3);
 
-begin
-  { DoCopy is not called — we only verify Copy(a) type-checks }
-  WriteLn('OK');
+  b := copy(a);
+  if length(b) <> 10 then
+    halt(4);
+  if b[0] <> 1 then
+    halt(5);
+
+  writeln('OK');
 end.


### PR DESCRIPTION
Implemented `kgpc_dynarray_copy` runtime function and updated `semcheck_builtin_copy` to support dynamic arrays. Dynamic array `Copy()` now correctly uses 0-based indexing, synthesizes an element size argument, and returns the original array type instead of a string. Verified with `tests/test_cases/copy_dynarray.p`.

Fixes #471

---
*PR created automatically by Jules for task [17214855293053155337](https://jules.google.com/task/17214855293053155337) started by @Kreijstal*

## Summary by Sourcery

Add runtime and semantic support for using the Copy() builtin with dynamic arrays, including correct indexing, element sizing, and return typing, and verify behavior with dedicated tests.

Bug Fixes:
- Ensure Copy() correctly handles dynamic arrays using 0-based indexing and returns a value of the original array type rather than a string.

Enhancements:
- Introduce a runtime helper for copying slices of dynamic arrays with bounds adjustment and safe allocation.
- Extend semantic checking of Copy() to accept dynamic arrays, synthesize an element size argument, and route calls to the new runtime helper.

Tests:
- Expand the dynamic array Copy() test to exercise both explicit and implicit argument forms and validate resulting lengths and element values.