### PR TITLE
Leaksremoval

### DIFF
--- a/KGPC/CodeGenerator/Intel_x86-64/codegen.c
+++ b/KGPC/CodeGenerator/Intel_x86-64/codegen.c
@@ -8113,14 +8113,15 @@ void codegen_procedure(Tree_t *proc_tree, CodeGenContext *ctx, SymTab_t *symtab)
         int self_depth = 0;
         StackNode_t *self_var = find_label_with_depth("self", &self_depth);
         char buffer[128];
+        const char *arg_reg = current_arg_reg64(0);
 
         if (self_var != NULL)
-            snprintf(buffer, sizeof(buffer), "\tmovq\t-%d(%%rbp), %%rdi\n", self_var->offset);
+            snprintf(buffer, sizeof(buffer), "\tmovq\t-%d(%%rbp), %s\n", self_var->offset, arg_reg);
         else
-            snprintf(buffer, sizeof(buffer), "\tmovq\t-8(%%rbp), %%rdi\n");
+            snprintf(buffer, sizeof(buffer), "\tmovq\t-8(%%rbp), %s\n", arg_reg);
         inst_list = add_inst(inst_list, buffer);
         inst_list = add_inst(inst_list, "\tmovl\t$0, %eax\n");
-        inst_list = add_inst(inst_list, "\tcall\tkgpc_freemem\n");
+        inst_list = codegen_call_with_shadow_space(inst_list, "kgpc_freemem");
     }
 
     /* For constructors, return Self in %rax.

--- a/KGPC/CodeGenerator/Intel_x86-64/codegen.c
+++ b/KGPC/CodeGenerator/Intel_x86-64/codegen.c
@@ -8837,6 +8837,29 @@ void codegen_function(Tree_t *func_tree, CodeGenContext *ctx, SymTab_t *symtab)
         }
     }
 
+    /* Constructors routed through codegen_function must return Self.
+     * Initialize the return variable with Self (-8(%rbp)) so that even if
+     * the constructor body doesn't explicitly set Result, the return value
+     * is the allocated instance pointer (not zero). */
+    {
+        int func_is_constructor = func->is_constructor;
+        if (!func_is_constructor && func->owner_class != NULL &&
+            func->method_name != NULL &&
+            strncasecmp(func->method_name, "Create", 6) == 0)
+        {
+            func_is_constructor = 1;
+        }
+        if (func_is_constructor && return_var != NULL)
+        {
+            char ctor_buf[128];
+            snprintf(ctor_buf, sizeof(ctor_buf), "\tmovq\t-8(%%rbp), %%rax\n");
+            inst_list = add_inst(inst_list, ctor_buf);
+            snprintf(ctor_buf, sizeof(ctor_buf), "\tmovq\t%%rax, -%d(%%rbp)\n",
+                return_var->offset);
+            inst_list = add_inst(inst_list, ctor_buf);
+        }
+    }
+
     codegen_function_locals(func->declarations, ctx, symtab);
 
     /* Allocate callee-save slots AFTER args (z) and locals (x) so that

--- a/KGPC/CodeGenerator/Intel_x86-64/codegen.c
+++ b/KGPC/CodeGenerator/Intel_x86-64/codegen.c
@@ -8105,6 +8105,24 @@ void codegen_procedure(Tree_t *proc_tree, CodeGenContext *ctx, SymTab_t *symtab)
     inst_list = codegen_var_initializers(proc->declarations, inst_list, ctx, symtab);
     inst_list = codegen_stmt(proc->statement_list, inst_list, ctx, symtab);
 
+    if (proc->owner_class != NULL &&
+        proc->method_name != NULL &&
+        pascal_identifier_equals(proc->owner_class, "TObject") &&
+        pascal_identifier_equals(proc->method_name, "Free"))
+    {
+        int self_depth = 0;
+        StackNode_t *self_var = find_label_with_depth("self", &self_depth);
+        char buffer[128];
+
+        if (self_var != NULL)
+            snprintf(buffer, sizeof(buffer), "\tmovq\t-%d(%%rbp), %%rdi\n", self_var->offset);
+        else
+            snprintf(buffer, sizeof(buffer), "\tmovq\t-8(%%rbp), %%rdi\n");
+        inst_list = add_inst(inst_list, buffer);
+        inst_list = add_inst(inst_list, "\tmovl\t$0, %eax\n");
+        inst_list = add_inst(inst_list, "\tcall\tkgpc_freemem\n");
+    }
+
     /* For constructors, return Self in %rax.
      * Constructors receive Self in the first parameter and should return it
      * to allow constructor chaining and assignment. */
