### PR TITLE
Fix memory leak in KgpcType record cloning

### DIFF
--- a/KGPC/Parser/ParseTree/KgpcType.c
+++ b/KGPC/Parser/ParseTree/KgpcType.c
@@ -772,7 +772,7 @@ KgpcType* kgpc_type_clone_shallow_owned(const KgpcType *src)
                     strdup(src->info.proc_info.return_type_id) : NULL;
             break;
         case TYPE_KIND_RECORD:
-            clone->info.record_info = clone_record_type(src->info.record_info);
+            clone->info.record_info = src->info.record_info;
             break;
         case TYPE_KIND_ARRAY_OF_CONST:
             clone->info.array_of_const_info.element_size =

--- a/KGPC/Parser/SemanticCheck/SemCheck_parts/SemCheck_symbols_and_class.c
+++ b/KGPC/Parser/SemanticCheck/SemCheck_parts/SemCheck_symbols_and_class.c
@@ -1378,20 +1378,12 @@ void mark_hashnode_unit_info(SymTab_t *symtab, HashNode_t *node,
     {
         if (symtab->current_scope != NULL && symtab->current_scope != symtab->builtin_scope)
         {
-            KgpcType *qualified_type = NULL;
             if (node->type != NULL)
-            {
-                qualified_type = kgpc_type_clone_shallow_owned(node->type);
-                if (qualified_type == NULL)
-                {
-                    free(qualified_id);
-                    return;
-                }
-            }
+                kgpc_type_retain(node->type);
             (void)AddIdentToTable(symtab->current_scope->table, qualified_id,
-                NULL, HASHTYPE_TYPE, qualified_type);
-            if (qualified_type != NULL)
-                kgpc_type_release(qualified_type);
+                NULL, HASHTYPE_TYPE, node->type);
+            if (node->type != NULL)
+                kgpc_type_release(node->type);
             if (FindSymbol(&existing, symtab, qualified_id) != 0 && existing != NULL)
             {
                 existing->defined_in_unit = 1;


### PR DESCRIPTION
Modified kgpc_type_clone_shallow_owned to perform a truly shallow clone for record types, avoiding unnecessary and leaky deep clones of RecordType structures. Additionally optimized mark_hashnode_unit_info to use reference counting (retain/release) instead of cloning when creating unit-qualified identifiers for types. This significantly reduces memory usage and addresses the largest reported leak when compiling complex FPC units like SysUtils.

---
*PR created automatically by Jules for task [4366297777309951960](https://jules.google.com/task/4366297777309951960) started by @Kreijstal*

## Summary by Sourcery

Fix memory leaks and unnecessary deep cloning in type handling for record and unit-qualified types.

Bug Fixes:
- Avoid leaking RecordType structures by making shallow clones reuse existing record_info instead of deep cloning.
- Prevent redundant type clones when creating unit-qualified identifiers by using reference counting retain/release semantics instead.

Enhancements:
- Simplify mark_hashnode_unit_info to operate directly on retained types instead of temporary cloned copies.