@@ -10856,19 +10874,17 @@ static ListNode_t *codegen_store_class_typeinfo(ListNode_t *inst_list,
      * and zero-initialize with calloc. A better approach would compute the actual size from the RecordType.
      */
     
-    /* Call calloc to allocate and zero-initialize the instance */
+    /* Allocate the instance through the runtime helper. This path is used in
+     * early generic class materialization where the Pascal heap bootstrap may
+     * not be ready yet. */
     char buffer[1024];
     const char *size_reg = current_arg_reg64(0);  /* RDI on Linux, RCX on Windows */
-    const char *count_reg = current_arg_reg64(1); /* RSI on Linux, RDX on Windows */
-    
-    if (size_reg != NULL && count_reg != NULL)
+
+    if (size_reg != NULL)
     {
-        /* calloc(1, 64) - allocate one 64-byte block */
-        snprintf(buffer, sizeof(buffer), "\tmovq\t$1, %s\n", size_reg);
+        snprintf(buffer, sizeof(buffer), "\tmovq\t$64, %s\n", size_reg);
         inst_list = add_inst(inst_list, buffer);
-        snprintf(buffer, sizeof(buffer), "\tmovq\t$64, %s\n", count_reg);
-        inst_list = add_inst(inst_list, buffer);
-        inst_list = codegen_call_with_shadow_space(inst_list, "calloc");
+        inst_list = codegen_call_with_shadow_space(inst_list, "kgpc_allocmem");
         
         /* RAX now contains the pointer to the allocated instance */
         /* Store the typeinfo pointer in the first field */

--- a/KGPC/CodeGenerator/Intel_x86-64/codegen_expression.c
+++ b/KGPC/CodeGenerator/Intel_x86-64/codegen_expression.c
@@ -10593,6 +10593,37 @@ ListNode_t *codegen_pass_arguments(ListNode_t *args, ListNode_t *inst_list,
                         return inst_list;
                     }
 
+                    /* When the argument expression is a char value (e.g. a single-char
+                     * string constant like version_nr = '3' which the semantic checker
+                     * resolves to CHAR_TYPE with ordinal value), we must promote it to
+                     * an AnsiString before kgpc_string_to_shortstring dereferences it
+                     * as a pointer.  Without this, the raw char ordinal (e.g. 51 for '3')
+                     * is passed as a pointer and causes a segfault. */
+                    if (expr_has_type_tag(arg_expr, CHAR_TYPE))
+                    {
+                        /* Save buf_addr_reg across the call since kgpc_char_to_string
+                         * clobbers caller-saved registers. */
+                        StackNode_t *buf_save = add_l_t("shortstr_buf_save");
+                        snprintf(buffer, sizeof(buffer), "\tmovq\t%s, -%d(%%rbp)\n",
+                            buf_addr_reg->bit_64, buf_save->offset);
+                        inst_list = add_inst(inst_list, buffer);
+
+                        const char *char_arg_reg32 = codegen_target_is_windows() ? "%ecx" : "%edi";
+                        snprintf(buffer, sizeof(buffer), "\tmovl\t%s, %s\n",
+                            value_reg->bit_32, char_arg_reg32);
+                        inst_list = add_inst(inst_list, buffer);
+                        inst_list = codegen_vect_reg(inst_list, 0);
+                        inst_list = codegen_call_with_shadow_space(inst_list, "kgpc_char_to_string");
+                        snprintf(buffer, sizeof(buffer), "\tmovq\t%%rax, %s\n", value_reg->bit_64);
+                        inst_list = add_inst(inst_list, buffer);
+                        free_arg_regs();
+
+                        /* Restore buf_addr_reg */
+                        snprintf(buffer, sizeof(buffer), "\tmovq\t-%d(%%rbp), %s\n",
+                            buf_save->offset, buf_addr_reg->bit_64);
+                        inst_list = add_inst(inst_list, buffer);
+                    }
+
                     if (codegen_target_is_windows())
                     {
                         snprintf(buffer, sizeof(buffer), "\tmovq\t%s, %%rcx\n", buf_addr_reg->bit_64);

--- a/KGPC/CodeGenerator/Intel_x86-64/codegen_statement_parts/codegen_stmt_assignment.c
+++ b/KGPC/CodeGenerator/Intel_x86-64/codegen_statement_parts/codegen_stmt_assignment.c
@@ -2016,20 +2016,13 @@ ListNode_t *codegen_assign_record_value(struct Expression *dest_expr,
                                 dest_reg->bit_64, dest_save_slot->offset);
                             inst_list = add_inst(inst_list, buffer);
                             
-                            /* Allocate zero-initialized memory using calloc
-                             * This ensures all fields (including dynamic array descriptors) start at zero */
-                            const char *size_arg_reg = codegen_target_is_windows() ? "%rcx" : "%rdi";
-                            const char *count_arg_reg = codegen_target_is_windows() ? "%rdx" : "%rsi";
-                            
-                            /* calloc(1, instance_size) - allocate 1 element of size instance_size */
-                            snprintf(buffer, sizeof(buffer), "\tmovq\t$1, %s\n", size_arg_reg);
-                            inst_list = add_inst(inst_list, buffer);
+                            /* Allocate zero-initialized memory through the runtime helper. */
+                            const char *alloc_arg_reg = codegen_target_is_windows() ? "%rcx" : "%rdi";
                             snprintf(buffer, sizeof(buffer), "\tmovq\t$%lld, %s\n",
-                                instance_size, count_arg_reg);
+                                instance_size, alloc_arg_reg);
                             inst_list = add_inst(inst_list, buffer);
-                            
                             inst_list = codegen_vect_reg(inst_list, 0);
-                            inst_list = codegen_call_with_shadow_space(inst_list, "calloc");
+                            inst_list = codegen_call_with_shadow_space(inst_list, "kgpc_allocmem");
                             free_arg_regs();
                             
                             /* Save the allocated instance pointer */
@@ -2597,4 +2590,3 @@ ListNode_t *codegen_assign_record_value(struct Expression *dest_expr,
     free_arg_regs();
     return inst_list;
 }
-

--- a/KGPC/CodeGenerator/Intel_x86-64/codegen_statement_parts/codegen_stmt_assignment.c
+++ b/KGPC/CodeGenerator/Intel_x86-64/codegen_statement_parts/codegen_stmt_assignment.c
@@ -1538,6 +1538,17 @@ ListNode_t *codegen_assign_static_array(struct Expression *dest_expr,
         return inst_list;
     }
 
+    /* For EXPR_ARRAY_LITERAL, codegen_address_for_expr returns a pointer to a
+     * descriptor {data_ptr, count}, not the data itself.  Dereference the
+     * descriptor to get the actual data pointer for the memcpy source. */
+    if (src_expr->type == EXPR_ARRAY_LITERAL &&
+        src_expr->expr_data.array_literal_data.element_count > 0)
+    {
+        snprintf(buffer, sizeof(buffer), "\tmovq\t(%s), %s\n",
+            src_reg->bit_64, src_reg->bit_64);
+        inst_list = add_inst(inst_list, buffer);
+    }
+
     /* If we spilled the destination, reload it */
     if (dest_spill_slot != NULL)
     {

--- a/KGPC/CodeGenerator/Intel_x86-64/codegen_statement_parts/codegen_stmt_calls_and_control.c
+++ b/KGPC/CodeGenerator/Intel_x86-64/codegen_statement_parts/codegen_stmt_calls_and_control.c
@@ -241,6 +241,13 @@ ListNode_t *codegen_var_assignment(struct Statement *stmt, ListNode_t *inst_list
 
             if (field_is_static_array && src_is_static_array)
                 return codegen_assign_static_array(var_expr, assign_expr, inst_list, ctx);
+            /* EXPR_ARRAY_LITERAL is created with array_is_dynamic=1 by default,
+             * but when assigned to a static array field (e.g., optypes: array[0..3]
+             * of int64 in a packed record), it must be treated as a static array
+             * copy, not a pointer store. */
+            if (field_is_static_array && assign_expr != NULL &&
+                assign_expr->type == EXPR_ARRAY_LITERAL)
+                return codegen_assign_static_array(var_expr, assign_expr, inst_list, ctx);
 
             /* Large set fields (> 4 bytes, e.g. set of enum with > 32 elements)
              * need memory-based construction via codegen_assign_record_value,
@@ -1529,7 +1536,7 @@ ListNode_t *codegen_var_assignment(struct Statement *stmt, ListNode_t *inst_list
         }
         else
         {
-            if (var_type_2 == CHAR_TYPE)
+            if (var_type_2 == CHAR_TYPE || record_element_size == 1)
             {
                 const char *value_reg8 = register_name8(value_reg);
                 if (value_reg8 == NULL)
@@ -1543,7 +1550,7 @@ ListNode_t *codegen_var_assignment(struct Statement *stmt, ListNode_t *inst_list
                     inst_list = add_inst(inst_list, buffer);
                 }
             }
-            else if (use_word)
+            else if (use_word || record_element_size == 2)
             {
                 const char *value_reg16 = codegen_register_name16(value_reg);
                 if (value_reg16 == NULL)
@@ -1819,6 +1826,21 @@ static struct Expression *codegen_build_temp_call_expr_from_stmt(
     }
     call_expr->expr_data.function_call_data.is_class_method_call =
         stmt->stmt_data.procedure_call_data.is_class_method_call;
+    call_expr->expr_data.function_call_data.is_constructor_call =
+        stmt->stmt_data.procedure_call_data.is_constructor_call;
+    /* For constructor-as-statement, create a constructor_receiver_expr from the
+     * class name so the codegen knows which class to allocate. */
+    if (stmt->stmt_data.procedure_call_data.is_constructor_call &&
+        stmt->stmt_data.procedure_call_data.constructor_class_name != NULL)
+    {
+        struct Expression *receiver = (struct Expression *)calloc(1, sizeof(struct Expression));
+        if (receiver != NULL)
+        {
+            receiver->type = EXPR_VAR_ID;
+            receiver->expr_data.id = strdup(stmt->stmt_data.procedure_call_data.constructor_class_name);
+            call_expr->expr_data.function_call_data.constructor_receiver_expr = receiver;
+        }
+    }
     return call_expr;
 }
 

--- a/KGPC/CodeGenerator/Intel_x86-64/expr_tree/expr_tree.c
+++ b/KGPC/CodeGenerator/Intel_x86-64/expr_tree/expr_tree.c
@@ -3102,9 +3102,28 @@ ListNode_t *gencode_case0(expr_node_t *node, ListNode_t *inst_list, CodeGenConte
              * codegen_pass_arguments. */
             self_index = arg_start_index;
 
-            /* Skip the first argument (class type) in the argument list */
-            if (args_to_pass != NULL)
-                args_to_pass = args_to_pass->next;
+            /* Skip the first argument (class type / Self placeholder) unless
+             * the constructor was set up from a STMT_PROCEDURE_CALL path where
+             * the type receiver was already removed by the semcheck.  In that
+             * case, constructor_receiver_expr is set but the first arg is a
+             * real user argument, not a placeholder to skip. */
+            {
+                int skip_first = 1;
+                if (expr->expr_data.function_call_data.constructor_receiver_expr != NULL &&
+                    args_to_pass != NULL)
+                {
+                    struct Expression *fa = (struct Expression *)args_to_pass->cur;
+                    if (fa != NULL && fa->type != EXPR_NIL)
+                    {
+                        /* First arg is not a Self placeholder — it's a real arg.
+                         * The class was derived from constructor_receiver_expr
+                         * which was set by the proc_call codegen path. */
+                        skip_first = 0;
+                    }
+                }
+                if (skip_first && args_to_pass != NULL)
+                    args_to_pass = args_to_pass->next;
+            }
             /* Shift register allocation by 1 for Self parameter */
             arg_start_index += 1;
         }

--- a/KGPC/CodeGenerator/Intel_x86-64/expr_tree/expr_tree.c
+++ b/KGPC/CodeGenerator/Intel_x86-64/expr_tree/expr_tree.c
@@ -2989,19 +2989,13 @@ ListNode_t *gencode_case0(expr_node_t *node, ListNode_t *inst_list, CodeGenConte
                 if (codegen_sizeof_record_type(ctx, class_record, &instance_size) == 0 &&
                     instance_size > 0)
                 {
-                    /* Allocate memory using calloc to zero-initialize all fields */
-                    const char *calloc_arg1_reg = codegen_target_is_windows() ? "%rcx" : "%rdi";
-                    const char *calloc_arg2_reg = codegen_target_is_windows() ? "%rdx" : "%rsi";
-                    
-                    /* calloc(1, size) - allocate 1 element of instance_size bytes, zeroed */
-                    snprintf(buffer, sizeof(buffer), "\tmovq\t$1, %s\n", calloc_arg1_reg);
-                    inst_list = add_inst(inst_list, buffer);
+                    /* Allocate memory through the runtime helper. */
+                    const char *alloc_arg_reg = codegen_target_is_windows() ? "%rcx" : "%rdi";
                     snprintf(buffer, sizeof(buffer), "\tmovq\t$%lld, %s\n",
-                        instance_size, calloc_arg2_reg);
+                        instance_size, alloc_arg_reg);
                     inst_list = add_inst(inst_list, buffer);
-                    
                     inst_list = codegen_vect_reg(inst_list, 0);
-                    inst_list = codegen_call_with_shadow_space(inst_list, "calloc");
+                    inst_list = codegen_call_with_shadow_space(inst_list, "kgpc_allocmem");
                     free_arg_regs();
                     
                     /* Save the allocated instance pointer */

--- a/KGPC/Parser/ParseTree/from_cparser_parts/from_cparser_expressions.c
+++ b/KGPC/Parser/ParseTree/from_cparser_parts/from_cparser_expressions.c
@@ -1678,16 +1678,17 @@ struct Expression *convert_member_access(ast_t *node) {
         /* Prepend base expression to args */
         args_list = PushListNodeFront(args_list, CreateListNode(base_expr, LIST_EXPR));
         
-        struct Expression *call_expr = (struct Expression *)calloc(1, sizeof(struct Expression));
-        call_expr->line_num = node->line;
-        call_expr->type = EXPR_FUNCTION_CALL;
-        call_expr->expr_data.function_call_data.id = method_id;
-        call_expr->expr_data.function_call_data.args_expr = args_list;
-        call_expr->expr_data.function_call_data.resolved_func = NULL;
-        call_expr->expr_data.function_call_data.is_method_call_placeholder = 1;
-        call_expr->expr_data.function_call_data.placeholder_method_name = strdup(method_id);
+        struct Expression *call_expr = mk_functioncall(node->line, method_id, args_list);
+        if (call_expr != NULL)
+        {
+            call_expr->expr_data.function_call_data.is_method_call_placeholder = 1;
+            call_expr->expr_data.function_call_data.placeholder_method_name = strdup(method_id);
+            return call_expr;
+        }
 
-        return call_expr;
+        free(method_id);
+        destroy_list(args_list);
+        return NULL;
     }
 
     struct Expression *record_expr = convert_expression(base_node);
@@ -1845,19 +1846,21 @@ static struct Expression *convert_member_access_chain(int line,
                 args_list = PushListNodeFront(args_list, base_node_list);
             }
             
-            struct Expression *call_expr = (struct Expression *)calloc(1, sizeof(struct Expression));
-            call_expr->line_num = line;
-            call_expr->type = EXPR_FUNCTION_CALL;
-            call_expr->expr_data.function_call_data.id = method_id;
-            call_expr->expr_data.function_call_data.args_expr = args_list;
-            call_expr->expr_data.function_call_data.resolved_func = NULL;
-            call_expr->resolved_kgpc_type = NULL;
-            call_expr->expr_data.function_call_data.is_method_call_placeholder = 1;
-            call_expr->expr_data.function_call_data.placeholder_method_name =
-                (placeholder_name != NULL) ? placeholder_name : strdup(method_id);
-            placeholder_name = NULL;
+            struct Expression *call_expr = mk_functioncall(line, method_id, args_list);
+            if (call_expr != NULL)
+            {
+                call_expr->expr_data.function_call_data.is_method_call_placeholder = 1;
+                call_expr->expr_data.function_call_data.placeholder_method_name =
+                    (placeholder_name != NULL) ? placeholder_name : strdup(method_id);
+                placeholder_name = NULL;
+                return call_expr;
+            }
 
-            return call_expr;
+            if (placeholder_name != NULL)
+                free(placeholder_name);
+            free(method_id);
+            destroy_list(args_list);
+            return NULL;
         }
         if (placeholder_name != NULL)
             free(placeholder_name);
@@ -1893,16 +1896,17 @@ static struct Expression *convert_member_access_chain(int line,
         /* Prepend base expression to args */
         args_list = PushListNodeFront(args_list, CreateListNode(base_expr, LIST_EXPR));
         
-        struct Expression *call_expr = (struct Expression *)calloc(1, sizeof(struct Expression));
-        call_expr->line_num = line;
-        call_expr->type = EXPR_FUNCTION_CALL;
-        call_expr->expr_data.function_call_data.id = method_id;
-        call_expr->expr_data.function_call_data.args_expr = args_list;
-        call_expr->expr_data.function_call_data.resolved_func = NULL;
-        call_expr->expr_data.function_call_data.is_method_call_placeholder = 1;
-        call_expr->expr_data.function_call_data.placeholder_method_name = strdup(method_id);
+        struct Expression *call_expr = mk_functioncall(line, method_id, args_list);
+        if (call_expr != NULL)
+        {
+            call_expr->expr_data.function_call_data.is_method_call_placeholder = 1;
+            call_expr->expr_data.function_call_data.placeholder_method_name = strdup(method_id);
+            return call_expr;
+        }
 
-        return call_expr;
+        free(method_id);
+        destroy_list(args_list);
+        return NULL;
     }
 
     if (unwrapped == NULL)
@@ -2421,4 +2425,3 @@ struct Statement *build_nested_with_statements(int line,
 
     return mk_with(line, expr, inner_stmt);
 }
-

--- a/KGPC/Parser/ParseTree/tree.c
+++ b/KGPC/Parser/ParseTree/tree.c
@@ -1422,9 +1422,10 @@ void destroy_tree(Tree_t *tree)
 
         case TREE_TYPE_DECL:
             free(tree->tree_data.type_decl_data.id);
-            if (tree->tree_data.type_decl_data.kgpc_type != NULL)
+            KgpcType *decl_kgpc_type = tree->tree_data.type_decl_data.kgpc_type;
+            if (decl_kgpc_type != NULL)
             {
-                destroy_kgpc_type(tree->tree_data.type_decl_data.kgpc_type);
+                destroy_kgpc_type(decl_kgpc_type);
                 tree->tree_data.type_decl_data.kgpc_type = NULL;
             }
             if (tree->tree_data.type_decl_data.kind == TYPE_DECL_RECORD)
@@ -1432,6 +1433,11 @@ void destroy_tree(Tree_t *tree)
             else if (tree->tree_data.type_decl_data.kind == TYPE_DECL_ALIAS)
             {
                 struct TypeAlias *alias = &tree->tree_data.type_decl_data.info.alias;
+                if (alias->kgpc_type != NULL && alias->kgpc_type != decl_kgpc_type)
+                {
+                    destroy_kgpc_type(alias->kgpc_type);
+                    alias->kgpc_type = NULL;
+                }
                 clear_type_alias_fields(alias);
             }
             else if (tree->tree_data.type_decl_data.kind == TYPE_DECL_GENERIC)
@@ -3535,6 +3541,16 @@ static void clear_type_alias_fields(struct TypeAlias *alias)
         destroy_list(alias->array_dimensions);
         alias->array_dimensions = NULL;
     }
+    if (alias->array_dim_start_str != NULL)
+    {
+        free(alias->array_dim_start_str);
+        alias->array_dim_start_str = NULL;
+    }
+    if (alias->array_dim_end_str != NULL)
+    {
+        free(alias->array_dim_end_str);
+        alias->array_dim_end_str = NULL;
+    }
     if (alias->pointer_type_id != NULL)
     {
         free(alias->pointer_type_id);
@@ -3597,6 +3613,7 @@ static void clear_type_alias_fields(struct TypeAlias *alias)
     }
     alias->is_char_alias = 0;
     alias->is_shortstring = 0;
+    alias->array_dims_parsed = 0;
     alias->enum_is_scoped = 0;
     alias->enum_has_explicit_values = 0;
     alias->is_range = 0;

--- a/KGPC/Parser/ParseTree/tree_types.h
+++ b/KGPC/Parser/ParseTree/tree_types.h
@@ -309,6 +309,8 @@ struct Statement
             int vmt_index;                   /* VMT index for virtual calls (-1 if not set) */
             char *self_class_name;           /* Class name for VMT lookup in virtual calls */
             int is_class_method_call;        /* 1 if calling a class method (Self = VMT, not instance) */
+            int is_constructor_call;         /* 1 if this is a class constructor call (needs object allocation) */
+            char *constructor_class_name;    /* Class to allocate for constructor calls (NULL if not constructor) */
             char *call_qualifier;            /* Unit prefix if call was qualified, e.g. "System" (NULL if unqualified) */
         } procedure_call_data;
 

--- a/KGPC/Parser/SemanticCheck/SemCheck_parts/SemCheck_env_types_errors.c
+++ b/KGPC/Parser/SemanticCheck/SemCheck_parts/SemCheck_env_types_errors.c
@@ -1245,11 +1245,17 @@ ListNode_t *semcheck_create_builtin_param(const char *name, int type_tag)
 
     ListNode_t *ids = CreateListNode(param_name, LIST_STRING);
     if (ids == NULL)
+    {
+        free(param_name);
         return NULL;
+    }
 
     Tree_t *decl = mk_vardecl(0, ids, type_tag, NULL, 0, 0, NULL, NULL, NULL, NULL);
     if (decl == NULL)
+    {
+        destroy_list(ids);
         return NULL;
+    }
 
     return CreateListNode(decl, LIST_TREE);
 }
@@ -1262,11 +1268,17 @@ ListNode_t *semcheck_create_builtin_param_var(const char *name, int type_tag)
 
     ListNode_t *ids = CreateListNode(param_name, LIST_STRING);
     if (ids == NULL)
+    {
+        free(param_name);
         return NULL;
+    }
 
     Tree_t *decl = mk_vardecl(0, ids, type_tag, NULL, 1, 0, NULL, NULL, NULL, NULL);
     if (decl == NULL)
+    {
+        destroy_list(ids);
         return NULL;
+    }
 
     return CreateListNode(decl, LIST_TREE);
 }
@@ -1280,7 +1292,10 @@ __attribute__((unused)) static ListNode_t *semcheck_create_builtin_param_with_id
 
     ListNode_t *ids = CreateListNode(param_name, LIST_STRING);
     if (ids == NULL)
+    {
+        free(param_name);
         return NULL;
+    }
 
     char *type_id_copy = NULL;
     if (type_id != NULL)
@@ -1290,6 +1305,7 @@ __attribute__((unused)) static ListNode_t *semcheck_create_builtin_param_with_id
         is_var_param, 0, NULL, NULL, NULL, NULL);
     if (decl == NULL)
     {
+        destroy_list(ids);
         if (type_id_copy != NULL)
             free(type_id_copy);
         return NULL;
@@ -2481,4 +2497,3 @@ int semcheck_id_not_main(char *id)
     }
     return 0;
 }
-

--- a/KGPC/Parser/SemanticCheck/SemCheck_parts/SemCheck_subprograms.c
+++ b/KGPC/Parser/SemanticCheck/SemCheck_parts/SemCheck_subprograms.c
@@ -602,8 +602,6 @@ int semcheck_subprogram(SymTab_t *symtab, Tree_t *subprogram, int max_scope_lev)
         if (result_check == NULL)
         {
             /* "Result" is not already declared in this scope, so add it as an alias */
-            if (return_kgpc_type != NULL)
-                kgpc_type_retain(return_kgpc_type);
             PushFuncRetOntoScope_Typed(symtab, "Result", return_kgpc_type);
             if (kgpc_getenv("KGPC_DEBUG_RESULT") != NULL)
             {
@@ -857,9 +855,6 @@ int semcheck_subprogram(SymTab_t *symtab, Tree_t *subprogram, int max_scope_lev)
                             }
                             if (param_type != NULL &&
                                 param_type == param_tree->tree_data.var_decl_data.cached_kgpc_type)
-                            {
-                                kgpc_type_retain(param_type);
-                            }
                             PushVarOntoScope_Typed(symtab, (char *)ids->cur, param_type);
                             if (param_type != NULL &&
                                 param_type != param_tree->tree_data.var_decl_data.cached_kgpc_type)
@@ -974,14 +969,13 @@ int semcheck_subprogram(SymTab_t *symtab, Tree_t *subprogram, int max_scope_lev)
 
             if (self_type != NULL)
             {
-                if (FindSymbol(&self_node, symtab, "Self") == 0)
-                {
-                    /* Push Self to the method scope (stack head) so it is cleaned up
-                     * when the method exits. */
-                    kgpc_type_retain(self_type);
-                    PushVarOntoScope_Typed(symtab, "Self", self_type);
-                    if (FindSymbol(&self_node, symtab, "Self") != 0 && self_node != NULL)
-                        self_node->is_var_parameter = self_is_var_param;
+                    if (FindSymbol(&self_node, symtab, "Self") == 0)
+                    {
+                        /* Push Self to the method scope (stack head) so it is cleaned up
+                         * when the method exits. */
+                        PushVarOntoScope_Typed(symtab, "Self", self_type);
+                        if (FindSymbol(&self_node, symtab, "Self") != 0 && self_node != NULL)
+                            self_node->is_var_parameter = self_is_var_param;
                     if (trace_nonlocal != NULL)
                     {
                         fprintf(stderr,

--- a/KGPC/Parser/SemanticCheck/SemChecks/SemCheck_Expr_Ops.c
+++ b/KGPC/Parser/SemanticCheck/SemChecks/SemCheck_Expr_Ops.c
@@ -2515,6 +2515,11 @@ int semcheck_varid(int *type_return,
         expr->expr_data.record_access_data.field_offset = 0;
         return semcheck_recordaccess(type_return, symtab, expr, max_scope_lev, mutating);
     }
+    if (with_expr != NULL)
+    {
+        destroy_expr(with_expr);
+        with_expr = NULL;
+    }
     if (with_status == 1 && with_context_count > 0 && id != NULL &&
         !direct_current_scope_value)
     {

--- a/KGPC/Parser/SemanticCheck/SemChecks/SemCheck_stmt.c
+++ b/KGPC/Parser/SemanticCheck/SemChecks/SemCheck_stmt.c
@@ -6119,6 +6119,22 @@ int semcheck_proccall(SymTab_t *symtab, struct Statement *stmt, int max_scope_le
                         }
                         else
                         {
+                            /* Check if this is a constructor call (e.g., TMyItem.Create(...)).
+                             * If so, mark it for the codegen so it allocates a new instance. */
+                            int is_ctor = 0;
+                            if (strncasecmp(method_name, "Create", 6) == 0)
+                            {
+                                struct MethodTemplate *tmpl =
+                                    from_cparser_get_method_template(record_info, method_name);
+                                if (tmpl != NULL && tmpl->kind == METHOD_TEMPLATE_CONSTRUCTOR)
+                                    is_ctor = 1;
+                            }
+                            if (is_ctor)
+                            {
+                                stmt->stmt_data.procedure_call_data.is_constructor_call = 1;
+                                stmt->stmt_data.procedure_call_data.constructor_class_name =
+                                    strdup(record_info->type_id);
+                            }
                             ListNode_t *remaining_args = args_given->next;
                             destroy_expr(first_arg);
                             args_given->cur = NULL;

--- a/KGPC/runtime.c
+++ b/KGPC/runtime.c
@@ -2755,6 +2755,8 @@ void Initialize(void *value)
     (void)value;
 }
 
+static void *kgpc_memory_manager_allocmem(uintptr_t size);
+
 /* Generic default constructor for classes without explicit constructors */
 /* Initialize interface vtable pointer slots in a class instance.
  * For each interface the class implements, the instance has a slot at
@@ -2794,7 +2796,7 @@ void __kgpc_init_interface_vtables(void *instance)
 void *__kgpc_default_create(size_t class_size, const void *vmt_ptr)
 {
     /* Allocate and zero-initialize the class instance */
-    void *instance = calloc(1, class_size);
+    void *instance = kgpc_memory_manager_allocmem((uintptr_t)class_size);
     if (instance == NULL)
     {
         fprintf(stderr, "KGPC runtime: failed to allocate %zu bytes for class instance.\\n", class_size);
@@ -2828,6 +2830,7 @@ static void *const KGPC_STRING_TOMBSTONE = (void *)1;
 static void **kgpc_string_set_slots = NULL;
 static size_t kgpc_string_set_cap = 0;
 static size_t kgpc_string_set_count = 0;
+static int kgpc_string_cleanup_registered = 0;
 
 static size_t kgpc_hash_ptr(const void *value)
 {
@@ -2872,10 +2875,38 @@ static void kgpc_string_set_grow(size_t new_cap)
     }
 }
 
+static void kgpc_string_set_cleanup(void)
+{
+    if (kgpc_string_set_slots == NULL)
+        return;
+
+    for (size_t i = 0; i < kgpc_string_set_cap; i++)
+    {
+        void *entry = kgpc_string_set_slots[i];
+        if (entry == NULL || entry == KGPC_STRING_TOMBSTONE)
+            continue;
+        KgpcStringHeader *hdr =
+            (KgpcStringHeader *)((char *)entry - (int64_t)sizeof(KgpcStringHeader));
+        free(hdr);
+        kgpc_string_set_slots[i] = NULL;
+    }
+
+    free(kgpc_string_set_slots);
+    kgpc_string_set_slots = NULL;
+    kgpc_string_set_cap = 0;
+    kgpc_string_set_count = 0;
+    kgpc_string_cleanup_registered = 0;
+}
+
 static void kgpc_string_set_insert(const void *value)
 {
     if (value == NULL || value == KGPC_STRING_TOMBSTONE)
         return;
+    if (!kgpc_string_cleanup_registered)
+    {
+        if (atexit(kgpc_string_set_cleanup) == 0)
+            kgpc_string_cleanup_registered = 1;
+    }
     for (;;)
     {
         if (kgpc_string_set_cap == 0)
@@ -3136,6 +3167,7 @@ void FPC_ANSISTR_UNIQUE(char **value)
     new_hdr->length = len;
     char *new_data = new_str + sizeof(KgpcStringHeader);
     memcpy(new_data, *value, len + 1);
+    kgpc_string_set_insert(new_data);
     kgpc_string_release(*value);
     *value = new_data;
 }
@@ -4519,6 +4551,20 @@ static uintptr_t kgpc_mm_memsize(void *p)
 }
 
 static void kgpc_mm_noop(void) {}
+
+typedef void *(*kgpc_mm_allocmem_fn)(uintptr_t size);
+
+static void *kgpc_memory_manager_allocmem(uintptr_t size)
+{
+    if (size == 0)
+        return NULL;
+
+    kgpc_mm_allocmem_fn alloc_fn = NULL;
+    memcpy(&alloc_fn, MemoryManager + 32, sizeof(alloc_fn));
+    if (alloc_fn == NULL)
+        return kgpc_mm_allocmem(size);
+    return alloc_fn(size);
+}
 
 __attribute__((constructor))
 static void kgpc_init_memory_manager(void)

--- a/tests/do_not_run_me_directly_but_through_meson.py
+++ b/tests/do_not_run_me_directly_but_through_meson.py
@@ -1351,6 +1351,8 @@ class TestCompiler(unittest.TestCase):
     def _callTestMethod(self, method):
         try:
             super()._callTestMethod(method)
+        except unittest.SkipTest:
+            raise
         except Exception:
             if FAILURE_ARTIFACT_DIR is not None:
                 ctx = self._artifact_context or {}

--- a/tests/do_not_run_me_directly_but_through_meson.py
+++ b/tests/do_not_run_me_directly_but_through_meson.py
@@ -1751,7 +1751,7 @@ class TestCompiler(unittest.TestCase):
             )
 
         # 2. Verify the expected call sequence:
-        #    calloc → save instance → VMT init → Self move → call constructor.
+        #    allocation helper → save instance → VMT init → Self move → call constructor.
         #    There must be exactly ONE movq into the first arg register between
         #    the VMT store and the constructor call.
         call_idx = None
@@ -1761,21 +1761,22 @@ class TestCompiler(unittest.TestCase):
                 break
         self.assertIsNotNone(call_idx, "constructor call not found in assembly")
 
-        # Count movq ..., <first_arg_reg> instructions between calloc return and the call.
-        calloc_idx = None
+        # Count movq ..., <first_arg_reg> instructions between the instance allocation
+        # helper return and the constructor call.
+        alloc_idx = None
         for i in range(call_idx - 1, -1, -1):
-            if "\tcall\tcalloc" in asm_lines[i]:
-                calloc_idx = i
+            if "\tcall\tkgpc_allocmem" in asm_lines[i] or "\tcall\tcalloc" in asm_lines[i]:
+                alloc_idx = i
                 break
-        self.assertIsNotNone(calloc_idx, "calloc call not found before constructor")
+        self.assertIsNotNone(alloc_idx, "allocation call not found before constructor")
 
         self_moves = [
-            line for line in asm_lines[calloc_idx:call_idx]
+            line for line in asm_lines[alloc_idx:call_idx]
             if line.startswith("\tmovq\t") and line.endswith(f", {first_arg_reg}")
         ]
         self.assertEqual(
             len(self_moves), 1,
-            f"Expected exactly 1 Self-move into {first_arg_reg} between calloc and constructor call, "
+            f"Expected exactly 1 Self-move into {first_arg_reg} between allocation and constructor call, "
             f"found {len(self_moves)}: {self_moves}",
         )
 


### PR DESCRIPTION
## Summary by Sourcery

Route class instance allocation and destruction through the KGPC runtime memory manager, tighten constructor/Free codegen semantics, and fix assorted leaks and lifetime issues in parsing, semantic analysis, and string/runtime handling.

New Features:
- Mark and propagate constructor calls from semantic checking through to code generation so that constructor-as-statement calls allocate class instances correctly.
- Track and register all created AnsiStrings in a runtime set with an atexit cleanup hook to reclaim leaked strings.

Bug Fixes:
- Avoid memory leaks and double-frees in type declarations and aliases by carefully destroying shared KgpcType instances and alias-owned resources.
- Prevent leaks in builtin parameter creation and member access conversion by freeing allocated strings and lists on error paths.
- Fix WITH-context handling so temporary with-expressions are destroyed when not used for record access, avoiding leaks.
- Ensure static array assignments from array literals treat the literal as a static array copy and dereference its descriptor correctly.
- Generate correct-sized stores for record element assignments by using the record element size to choose byte/word moves.
- Fix shortstring conversion of char-typed arguments by promoting chars to AnsiString before calling the string conversion helper, preventing invalid pointer dereferences.
- Ensure skipping of constructor Self placeholders in argument lists is correct for both expression and statement-based constructor calls, avoiding misaligned arguments.
- Preserve test failure artifact capture behavior while letting explicitly skipped unittest cases propagate SkipTest instead of being treated as errors.

Enhancements:
- Refactor parser member access conversion to use the mk_functioncall helper for method call placeholders, centralizing function call expression construction.
- Use the runtime memory manager allocmem helper instead of direct calloc for class and record allocations in the code generator, improving integration with the Pascal heap and future custom allocators.
- Initialize constructor return values from Self in generic function codegen paths so constructors reliably return the allocated instance.
- Add runtime abstraction for memory-manager-based allocation and use it in the default class constructor to zero-initialize instances via the configured allocator.
- Improve constructor call modeling in codegen by synthesizing a constructor_receiver_expr for constructor-as-statement calls so codegen can derive the target class.
- Update tests and comments to reflect the new allocation helper instead of direct calloc, keeping test expectations aligned with codegen output.

Tests:
- Adjust assembly-based tests for constructor call sequences to look for the new allocation helper and maintain the invariant of a single Self move before the constructor call.

Chores:
- Minor whitespace cleanup and defensive null checks in various parser and semantic checker utilities to improve robustness without changing behavior.