### PR TITLE
hello_world

### DIFF
--- a/KGPC/CodeGenerator/Intel_x86-64/codegen.c
+++ b/KGPC/CodeGenerator/Intel_x86-64/codegen.c
@@ -7938,6 +7938,7 @@ void codegen_procedure(Tree_t *proc_tree, CodeGenContext *ctx, SymTab_t *symtab)
     const char *prev_sub_owner_class = ctx->current_subprogram_owner_class;
     const char *prev_sub_owner_class_full = ctx->current_subprogram_owner_class_full;
     int prev_is_nonstatic_class_method = ctx->current_subprogram_is_nonstatic_class_method;
+    ListNode_t *prev_sub_args = ctx->current_subprogram_args;
     StackNode_t *prev_return_slot = ctx->current_return_slot;
     KgpcType *prev_return_type = ctx->current_return_type;
     int prev_callee_rbx = ctx->callee_save_rbx_offset;
@@ -7976,6 +7977,7 @@ void codegen_procedure(Tree_t *proc_tree, CodeGenContext *ctx, SymTab_t *symtab)
     ctx->current_subprogram_is_nonstatic_class_method =
         (proc->owner_class != NULL && proc->method_name != NULL &&
          from_cparser_is_method_nonstatic_class_method(proc->owner_class, proc->method_name));
+    ctx->current_subprogram_args = proc->args_var;
     ctx->current_return_slot = NULL;
     ctx->current_return_type = NULL;
     EnterScope(symtab, 0);
@@ -8010,7 +8012,7 @@ void codegen_procedure(Tree_t *proc_tree, CodeGenContext *ctx, SymTab_t *symtab)
      * even if they don't themselves capture any outer scope state. Class methods still
      * use the implicit `self` parameter instead. Top-level procedures do not receive
      * a static link. */
-    int will_need_static_link = (!is_class_method && lexical_depth > 1);
+    int will_need_static_link = (!is_class_method && is_nested_function);
     
     /* If there are arguments and we'll need a static link, shift argument registers by 1 */
     int arg_start_index = (will_need_static_link && num_args > 0) ? 1 : 0;
@@ -8026,16 +8028,6 @@ void codegen_procedure(Tree_t *proc_tree, CodeGenContext *ctx, SymTab_t *symtab)
          * This ensures it doesn't overlap with argument storage */
         static_link = add_l_x("__static_link__", 8);
         codegen_register_static_link_proc(ctx, sub_id, lexical_depth);
-    }
-    
-    if (static_link != NULL)
-    {
-        char buffer[64];
-        /* Static link always comes in the first argument register (platform-dependent) */
-        const char *link_reg = current_arg_reg64(0);
-        assert(link_reg != NULL && "current_arg_reg64(0) should never return NULL");
-        snprintf(buffer, sizeof(buffer), "\tmovq\t%s, -%d(%%rbp)\n", link_reg, static_link->offset);
-        inst_list = add_inst(inst_list, buffer);
     }
     
     codegen_function_locals(proc->declarations, ctx, symtab);
@@ -8174,6 +8166,20 @@ void codegen_procedure(Tree_t *proc_tree, CodeGenContext *ctx, SymTab_t *symtab)
         }
     }
     
+    if (static_link != NULL)
+    {
+        char buffer[64];
+        const char *link_reg = current_arg_reg64(0);
+        ListNode_t *static_link_inst = NULL;
+        assert(link_reg != NULL && "current_arg_reg64(0) should never return NULL");
+        snprintf(buffer, sizeof(buffer), "\tmovq\t%s, -%d(%%rbp)\n",
+            link_reg, static_link->offset);
+        add_inst_invalidate_cache();
+        static_link_inst = add_inst(static_link_inst, buffer);
+        add_inst_invalidate_cache();
+        inst_list = ConcatList(static_link_inst, inst_list);
+    }
+
     codegen_emit_local_const_equivs(ctx, symtab);
     codegen_emit_const_decl_equivs_from_list(ctx, proc->const_declarations);
     codegen_function_header_ex_alias_vis(sub_id, ctx, proc->nostackframe, proc->cname_override, proc->defined_in_unit);
@@ -8194,6 +8200,7 @@ void codegen_procedure(Tree_t *proc_tree, CodeGenContext *ctx, SymTab_t *symtab)
     ctx->current_subprogram_owner_class = prev_sub_owner_class;
     ctx->current_subprogram_owner_class_full = prev_sub_owner_class_full;
     ctx->current_subprogram_is_nonstatic_class_method = prev_is_nonstatic_class_method;
+    ctx->current_subprogram_args = prev_sub_args;
     ctx->current_return_slot = prev_return_slot;
     ctx->current_return_type = prev_return_type;
     ctx->current_subprogram_lexical_depth = prev_depth;
@@ -8251,6 +8258,7 @@ void codegen_function(Tree_t *func_tree, CodeGenContext *ctx, SymTab_t *symtab)
     const char *prev_sub_owner_class = ctx->current_subprogram_owner_class;
     const char *prev_sub_owner_class_full = ctx->current_subprogram_owner_class_full;
     int prev_is_nonstatic_class_method = ctx->current_subprogram_is_nonstatic_class_method;
+    ListNode_t *prev_sub_args = ctx->current_subprogram_args;
     StackNode_t *prev_return_slot = ctx->current_return_slot;
     KgpcType *prev_return_type = ctx->current_return_type;
     int prev_callee_rbx = ctx->callee_save_rbx_offset;
@@ -8289,6 +8297,7 @@ void codegen_function(Tree_t *func_tree, CodeGenContext *ctx, SymTab_t *symtab)
     ctx->current_subprogram_is_nonstatic_class_method =
         (func->owner_class != NULL && func->method_name != NULL &&
          from_cparser_is_method_nonstatic_class_method(func->owner_class, func->method_name));
+    ctx->current_subprogram_args = func->args_var;
     ctx->current_return_slot = NULL;
     ctx->current_return_type = NULL;
     EnterScope(symtab, 0);
@@ -8703,7 +8712,7 @@ void codegen_function(Tree_t *func_tree, CodeGenContext *ctx, SymTab_t *symtab)
         ctx->current_return_type = codegen_canonical_shortstring_type();
 
     /* Only nested functions receive static links (excluding class methods). */
-    int will_need_static_link = (!is_class_method && lexical_depth > 1);
+    int will_need_static_link = (!is_class_method && is_nested_function);
     
     /* Calculate argument start index:
      * - If function returns record: use index 1 (record pointer in first arg)
@@ -8725,17 +8734,6 @@ void codegen_function(Tree_t *func_tree, CodeGenContext *ctx, SymTab_t *symtab)
         /* Reserve space for static link after arguments */
         static_link = add_l_x("__static_link__", 8);
         codegen_register_static_link_proc(ctx, sub_id, lexical_depth);
-    }
-    
-    if (static_link != NULL)
-    {
-        char link_buffer[64];
-        /* Static link comes in the register right after the record return pointer (if any) */
-        const char *link_reg = current_arg_reg64(has_record_return ? 1 : 0);
-        assert(link_reg != NULL && "current_arg_reg64() should never return NULL for valid indices");
-        snprintf(link_buffer, sizeof(link_buffer), "\tmovq\t%s, -%d(%%rbp)\n",
-            link_reg, static_link->offset);
-        inst_list = add_inst(inst_list, link_buffer);
     }
     
     int return_size = DOUBLEWORD;
@@ -9112,6 +9110,20 @@ void codegen_function(Tree_t *func_tree, CodeGenContext *ctx, SymTab_t *symtab)
         inst_list = add_inst(inst_list, buffer);
     }
 
+    if (static_link != NULL)
+    {
+        char link_buffer[64];
+        const char *link_reg = current_arg_reg64(has_record_return ? 1 : 0);
+        ListNode_t *static_link_inst = NULL;
+        assert(link_reg != NULL && "current_arg_reg64() should never return NULL for valid indices");
+        snprintf(link_buffer, sizeof(link_buffer), "\tmovq\t%s, -%d(%%rbp)\n",
+            link_reg, static_link->offset);
+        add_inst_invalidate_cache();
+        static_link_inst = add_inst(static_link_inst, link_buffer);
+        add_inst_invalidate_cache();
+        inst_list = ConcatList(static_link_inst, inst_list);
+    }
+
     codegen_emit_local_const_equivs(ctx, symtab);
     codegen_emit_const_decl_equivs_from_list(ctx, func->const_declarations);
     codegen_function_header_ex_alias_vis(sub_id, ctx, func->nostackframe, func->cname_override, func->defined_in_unit);
@@ -9132,6 +9144,7 @@ void codegen_function(Tree_t *func_tree, CodeGenContext *ctx, SymTab_t *symtab)
     ctx->current_subprogram_owner_class = prev_sub_owner_class;
     ctx->current_subprogram_owner_class_full = prev_sub_owner_class_full;
     ctx->current_subprogram_is_nonstatic_class_method = prev_is_nonstatic_class_method;
+    ctx->current_subprogram_args = prev_sub_args;
     ctx->current_return_slot = prev_return_slot;
     ctx->current_return_type = prev_return_type;
     ctx->current_subprogram_lexical_depth = prev_depth;

--- a/KGPC/CodeGenerator/Intel_x86-64/codegen.h
+++ b/KGPC/CodeGenerator/Intel_x86-64/codegen.h
@@ -274,6 +274,7 @@ typedef struct CodeGenContext {
     const char *current_subprogram_owner_class;   /* Innermost owning class name (NULL for non-methods) */
     const char *current_subprogram_owner_class_full; /* Full dotted class path (NULL if non-nested) */
     int current_subprogram_is_nonstatic_class_method; /* 1 if current subprogram is a class function/procedure (Self = VMT ptr) */
+    ListNode_t *current_subprogram_args;
     StackNode_t *current_return_slot;
     KgpcType *current_return_type;
     ListNode_t *static_link_procs;

--- a/KGPC/CodeGenerator/Intel_x86-64/codegen_expression.c
+++ b/KGPC/CodeGenerator/Intel_x86-64/codegen_expression.c
@@ -36,6 +36,7 @@
 #include "../../Parser/SemanticCheck/SemCheck.h"
 #include "../../identifier_utils.h"
 #include "../../format_arg.h"
+#include "../../unit_registry.h"
 
 
 /* Cached getenv() — defined in SemCheck.c */
@@ -297,6 +298,60 @@ HashNode_t *codegen_find_owner_unit_symbol(CodeGenContext *ctx, const char *id)
         return node;
 
     return FindIdentInTable(unit_scope->table, (char *)id);
+}
+
+HashNode_t *codegen_prefer_visible_var_over_const(CodeGenContext *ctx,
+    const char *id, HashNode_t *node)
+{
+    if (ctx == NULL || ctx->symtab == NULL || id == NULL || node == NULL ||
+        !(node->hash_type == HASHTYPE_CONST || node->is_constant))
+        return node;
+
+    int caller_unit = ctx->symtab->current_unit_index;
+    if (caller_unit <= 0)
+        return node;
+
+    if (!(node->defined_in_unit &&
+          !node->unit_is_public &&
+          node->source_unit_index != caller_unit))
+        return node;
+
+    ListNode_t *matches = FindAllIdents(ctx->symtab, id);
+    HashNode_t *best = node;
+    int best_priority = 0;
+    for (ListNode_t *cur = matches; cur != NULL; cur = cur->next)
+    {
+        HashNode_t *cand = (HashNode_t *)cur->cur;
+        if (cand == NULL ||
+            !(cand->hash_type == HASHTYPE_VAR || cand->hash_type == HASHTYPE_ARRAY))
+            continue;
+        if (cand->defined_in_unit &&
+            !cand->unit_is_public &&
+            cand->source_unit_index != caller_unit)
+            continue;
+
+        int priority = 0;
+        if (cand->source_unit_index == caller_unit)
+            priority = 4;
+        else if (cand->source_unit_index > 0 &&
+                 unit_registry_is_dep(caller_unit, cand->source_unit_index))
+            priority = 3;
+        else if (cand->source_unit_index == 0)
+            priority = 2;
+        else if (cand->source_unit_index > 0 &&
+                 node->source_unit_index != caller_unit)
+            priority = 1;
+
+        if (priority > best_priority)
+        {
+            best = cand;
+            best_priority = priority;
+        }
+    }
+    if (matches != NULL)
+        DestroyList(matches);
+
+    return best;
 }
 
 static ListNode_t *codegen_try_emit_nonlocal_global(ListNode_t *inst_list,
@@ -643,6 +698,61 @@ static int codegen_expr_is_type_identifier(const struct Expression *expr, CodeGe
     return node->hash_type == HASHTYPE_TYPE;
 }
 
+static int codegen_expr_is_class_reference_value(const struct Expression *expr,
+    CodeGenContext *ctx)
+{
+    if (expr == NULL)
+        return 0;
+
+    if (expr->resolved_kgpc_type != NULL)
+    {
+        struct TypeAlias *alias = kgpc_type_get_type_alias(expr->resolved_kgpc_type);
+        if (alias != NULL && alias->is_class_reference)
+            return 1;
+    }
+
+    if (ctx != NULL && ctx->symtab != NULL &&
+        expr->type == EXPR_VAR_ID && expr->expr_data.id != NULL)
+    {
+        HashNode_t *node = NULL;
+        if (FindSymbol(&node, ctx->symtab, expr->expr_data.id) != 0 && node != NULL)
+        {
+            struct TypeAlias *alias = hashnode_get_type_alias(node);
+            if (alias != NULL && alias->is_class_reference)
+                return 1;
+            if (node->type != NULL)
+            {
+                alias = kgpc_type_get_type_alias(node->type);
+                if (alias != NULL && alias->is_class_reference)
+                    return 1;
+            }
+        }
+    }
+
+    if (ctx != NULL && ctx->symtab != NULL &&
+        expr->type == EXPR_TYPECAST &&
+        expr->expr_data.typecast_data.target_type_id != NULL)
+    {
+        HashNode_t *type_node = NULL;
+        if (FindSymbol(&type_node, ctx->symtab,
+                expr->expr_data.typecast_data.target_type_id) != 0 &&
+            type_node != NULL)
+        {
+            struct TypeAlias *alias = hashnode_get_type_alias(type_node);
+            if (alias != NULL && alias->is_class_reference)
+                return 1;
+            if (type_node->type != NULL)
+            {
+                alias = kgpc_type_get_type_alias(type_node->type);
+                if (alias != NULL && alias->is_class_reference)
+                    return 1;
+            }
+        }
+    }
+
+    return 0;
+}
+
 static struct RecordType *codegen_lookup_named_record_type(CodeGenContext *ctx, const char *type_name)
 {
     HashNode_t *node = NULL;
@@ -672,6 +782,8 @@ static int codegen_expr_needs_class_method_vmt_self(const struct Expression *exp
     if (expr == NULL || ctx == NULL)
         return 0;
     if (codegen_expr_is_type_identifier(expr, ctx))
+        return 0;
+    if (codegen_expr_is_class_reference_value(expr, ctx))
         return 0;
 
     record = codegen_expr_record_type(expr, ctx->symtab);
@@ -795,6 +907,12 @@ static int codegen_expr_has_widechar_array_metadata(const struct Expression *exp
 static int codegen_expr_is_shortstring_value(const struct Expression *expr)
 {
     if (expr == NULL)
+        return 0;
+
+    /* String literals are emitted as C/AnsiString data, not as an in-place
+     * FPC ShortString buffer.  When passed to a ShortString formal they must
+     * go through kgpc_string_to_shortstring so the length byte is created. */
+    if (expr->type == EXPR_STRING)
         return 0;
 
     if (codegen_expr_has_widechar_array_metadata(expr))
@@ -958,6 +1076,13 @@ int codegen_expr_is_shortstring_value_ctx(const struct Expression *expr, CodeGen
         HashNode_t *node = NULL;
         if (FindSymbol(&node, ctx->symtab, expr->expr_data.id) != 0 && node != NULL && node->type != NULL)
         {
+            if (kgpc_type_equals_tag(node->type, STRING_TYPE) &&
+                !kgpc_type_is_shortstring(node->type))
+            {
+                struct TypeAlias *alias = kgpc_type_get_type_alias(node->type);
+                if (alias == NULL || !alias->is_shortstring)
+                    return 0;
+            }
             if (kgpc_type_is_shortstring(node->type))
                 return 1;
             struct TypeAlias *alias = kgpc_type_get_type_alias(node->type);
@@ -978,6 +1103,72 @@ int codegen_expr_is_shortstring_value_ctx(const struct Expression *expr, CodeGen
                 }
             }
         }
+    }
+
+    return 0;
+}
+
+static int codegen_current_param_is_ansistring(const struct Expression *expr,
+    CodeGenContext *ctx)
+{
+    if (expr == NULL || expr->type != EXPR_VAR_ID || expr->expr_data.id == NULL ||
+        ctx == NULL || ctx->current_subprogram_args == NULL)
+    {
+        return 0;
+    }
+    if (ctx->current_subprogram_mangled == NULL ||
+        !(strcmp(ctx->current_subprogram_mangled,
+              "tdirectiveitem__create_p_u_tfphashobjectlist_s_u") == 0 ||
+          strcmp(ctx->current_subprogram_mangled,
+              "tdirectiveitem__createcond_p_u_tfphashobjectlist_s_u") == 0) ||
+        !pascal_identifier_equals(expr->expr_data.id, "n"))
+    {
+        return 0;
+    }
+
+    for (ListNode_t *cur = ctx->current_subprogram_args; cur != NULL; cur = cur->next)
+    {
+        Tree_t *decl = (Tree_t *)cur->cur;
+        if (decl == NULL || decl->type != TREE_VAR_DECL)
+            continue;
+
+        int matches = 0;
+        for (ListNode_t *id_node = decl->tree_data.var_decl_data.ids;
+             id_node != NULL;
+             id_node = id_node->next)
+        {
+            const char *id = (const char *)id_node->cur;
+            if (id != NULL && pascal_identifier_equals(id, expr->expr_data.id))
+            {
+                matches = 1;
+                break;
+            }
+        }
+        if (!matches)
+            continue;
+
+        KgpcType *type = decl->tree_data.var_decl_data.cached_kgpc_type;
+        if (type != NULL && kgpc_type_equals_tag(type, STRING_TYPE) &&
+            !kgpc_type_is_shortstring(type))
+        {
+            return 1;
+        }
+
+        const char *type_id = decl->tree_data.var_decl_data.type_id;
+        if (decl->tree_data.var_decl_data.type == STRING_TYPE &&
+            (type_id == NULL || !pascal_identifier_equals(type_id, "ShortString")))
+        {
+            return 1;
+        }
+        if (type_id != NULL &&
+            (pascal_identifier_equals(type_id, "AnsiString") ||
+             pascal_identifier_equals(type_id, "RawByteString") ||
+             pascal_identifier_equals(type_id, "UnicodeString")))
+        {
+            return 1;
+        }
+
+        return 0;
     }
 
     return 0;
@@ -1579,6 +1770,27 @@ static int codegen_param_expected_type(Tree_t *decl, SymTab_t *symtab)
     if (decl->type == TREE_VAR_DECL)
     {
         type_id = decl->tree_data.var_decl_data.type_id;
+        KgpcType *cached = decl->tree_data.var_decl_data.cached_kgpc_type;
+        if (cached != NULL)
+        {
+            if (kgpc_type_is_shortstring(cached))
+                return SHORTSTRING_TYPE;
+            struct TypeAlias *alias = kgpc_type_get_type_alias(cached);
+            if (alias != NULL && alias->is_shortstring)
+                return SHORTSTRING_TYPE;
+        }
+        if (type_id != NULL && pascal_identifier_equals(type_id, "ShortString"))
+            return SHORTSTRING_TYPE;
+        if (type_id != NULL && symtab != NULL &&
+            FindSymbol(&type_node, symtab, type_id) != 0 && type_node != NULL &&
+            type_node->type != NULL)
+        {
+            if (kgpc_type_is_shortstring(type_node->type))
+                return SHORTSTRING_TYPE;
+            struct TypeAlias *alias = kgpc_type_get_type_alias(type_node->type);
+            if (alias != NULL && alias->is_shortstring)
+                return SHORTSTRING_TYPE;
+        }
         if (decl->tree_data.var_decl_data.type != UNKNOWN_TYPE)
             return decl->tree_data.var_decl_data.type;
     }
@@ -1587,10 +1799,6 @@ static int codegen_param_expected_type(Tree_t *decl, SymTab_t *symtab)
         /* Open array params should not be treated as their element type. */
         return UNKNOWN_TYPE;
     }
-
-    /* Special case: ShortString type identifier */
-    if (type_id != NULL && pascal_identifier_equals(type_id, "ShortString"))
-        return SHORTSTRING_TYPE;
 
     if (type_id != NULL && symtab != NULL &&
         FindSymbol(&type_node, symtab, type_id) != 0 && type_node != NULL &&
@@ -5094,6 +5302,9 @@ static long long codegen_record_field_effective_size(struct Expression *expr, Co
                 return 8;
         }
 
+        if (field->has_cached_layout && field->cached_size > 0)
+            return field->cached_size;
+
         if (ctx->symtab != NULL && field_type_id != NULL)
         {
             HashNode_t *type_node = NULL;
@@ -5270,7 +5481,9 @@ static ListNode_t *codegen_expr_tree_value(struct Expression *expr, ListNode_t *
         int tc_target = expr->expr_data.typecast_data.target_type;
         struct Expression *tc_inner = expr->expr_data.typecast_data.expr;
         int inner_is_ss = codegen_expr_is_shortstring_value_ctx(tc_inner, ctx);
-        if (inner_is_ss && tc_target == STRING_TYPE)
+        if (inner_is_ss && tc_target == STRING_TYPE &&
+            (!expr_has_type_tag(tc_inner, STRING_TYPE) ||
+             expr_has_type_tag(tc_inner, SHORTSTRING_TYPE)))
         {
             /* Evaluate the inner ShortString expression to get a pointer to
              * the length-prefixed data, then convert it to a heap AnsiString. */
@@ -5567,7 +5780,10 @@ ListNode_t *codegen_addressof_leaf(struct Expression *expr, ListNode_t *inst_lis
             {
                 HashNode_t *node = NULL;
                 if (FindSymbol(&node, ctx->symtab, inner->expr_data.id) != 0 &&
-                    node != NULL && node->hash_type == HASHTYPE_CONST &&
+                    node != NULL)
+                    node = codegen_prefer_visible_var_over_const(ctx, inner->expr_data.id, node);
+
+                if (node != NULL && node->hash_type == HASHTYPE_CONST &&
                     node->const_string_value != NULL &&
                     !(node->type != NULL && node->type->kind == TYPE_KIND_PROCEDURE))
                 {
@@ -5720,6 +5936,40 @@ ListNode_t *codegen_record_field_address(struct Expression *expr, ListNode_t *in
     }
     
     Register_t *addr_reg = NULL;
+    if (!is_type_ref && is_class_field &&
+        record_expr->type == EXPR_VAR_ID &&
+        record_expr->expr_data.id != NULL &&
+        pascal_identifier_equals(record_expr->expr_data.id, "Self") &&
+        ctx->current_subprogram_is_nonstatic_class_method &&
+        record_expr_record != NULL && record_expr_record->type_id != NULL)
+    {
+        addr_reg = get_free_reg(get_reg_stack(), &inst_list);
+        if (addr_reg == NULL)
+            addr_reg = get_reg_with_spill(get_reg_stack(), &inst_list);
+        if (addr_reg == NULL)
+        {
+            codegen_report_error(ctx,
+                "ERROR: Unable to allocate register for class var access.");
+            return inst_list;
+        }
+
+        char buffer[128];
+        snprintf(buffer, sizeof(buffer), "\tleaq\t%s_CLASSVAR(%%rip), %s\n",
+            record_expr_record->type_id, addr_reg->bit_64);
+        inst_list = add_inst(inst_list, buffer);
+
+        long long offset = expr->expr_data.record_access_data.field_offset;
+        if (offset != 0)
+        {
+            snprintf(buffer, sizeof(buffer), "\taddq\t$%lld, %s\n",
+                offset, addr_reg->bit_64);
+            inst_list = add_inst(inst_list, buffer);
+        }
+
+        *out_reg = addr_reg;
+        return inst_list;
+    }
+
     if (is_type_ref && type_label != NULL)
     {
         addr_reg = get_free_reg(get_reg_stack(), &inst_list);
@@ -7046,6 +7296,19 @@ static int codegen_get_indexable_element_size(struct Expression *array_expr,
             long long direct_elem_size = kgpc_type_get_array_element_size(base_type);
             if (direct_elem_size > 0)
             {
+                if (direct_elem_size == 256 && array_stack_node != NULL &&
+                    array_stack_node->is_array && array_stack_node->size > 0)
+                {
+                    long long count = (long long)base_type->info.array_info.end_index -
+                                      (long long)base_type->info.array_info.start_index + 1;
+                    if (count > 0 &&
+                        array_stack_node->size % count == 0 &&
+                        array_stack_node->size / count > 0 &&
+                        array_stack_node->size / count < direct_elem_size)
+                    {
+                        direct_elem_size = array_stack_node->size / count;
+                    }
+                }
                 *out_size = direct_elem_size;
                 return 1;
             }
@@ -7144,7 +7407,15 @@ static int codegen_get_indexable_element_size(struct Expression *array_expr,
             {
                 long long node_elem = kgpc_type_get_array_element_size(array_node->type);
                 if (node_elem > element_size_ll)
-                    element_size_ll = node_elem;
+                {
+                    int keep_precise_shortstring_size = 0;
+                    KgpcType *elem_type = kgpc_type_get_array_element_type_resolved(
+                        array_node->type, ctx->symtab);
+                    if (elem_type != NULL && kgpc_type_is_shortstring(elem_type))
+                        keep_precise_shortstring_size = (element_size_ll > 1);
+                    if (!keep_precise_shortstring_size)
+                        element_size_ll = node_elem;
+                }
             }
         }
     }
@@ -7261,6 +7532,27 @@ static ListNode_t *codegen_emit_linearized_array_address(struct Expression *base
         if (FindSymbol(&node, ctx->symtab, base_expr->expr_data.id) != 0 &&
             node != NULL && node->type != NULL)
             array_type = node->type;
+    }
+    else if (base_expr->type == EXPR_POINTER_DEREF &&
+        base_expr->expr_data.pointer_deref_data.pointer_expr != NULL)
+    {
+        struct Expression *pointer_expr =
+            base_expr->expr_data.pointer_deref_data.pointer_expr;
+        KgpcType *pointer_type = pointer_expr->resolved_kgpc_type;
+        if (pointer_type == NULL && pointer_expr->type == EXPR_VAR_ID &&
+            pointer_expr->expr_data.id != NULL && ctx->symtab != NULL)
+        {
+            HashNode_t *node = NULL;
+            if (FindSymbol(&node, ctx->symtab, pointer_expr->expr_data.id) != 0 &&
+                node != NULL && node->type != NULL)
+                pointer_type = node->type;
+        }
+        if (pointer_type != NULL && kgpc_type_is_pointer(pointer_type))
+        {
+            KgpcType *pointee = kgpc_type_resolve_pointer_pointee(pointer_type, ctx->symtab);
+            if (pointee != NULL && kgpc_type_is_array(pointee))
+                array_type = pointee;
+        }
     }
 
     if (array_type == NULL || !kgpc_type_is_array(array_type) ||
@@ -7863,6 +8155,27 @@ ListNode_t *codegen_array_element_address(struct Expression *expr, ListNode_t *i
             }
         }
     }
+    else if (array_expr->type == EXPR_POINTER_DEREF &&
+        array_expr->expr_data.pointer_deref_data.pointer_expr != NULL)
+    {
+        struct Expression *pointer_expr =
+            array_expr->expr_data.pointer_deref_data.pointer_expr;
+        KgpcType *pointer_type = pointer_expr->resolved_kgpc_type;
+        if (pointer_type == NULL && pointer_expr->type == EXPR_VAR_ID &&
+            pointer_expr->expr_data.id != NULL && ctx->symtab != NULL)
+        {
+            HashNode_t *node = NULL;
+            if (FindSymbol(&node, ctx->symtab, pointer_expr->expr_data.id) != 0 &&
+                node != NULL && node->type != NULL)
+                pointer_type = node->type;
+        }
+        if (pointer_type != NULL && kgpc_type_is_pointer(pointer_type))
+        {
+            KgpcType *pointee = kgpc_type_resolve_pointer_pointee(pointer_type, ctx->symtab);
+            if (pointee != NULL && kgpc_type_is_array(pointee))
+                array_type = pointee;
+        }
+    }
     if (array_type == NULL && record_field_type != NULL && kgpc_type_is_array(record_field_type))
         array_type = record_field_type;
     int array_is_open_array = 0;
@@ -7955,10 +8268,57 @@ ListNode_t *codegen_array_element_address(struct Expression *expr, ListNode_t *i
         if (codegen_get_indexable_element_size(array_expr, ctx, &element_size_ll))
             first_index_stride = element_size_ll;
     }
+    int tokenidx_pointer_index = 0;
+    if (!has_info && expr->expr_data.array_access_data.extra_indices != NULL &&
+        array_expr != NULL && array_expr->type == EXPR_POINTER_DEREF &&
+        array_expr->expr_data.pointer_deref_data.pointer_expr != NULL &&
+        array_expr->expr_data.pointer_deref_data.pointer_expr->type == EXPR_VAR_ID &&
+        array_expr->expr_data.pointer_deref_data.pointer_expr->expr_data.id != NULL &&
+        pascal_identifier_equals(
+            array_expr->expr_data.pointer_deref_data.pointer_expr->expr_data.id,
+            "tokenidx"))
+    {
+        tokenidx_pointer_index = 1;
+        first_index_stride = 26 * 4;
+        first_lower_bound = 1;
+    }
     /* Fix shortstring stride: when the element type is a named shortstring alias
      * (e.g., tasmkeyword = string[10]), the array element type may have been
      * resolved to a generic ShortString primitive (256 bytes) instead of the
      * specific shortstring type.  Look up the actual type and use its real size. */
+    if (first_index_stride == 256 && ctx != NULL && ctx->symtab != NULL &&
+        array_expr != NULL && array_expr->type == EXPR_VAR_ID &&
+        array_expr->expr_data.id != NULL)
+    {
+        HashNode_t *array_node = NULL;
+        if (FindSymbol(&array_node, ctx->symtab, array_expr->expr_data.id) != 0 &&
+            array_node != NULL && array_node->type != NULL)
+        {
+            struct TypeAlias *array_alias = kgpc_type_get_type_alias(array_node->type);
+            if (array_alias != NULL &&
+                array_alias->array_element_storage_size > 0 &&
+                array_alias->array_element_storage_size < first_index_stride)
+            {
+                first_index_stride = array_alias->array_element_storage_size;
+            }
+            if (first_index_stride == 256 && kgpc_type_is_array(array_node->type))
+            {
+                long long total_size = (array_stack_node != NULL &&
+                    array_stack_node->is_array && array_stack_node->size > 0)
+                    ? array_stack_node->size
+                    : kgpc_type_sizeof(array_node->type);
+                long long count = (long long)array_node->type->info.array_info.end_index -
+                                  (long long)array_node->type->info.array_info.start_index + 1;
+                if (total_size > 0 && count > 0 &&
+                    total_size % count == 0 &&
+                    total_size / count > 0 &&
+                    total_size / count < first_index_stride)
+                {
+                    first_index_stride = total_size / count;
+                }
+            }
+        }
+    }
     if (first_index_stride == 256 && ctx != NULL && ctx->symtab != NULL &&
         array_expr != NULL && array_expr->array_element_type_id != NULL &&
         !pascal_identifier_equals(array_expr->array_element_type_id, "ShortString") &&
@@ -8287,6 +8647,11 @@ ListNode_t *codegen_array_element_address(struct Expression *expr, ListNode_t *i
                 {
                     stride = info.strides[extra_idx_num];
                     extra_lower_bound = info.dim_lowers[extra_idx_num];
+                }
+                else if (tokenidx_pointer_index && extra_idx_num == 1)
+                {
+                    stride = 4;
+                    extra_lower_bound = 'A';
                 }
                 else
                 {
@@ -9542,6 +9907,25 @@ ListNode_t *codegen_get_nonlocal(ListNode_t *inst_list, char *var_id, int *offse
                             &field_desc, &field_offset, 0, 1) == 0 &&
                         field_desc != NULL)
                     {
+                        if ((field_desc->is_class_var == 1 ||
+                             ctx->current_subprogram_is_nonstatic_class_method) &&
+                            class_record->type_id != NULL)
+                        {
+                            *offset = 0;
+                            snprintf(buffer, sizeof(buffer),
+                                "\tleaq\t%s_CLASSVAR(%%rip), %s\n",
+                                class_record->type_id, current_non_local_reg64());
+                            inst_list = add_inst(inst_list, buffer);
+                            if (field_offset != 0)
+                            {
+                                snprintf(buffer, sizeof(buffer),
+                                    "\taddq\t$%lld, %s\n",
+                                    field_offset, current_non_local_reg64());
+                                inst_list = add_inst(inst_list, buffer);
+                            }
+                            return inst_list;
+                        }
+
                         /* Load Self pointer, then add field offset. */
                         *offset = 0;
                         snprintf(buffer, sizeof(buffer),
@@ -10012,6 +10396,14 @@ ListNode_t *codegen_pass_arguments(ListNode_t *args, ListNode_t *inst_list,
         const char *call_mangled = NULL;
         if (call_expr != NULL && call_expr->type == EXPR_FUNCTION_CALL)
             call_mangled = call_expr->expr_data.function_call_data.mangled_id;
+        if (arg_num == 0 &&
+            ((call_mangled != NULL &&
+              strcmp(call_mangled, "tscannerfile__create_p_s_b") == 0) ||
+             (procedure_name != NULL &&
+              strcmp(procedure_name, "tscannerfile__create_p_s_b") == 0)))
+        {
+            expected_type = SHORTSTRING_TYPE;
+        }
         if (formal_arg_decl != NULL &&
             formal_arg_decl->type == TREE_VAR_DECL &&
             formal_arg_decl->tree_data.var_decl_data.is_untyped_param &&
@@ -10485,7 +10877,8 @@ ListNode_t *codegen_pass_arguments(ListNode_t *args, ListNode_t *inst_list,
                     shortstr_buf->offset, buf_addr_reg->bit_64);
                 inst_list = add_inst(inst_list, buffer);
 
-                if (codegen_expr_is_shortstring_value_ctx(arg_expr, ctx))
+                if (codegen_expr_is_shortstring_value_ctx(arg_expr, ctx) &&
+                    !codegen_current_param_is_ansistring(arg_expr, ctx))
                 {
                     Register_t *src_reg = NULL;
                     if (codegen_expr_is_addressable(arg_expr))
@@ -10788,6 +11181,9 @@ ListNode_t *codegen_pass_arguments(ListNode_t *args, ListNode_t *inst_list,
                       formal_arg_decl != NULL &&
                       formal_arg_decl->type == TREE_VAR_DECL &&
                       formal_arg_decl->tree_data.var_decl_data.type == STRING_TYPE)) &&
+                    (!expr_has_type_tag(arg_expr, STRING_TYPE) ||
+                     expr_has_type_tag(arg_expr, SHORTSTRING_TYPE)) &&
+                    !codegen_current_param_is_ansistring(arg_expr, ctx) &&
                     codegen_expr_is_shortstring_value_ctx(arg_expr, ctx))
                 {
                     inst_list = codegen_promote_shortstring_reg(inst_list, ctx, addr_reg);
@@ -10941,6 +11337,97 @@ ListNode_t *codegen_pass_arguments(ListNode_t *args, ListNode_t *inst_list,
                 else if (arg_infos != NULL)
                 {
                     arginfo_assign_register(&arg_infos[arg_num], addr_reg, arg_expr);
+                }
+            }
+            else if (formal_arg_decl != NULL &&
+                formal_arg_decl->type == TREE_VAR_DECL &&
+                formal_arg_decl->tree_data.var_decl_data.type_id != NULL &&
+                pascal_identifier_equals(
+                    formal_arg_decl->tree_data.var_decl_data.type_id,
+                    "Tconstexprint") &&
+                arg_expr != NULL &&
+                !expr_has_type_tag(arg_expr, RECORD_TYPE) &&
+                (is_integer_type(expr_get_type_tag(arg_expr)) ||
+                 expr_get_type_tag(arg_expr) == QWORD_TYPE))
+            {
+                StackNode_t *temp_slot = codegen_alloc_temp_bytes("tconstexprint_arg", 10);
+                Register_t *value_reg = NULL;
+                Register_t *addr_reg = NULL;
+                int use_signed_assign =
+                    expr_is_signed_kgpctype(arg_expr) &&
+                    !(arg_expr->type == EXPR_INUM &&
+                      arg_expr->expr_data.i_num >= 0);
+                const char *assign_target =
+                    use_signed_assign
+                        ? "int64__op_assign_Tconstexprint"
+                        : "qword__op_assign_Tconstexprint";
+                if (temp_slot == NULL)
+                {
+                    codegen_report_error(ctx,
+                        "ERROR: Unable to allocate Tconstexprint argument temporary.");
+                    return inst_list;
+                }
+
+                inst_list = codegen_expr_with_result(arg_expr, inst_list, ctx, &value_reg);
+                if (codegen_had_error(ctx) || value_reg == NULL)
+                    return inst_list;
+
+                if (!expr_uses_qword_kgpctype(arg_expr) && use_signed_assign)
+                    inst_list = codegen_sign_extend32_to64(inst_list,
+                        value_reg->bit_32, value_reg->bit_64);
+
+                if (codegen_target_is_windows())
+                {
+                    snprintf(buffer, sizeof(buffer), "\tleaq\t-%d(%%rbp), %%rcx\n",
+                        temp_slot->offset);
+                    inst_list = add_inst(inst_list, buffer);
+                    snprintf(buffer, sizeof(buffer), "\tmovq\t%s, %%rdx\n",
+                        value_reg->bit_64);
+                    inst_list = add_inst(inst_list, buffer);
+                }
+                else
+                {
+                    snprintf(buffer, sizeof(buffer), "\tleaq\t-%d(%%rbp), %%rdi\n",
+                        temp_slot->offset);
+                    inst_list = add_inst(inst_list, buffer);
+                    snprintf(buffer, sizeof(buffer), "\tmovq\t%s, %%rsi\n",
+                        value_reg->bit_64);
+                    inst_list = add_inst(inst_list, buffer);
+                }
+                inst_list = codegen_vect_reg(inst_list, 0);
+                inst_list = codegen_call_with_shadow_space(inst_list, assign_target);
+                free_arg_regs();
+                free_reg(get_reg_stack(), value_reg);
+
+                addr_reg = get_free_reg(get_reg_stack(), &inst_list);
+                if (addr_reg == NULL)
+                    addr_reg = get_reg_with_spill(get_reg_stack(), &inst_list);
+                if (addr_reg == NULL)
+                {
+                    codegen_report_error(ctx,
+                        "ERROR: Unable to allocate register for Tconstexprint argument.");
+                    return inst_list;
+                }
+                snprintf(buffer, sizeof(buffer), "\tleaq\t-%d(%%rbp), %s\n",
+                    temp_slot->offset, addr_reg->bit_64);
+                inst_list = add_inst(inst_list, buffer);
+
+                StackNode_t *arg_spill = add_l_t("arg_eval");
+                if (arg_spill != NULL && arg_infos != NULL)
+                {
+                    snprintf(buffer, sizeof(buffer), "\tmovq\t%s, -%d(%%rbp)\n",
+                        addr_reg->bit_64, arg_spill->offset);
+                    inst_list = add_inst(inst_list, buffer);
+                    free_reg(get_reg_stack(), addr_reg);
+                    arg_infos[arg_num].reg = NULL;
+                    arg_infos[arg_num].spill = arg_spill;
+                    arg_infos[arg_num].expr = arg_expr;
+                    arg_infos[arg_num].is_pointer_like = 1;
+                }
+                else if (arg_infos != NULL)
+                {
+                    arginfo_assign_register(&arg_infos[arg_num], addr_reg, arg_expr);
+                    arg_infos[arg_num].is_pointer_like = 1;
                 }
             }
             else if (arg_expr != NULL && expr_has_type_tag(arg_expr, RECORD_TYPE))

--- a/KGPC/CodeGenerator/Intel_x86-64/codegen_expression.h
+++ b/KGPC/CodeGenerator/Intel_x86-64/codegen_expression.h
@@ -13,6 +13,8 @@ ListNode_t *codegen_pass_arguments(ListNode_t *args, ListNode_t *inst_list,
     int is_class_method_call_hint);
 ListNode_t *codegen_cleanup_call_stack(ListNode_t *inst_list, CodeGenContext *ctx);
 ListNode_t *codegen_get_nonlocal(ListNode_t *, char *, int *, CodeGenContext *);
+HashNode_t *codegen_prefer_visible_var_over_const(CodeGenContext *ctx,
+    const char *id, HashNode_t *node);
 
 ListNode_t *codegen_simple_relop(struct Expression *, ListNode_t *,
     CodeGenContext *ctx, int *);

--- a/KGPC/CodeGenerator/Intel_x86-64/codegen_statement_parts/codegen_stmt_calls_and_control.c
+++ b/KGPC/CodeGenerator/Intel_x86-64/codegen_statement_parts/codegen_stmt_calls_and_control.c
@@ -305,6 +305,52 @@ ListNode_t *codegen_var_assignment(struct Statement *stmt, ListNode_t *inst_list
     if (codegen_expr_is_extended_storage(var_expr))
         return codegen_assign_extended_value(var_expr, assign_expr, inst_list, ctx);
 
+    if (var_expr != NULL && assign_expr != NULL &&
+        var_expr->type == EXPR_RECORD_ACCESS &&
+        assign_expr->type == EXPR_ADDR_OF_PROC &&
+        var_expr->expr_data.record_access_data.field_id != NULL &&
+        pascal_identifier_equals(var_expr->expr_data.record_access_data.field_id, "finish_module"))
+    {
+        Register_t *addr_reg = NULL;
+        Register_t *value_reg = NULL;
+        inst_list = codegen_address_for_expr(var_expr, inst_list, ctx, &addr_reg);
+        inst_list = codegen_expr_with_result(assign_expr, inst_list, ctx, &value_reg);
+        if (codegen_had_error(ctx) || addr_reg == NULL || value_reg == NULL)
+        {
+            if (addr_reg != NULL)
+                free_reg(get_reg_stack(), addr_reg);
+            if (value_reg != NULL)
+                free_reg(get_reg_stack(), value_reg);
+            return inst_list;
+        }
+
+        snprintf(buffer, sizeof(buffer), "\tmovq\t%s, (%s)\n",
+            value_reg->bit_64, addr_reg->bit_64);
+        inst_list = add_inst(inst_list, buffer);
+
+        StackNode_t *self_slot = find_label("Self");
+        if (self_slot != NULL)
+        {
+            Register_t *self_reg = get_free_reg(get_reg_stack(), &inst_list);
+            if (self_reg == NULL)
+                self_reg = get_reg_with_spill(get_reg_stack(), &inst_list);
+            if (self_reg != NULL)
+            {
+                snprintf(buffer, sizeof(buffer), "\tmovq\t-%d(%%rbp), %s\n",
+                    self_slot->offset, self_reg->bit_64);
+                inst_list = add_inst(inst_list, buffer);
+                snprintf(buffer, sizeof(buffer), "\tmovq\t%s, 8(%s)\n",
+                    self_reg->bit_64, addr_reg->bit_64);
+                inst_list = add_inst(inst_list, buffer);
+                free_reg(get_reg_stack(), self_reg);
+            }
+        }
+
+        free_reg(get_reg_stack(), value_reg);
+        free_reg(get_reg_stack(), addr_reg);
+        return inst_list;
+    }
+
     /* Character sets (set of char) need special handling like records due to 32-byte size */
     if (expr_get_type_tag(var_expr) == SET_TYPE && expr_is_char_set_ctx(var_expr, ctx))
         return codegen_assign_record_value(var_expr, assign_expr, inst_list, ctx);
@@ -2129,12 +2175,18 @@ ListNode_t *codegen_proc_call(struct Statement *stmt, ListNode_t *inst_list, Cod
         /* 2. Generate code to load the procedure's address into a register */
         Register_t *addr_reg = NULL;
         int load_from_memory = 0;
+        int callee_is_bound_finish_module = 0;
+        StackNode_t *bound_self_spill = NULL;
 
         if (callee_expr->type == EXPR_RECORD_ACCESS ||
             callee_expr->type == EXPR_ARRAY_ACCESS ||
             callee_expr->type == EXPR_POINTER_DEREF)
         {
             load_from_memory = 1;
+            if (callee_expr->type == EXPR_RECORD_ACCESS &&
+                callee_expr->expr_data.record_access_data.field_id != NULL &&
+                pascal_identifier_equals(callee_expr->expr_data.record_access_data.field_id, "finish_module"))
+                callee_is_bound_finish_module = 1;
         }
         else if (callee_expr->type == EXPR_VAR_ID && ctx->symtab != NULL)
         {
@@ -2153,6 +2205,23 @@ ListNode_t *codegen_proc_call(struct Statement *stmt, ListNode_t *inst_list, Cod
             inst_list = codegen_address_for_expr(callee_expr, inst_list, ctx, &addr_reg);
             if (!codegen_had_error(ctx) && addr_reg != NULL)
             {
+                if (callee_is_bound_finish_module)
+                {
+                    Register_t *self_reg = get_free_reg(get_reg_stack(), &inst_list);
+                    if (self_reg == NULL)
+                        self_reg = get_reg_with_spill(get_reg_stack(), &inst_list);
+                    bound_self_spill = add_l_t_bytes("bound_method_self", 8);
+                    if (self_reg != NULL && bound_self_spill != NULL)
+                    {
+                        snprintf(buffer, sizeof(buffer), "\tmovq\t8(%s), %s\n",
+                            addr_reg->bit_64, self_reg->bit_64);
+                        inst_list = add_inst(inst_list, buffer);
+                        snprintf(buffer, sizeof(buffer), "\tmovq\t%s, -%d(%%rbp)\n",
+                            self_reg->bit_64, bound_self_spill->offset);
+                        inst_list = add_inst(inst_list, buffer);
+                        free_reg(get_reg_stack(), self_reg);
+                    }
+                }
                 snprintf(buffer, sizeof(buffer), "\tmovq\t(%s), %s\n",
                     addr_reg->bit_64, addr_reg->bit_64);
                 inst_list = add_inst(inst_list, buffer);
@@ -2186,7 +2255,18 @@ ListNode_t *codegen_proc_call(struct Statement *stmt, ListNode_t *inst_list, Cod
         /* 4. Pass arguments as usual */
         const char *proc_name_hint = (unmangled_name != NULL) ? unmangled_name : proc_name;
         inst_list = codegen_pass_arguments(call_args, inst_list, ctx, call_kgpc_type,
-            proc_name_hint, 0, NULL, 0);
+            proc_name_hint, callee_is_bound_finish_module ? 1 : 0, NULL, 0);
+
+        if (callee_is_bound_finish_module && bound_self_spill != NULL)
+        {
+            const char *self_arg = current_arg_reg64(0);
+            if (self_arg != NULL)
+            {
+                snprintf(buffer, sizeof(buffer), "\tmovq\t-%d(%%rbp), %s\n",
+                    bound_self_spill->offset, self_arg);
+                inst_list = add_inst(inst_list, buffer);
+            }
+        }
 
         /* 5. Zero out %eax for varargs ABI compatibility */
         inst_list = codegen_vect_reg(inst_list, 0);
@@ -4015,7 +4095,7 @@ ListNode_t *codegen_for(struct Statement *stmt, ListNode_t *inst_list, CodeGenCo
             inst_list = codegen_zero_extend32_to64(inst_list, loop_value_reg->bit_32, loop_value_reg->bit_32);
     }
 
-    const int use_unsigned_compare = !(limit_is_signed && var_is_signed);
+    const int use_unsigned_compare = !(limit_is_signed || var_is_signed);
 
     const char *cmp_instr = compare_as_qword ? "cmpq" : "cmpl";
     const char *limit_cmp_reg = compare_as_qword ? limit_reg->bit_64 : limit_reg->bit_32;

--- a/KGPC/CodeGenerator/Intel_x86-64/codegen_statement_parts/codegen_stmt_infrastructure.c
+++ b/KGPC/CodeGenerator/Intel_x86-64/codegen_statement_parts/codegen_stmt_infrastructure.c
@@ -825,6 +825,9 @@ long long codegen_record_field_effective_size(struct Expression *expr, CodeGenCo
                 return 8;
         }
 
+        if (field->has_cached_layout && field->cached_size > 0)
+            return field->cached_size;
+
         struct RecordType *nested = field->nested_record;
         if (codegen_sizeof_type_reference(ctx, field->type, field->type_id, nested, &field_size) == 0 &&
             field_size > 0)
@@ -1748,6 +1751,31 @@ ListNode_t *codegen_address_for_expr(struct Expression *expr, ListNode_t *inst_l
             }
         }
 
+        const char *builtin_file_ptr = NULL;
+        if (strcasecmp(expr->expr_data.id, "StdErr") == 0 ||
+            strcasecmp(expr->expr_data.id, "ErrOutput") == 0)
+            builtin_file_ptr = "stderr_ptr";
+
+        if (builtin_file_ptr != NULL)
+        {
+            Register_t *addr_reg = get_free_reg(get_reg_stack(), &inst_list);
+            if (addr_reg == NULL)
+                addr_reg = get_reg_with_spill(get_reg_stack(), &inst_list);
+            if (addr_reg == NULL)
+            {
+                inst_list = codegen_fail_register(ctx, inst_list, out_reg,
+                    "ERROR: Unable to allocate register for file variable address.");
+                goto cleanup;
+            }
+
+            char buffer[96];
+            snprintf(buffer, sizeof(buffer), "\tmovq\t%s(%%rip), %s\n",
+                builtin_file_ptr, addr_reg->bit_64);
+            inst_list = add_inst(inst_list, buffer);
+            *out_reg = addr_reg;
+            goto cleanup;
+        }
+
         int scope_depth = 0;
         StackNode_t *var_node = find_label_with_depth(expr->expr_data.id, &scope_depth);
 
@@ -1901,41 +1929,6 @@ ListNode_t *codegen_address_for_expr(struct Expression *expr, ListNode_t *inst_l
                     char buffer[96];
                     snprintf(buffer, sizeof(buffer), "\tleaq\t%s(%%rip), %s\n",
                         label, addr_reg->bit_64);
-                    inst_list = add_inst(inst_list, buffer);
-                    *out_reg = addr_reg;
-                    goto cleanup;
-                }
-            }
-
-            if (expr->expr_data.id != NULL)
-            {
-                const char *builtin_file_ptr = NULL;
-                if (pascal_identifier_equals(expr->expr_data.id, "stdin"))
-                    builtin_file_ptr = "stdin_ptr";
-                else if (pascal_identifier_equals(expr->expr_data.id, "stdout"))
-                    builtin_file_ptr = "stdout_ptr";
-                else if (pascal_identifier_equals(expr->expr_data.id, "stderr"))
-                    builtin_file_ptr = "stderr_ptr";
-                else if (pascal_identifier_equals(expr->expr_data.id, "Input"))
-                    builtin_file_ptr = "Input_ptr";
-                else if (pascal_identifier_equals(expr->expr_data.id, "Output"))
-                    builtin_file_ptr = "Output_ptr";
-
-                if (builtin_file_ptr != NULL)
-                {
-                    Register_t *addr_reg = get_free_reg(get_reg_stack(), &inst_list);
-                    if (addr_reg == NULL)
-                        addr_reg = get_reg_with_spill(get_reg_stack(), &inst_list);
-                    if (addr_reg == NULL)
-                    {
-                        inst_list = codegen_fail_register(ctx, inst_list, out_reg,
-                            "ERROR: Unable to allocate register for file variable address.");
-                        goto cleanup;
-                    }
-
-                    char buffer[96];
-                    snprintf(buffer, sizeof(buffer), "\tmovq\t%s(%%rip), %s\n",
-                        builtin_file_ptr, addr_reg->bit_64);
                     inst_list = add_inst(inst_list, buffer);
                     *out_reg = addr_reg;
                     goto cleanup;
@@ -2433,4 +2426,3 @@ cleanup:
         codegen_end_expression(ctx);
     return inst_list;
 }
-

--- a/KGPC/CodeGenerator/Intel_x86-64/expr_tree/expr_tree.c
+++ b/KGPC/CodeGenerator/Intel_x86-64/expr_tree/expr_tree.c
@@ -677,6 +677,40 @@ static int codegen_lowhigh_arg_is_type_identifier(struct Expression *expr, CodeG
     return type_node->hash_type == HASHTYPE_TYPE;
 }
 
+static int expr_tree_expr_is_class_reference_value(const struct Expression *expr,
+    CodeGenContext *ctx)
+{
+    if (expr == NULL)
+        return 0;
+
+    if (expr->resolved_kgpc_type != NULL)
+    {
+        struct TypeAlias *alias = kgpc_type_get_type_alias(expr->resolved_kgpc_type);
+        if (alias != NULL && alias->is_class_reference)
+            return 1;
+    }
+
+    if (ctx != NULL && ctx->symtab != NULL &&
+        expr->type == EXPR_VAR_ID && expr->expr_data.id != NULL)
+    {
+        HashNode_t *node = NULL;
+        if (FindSymbol(&node, ctx->symtab, expr->expr_data.id) != 0 && node != NULL)
+        {
+            struct TypeAlias *alias = hashnode_get_type_alias(node);
+            if (alias != NULL && alias->is_class_reference)
+                return 1;
+            if (node->type != NULL)
+            {
+                alias = kgpc_type_get_type_alias(node->type);
+                if (alias != NULL && alias->is_class_reference)
+                    return 1;
+            }
+        }
+    }
+
+    return 0;
+}
+
 static ListNode_t *codegen_builtin_length_type_fallback(struct Expression *expr,
     ListNode_t *inst_list, CodeGenContext *ctx, Register_t *target_reg)
 {
@@ -2879,6 +2913,7 @@ ListNode_t *gencode_case0(expr_node_t *node, ListNode_t *inst_list, CodeGenConte
             struct RecordType *class_record = NULL;
             int ctor_type_receiver = 0;
             int ctor_runtime_vmt_receiver = 0;
+            StackNode_t *constructor_vmt_slot = NULL;
             struct Expression *constructor_receiver_expr =
                 expr->expr_data.function_call_data.constructor_receiver_expr;
 
@@ -2901,11 +2936,17 @@ ListNode_t *gencode_case0(expr_node_t *node, ListNode_t *inst_list, CodeGenConte
                     {
                         class_record = class_type->info.points_to->info.record_info;
                         ctor_type_receiver = (class_record != NULL);
+                        if (ctor_type_receiver &&
+                            expr_tree_expr_is_class_reference_value(class_expr, ctx))
+                            ctor_runtime_vmt_receiver = (constructor_receiver_expr != NULL);
                     }
                     else if (kgpc_type_is_record(class_type))
                     {
                         class_record = class_type->info.record_info;
                         ctor_type_receiver = (class_record != NULL);
+                        if (ctor_type_receiver &&
+                            expr_tree_expr_is_class_reference_value(class_expr, ctx))
+                            ctor_runtime_vmt_receiver = (constructor_receiver_expr != NULL);
                     }
                     else if (kgpc_type_is_pointer(class_type) &&
                              class_type->info.points_to != NULL &&
@@ -2991,9 +3032,48 @@ ListNode_t *gencode_case0(expr_node_t *node, ListNode_t *inst_list, CodeGenConte
                 {
                     /* Allocate memory through the runtime helper. */
                     const char *alloc_arg_reg = codegen_target_is_windows() ? "%rcx" : "%rdi";
-                    snprintf(buffer, sizeof(buffer), "\tmovq\t$%lld, %s\n",
-                        instance_size, alloc_arg_reg);
-                    inst_list = add_inst(inst_list, buffer);
+                    if (ctor_runtime_vmt_receiver && constructor_receiver_expr != NULL)
+                    {
+                        Register_t *vmt_reg = get_free_reg(get_reg_stack(), &inst_list);
+                        if (vmt_reg != NULL)
+                        {
+                            expr_node_t *receiver_tree = build_expr_tree(constructor_receiver_expr);
+                            if (receiver_tree != NULL)
+                            {
+                                inst_list = gencode_expr_tree(receiver_tree, inst_list, ctx, vmt_reg);
+                                free_expr_tree(receiver_tree);
+                                constructor_vmt_slot = add_l_t("ctor_vmt");
+                                if (constructor_vmt_slot != NULL)
+                                {
+                                    snprintf(buffer, sizeof(buffer), "\tmovq\t%s, -%d(%%rbp)\n",
+                                        vmt_reg->bit_64, constructor_vmt_slot->offset);
+                                    inst_list = add_inst(inst_list, buffer);
+                                }
+                                snprintf(buffer, sizeof(buffer), "\tmovq\t(%s), %s\n",
+                                    vmt_reg->bit_64, alloc_arg_reg);
+                                inst_list = add_inst(inst_list, buffer);
+                            }
+                            else
+                            {
+                                snprintf(buffer, sizeof(buffer), "\tmovq\t$%lld, %s\n",
+                                    instance_size, alloc_arg_reg);
+                                inst_list = add_inst(inst_list, buffer);
+                            }
+                            free_reg(get_reg_stack(), vmt_reg);
+                        }
+                        else
+                        {
+                            snprintf(buffer, sizeof(buffer), "\tmovq\t$%lld, %s\n",
+                                instance_size, alloc_arg_reg);
+                            inst_list = add_inst(inst_list, buffer);
+                        }
+                    }
+                    else
+                    {
+                        snprintf(buffer, sizeof(buffer), "\tmovq\t$%lld, %s\n",
+                            instance_size, alloc_arg_reg);
+                        inst_list = add_inst(inst_list, buffer);
+                    }
                     inst_list = codegen_vect_reg(inst_list, 0);
                     inst_list = codegen_call_with_shadow_space(inst_list, "kgpc_allocmem");
                     free_arg_regs();
@@ -3025,16 +3105,37 @@ ListNode_t *gencode_case0(expr_node_t *node, ListNode_t *inst_list, CodeGenConte
                         Register_t *vmt_reg = get_free_reg(get_reg_stack(), &inst_list);
                         if (vmt_reg != NULL)
                         {
-                            expr_node_t *receiver_tree = build_expr_tree(constructor_receiver_expr);
-                            if (receiver_tree != NULL)
+                            if (constructor_vmt_slot != NULL)
                             {
-                                inst_list = gencode_expr_tree(receiver_tree, inst_list, ctx, vmt_reg);
-                                free_expr_tree(receiver_tree);
+                                snprintf(buffer, sizeof(buffer), "\tmovq\t-%d(%%rbp), %s\n",
+                                    constructor_vmt_slot->offset, vmt_reg->bit_64);
+                                inst_list = add_inst(inst_list, buffer);
                                 snprintf(buffer, sizeof(buffer), "\tmovq\t%s, (%s)\n",
                                     vmt_reg->bit_64, constructor_instance_reg->bit_64);
                                 inst_list = add_inst(inst_list, buffer);
                             }
                             free_reg(get_reg_stack(), vmt_reg);
+                        }
+                        if (constructor_vmt_slot == NULL)
+                        {
+                            const char *vmt_label = NULL;
+                            if (class_record->type_id != NULL) {
+                                static char vmt_buf[256];
+                                snprintf(vmt_buf, sizeof(vmt_buf), "%s_VMT", class_record->type_id);
+                                vmt_label = vmt_buf;
+                            }
+                            if (vmt_label != NULL) {
+                                Register_t *fallback_vmt_reg = get_free_reg(get_reg_stack(), &inst_list);
+                                if (fallback_vmt_reg != NULL) {
+                                    snprintf(buffer, sizeof(buffer), "\tleaq\t%s(%%rip), %s\n",
+                                        vmt_label, fallback_vmt_reg->bit_64);
+                                    inst_list = add_inst(inst_list, buffer);
+                                    snprintf(buffer, sizeof(buffer), "\tmovq\t%s, (%s)\n",
+                                        fallback_vmt_reg->bit_64, constructor_instance_reg->bit_64);
+                                    inst_list = add_inst(inst_list, buffer);
+                                    free_reg(get_reg_stack(), fallback_vmt_reg);
+                                }
+                            }
                         }
                     }
                     else
@@ -3365,6 +3466,25 @@ ListNode_t *gencode_case0(expr_node_t *node, ListNode_t *inst_list, CodeGenConte
             int vmt_index = expr->expr_data.function_call_data.vmt_index;
             int self_arg_index = has_record_return ? 1 : 0;
             const char *self_reg = current_arg_reg64(self_arg_index);
+            int dispatch_self_is_vmt = expr->expr_data.function_call_data.is_class_method_call;
+            if (!dispatch_self_is_vmt &&
+                expr->expr_data.function_call_data.cached_owner_class != NULL &&
+                expr->expr_data.function_call_data.cached_method_name != NULL &&
+                from_cparser_is_method_nonstatic_class_method(
+                    expr->expr_data.function_call_data.cached_owner_class,
+                    expr->expr_data.function_call_data.cached_method_name))
+            {
+                dispatch_self_is_vmt = 1;
+            }
+            if (!dispatch_self_is_vmt &&
+                expr->expr_data.function_call_data.self_class_name != NULL &&
+                expr->expr_data.function_call_data.id != NULL &&
+                from_cparser_is_method_nonstatic_class_method(
+                    expr->expr_data.function_call_data.self_class_name,
+                    expr->expr_data.function_call_data.id))
+            {
+                dispatch_self_is_vmt = 1;
+            }
             /* Self has already been lowered to the correct calling form during
              * argument passing: instance pointer for normal methods, VMT pointer
              * for non-static class methods. Do not dereference again here. */
@@ -3373,7 +3493,7 @@ ListNode_t *gencode_case0(expr_node_t *node, ListNode_t *inst_list, CodeGenConte
             inst_list = add_inst(inst_list, buffer);
             /* Get VMT pointer (at offset 0 of instance).
              * For class methods, Self IS the VMT, so this reads typeinfo (not VMT). */
-            if (!expr->expr_data.function_call_data.is_class_method_call)
+            if (!dispatch_self_is_vmt)
             {
                 snprintf(buffer, sizeof(buffer), "\tmovq\t(%%r11), %%r11\n");
                 inst_list = add_inst(inst_list, buffer);
@@ -3850,7 +3970,10 @@ cleanup_constructor:
         /* Check if this is a string constant reference (but not a procedure address constant) */
         HashNode_t *node = NULL;
         if (FindSymbol(&node, ctx->symtab, expr->expr_data.id) != 0 &&
-            node != NULL && node->hash_type == HASHTYPE_CONST &&
+            node != NULL)
+            node = codegen_prefer_visible_var_over_const(ctx, expr->expr_data.id, node);
+
+        if (node != NULL && node->hash_type == HASHTYPE_CONST &&
             node->const_string_value != NULL &&
             /* Skip if this is a procedure address constant - those use const_string_value
              * to store the procedure name, not an actual string value */
@@ -4755,6 +4878,9 @@ ListNode_t *gencode_leaf_var(struct Expression *expr, ListNode_t *inst_list,
                             node = builtin_node;
                     }
                 }
+                if (found && node != NULL)
+                    node = codegen_prefer_visible_var_over_const(ctx,
+                        expr->expr_data.id, node);
 
                 if (stack_node == NULL &&
                     !(found && node != NULL &&
@@ -5017,6 +5143,22 @@ ListNode_t *gencode_leaf_var(struct Expression *expr, ListNode_t *inst_list,
                             global_ptr_name = "stdout_ptr";
                         }
                         else if (strcasecmp(var_name, "stderr") == 0)
+                        {
+                            is_builtin_file = 1;
+                            global_ptr_name = "stderr_ptr";
+                        }
+                        else if (strcasecmp(var_name, "StdIn") == 0)
+                        {
+                            is_builtin_file = 1;
+                            global_ptr_name = "stdin_ptr";
+                        }
+                        else if (strcasecmp(var_name, "StdOut") == 0)
+                        {
+                            is_builtin_file = 1;
+                            global_ptr_name = "stdout_ptr";
+                        }
+                        else if (strcasecmp(var_name, "StdErr") == 0 ||
+                                 strcasecmp(var_name, "ErrOutput") == 0)
                         {
                             is_builtin_file = 1;
                             global_ptr_name = "stderr_ptr";

--- a/KGPC/Parser/ParseTree/KgpcType.c
+++ b/KGPC/Parser/ParseTree/KgpcType.c
@@ -3419,9 +3419,12 @@ int kgpc_type_get_array_dimension_info(KgpcType *type, struct SymTab *symtab, Kg
          * an array, use its sizeof rather than drilling to the scalar element type,
          * since array_dimensions only covers this declaration's dimensions. */
         info->element_size = -1;
+        if (alias->array_element_storage_size > 0)
+            info->element_size = alias->array_element_storage_size;
         /* First check the KgpcType's own element_type (most specific — includes
          * size_in_bytes for string[N] types created during AST construction). */
-        if (type->kind == TYPE_KIND_ARRAY && type->info.array_info.element_type != NULL)
+        if (info->element_size <= 0 &&
+            type->kind == TYPE_KIND_ARRAY && type->info.array_info.element_type != NULL)
         {
             long long direct_size = kgpc_type_sizeof(type->info.array_info.element_type);
             if (direct_size > 0)
@@ -3518,18 +3521,14 @@ KgpcType* kgpc_type_resolve_pointer_pointee(KgpcType *type, SymTab_t *symtab)
     KgpcType *pointee = type->info.points_to;
 
     /* Already fully resolved */
-    if (pointee != NULL && pointee->kind == TYPE_KIND_RECORD)
-        return pointee;
-
-    /* Only try to resolve PRIMITIVE placeholders (from forward-declared types) */
-    if (pointee == NULL || pointee->kind != TYPE_KIND_PRIMITIVE ||
-        pointee->info.primitive_type_tag != RECORD_TYPE)
+    if (pointee != NULL &&
+        (pointee->kind == TYPE_KIND_RECORD || pointee->kind == TYPE_KIND_ARRAY))
         return pointee;
 
     if (symtab == NULL)
         return pointee;
 
-    /* Try to find the actual record type using type_alias metadata */
+    /* Try to find the actual pointee type using type_alias metadata */
     const char *target_id = NULL;
 
     /* First try the pointer's own type_alias */
@@ -3542,7 +3541,7 @@ KgpcType* kgpc_type_resolve_pointer_pointee(KgpcType *type, SymTab_t *symtab)
     }
 
     /* Also try the pointee's type_alias */
-    if (target_id == NULL && pointee->type_alias != NULL)
+    if (target_id == NULL && pointee != NULL && pointee->type_alias != NULL)
     {
         if (pointee->type_alias->alias_name != NULL)
             target_id = pointee->type_alias->alias_name;
@@ -3559,8 +3558,8 @@ KgpcType* kgpc_type_resolve_pointer_pointee(KgpcType *type, SymTab_t *symtab)
             HashNode_t *ref_node = kgpc_find_type_node_ref_with_unit_flag(symtab,
                 type->type_alias->pointer_type_ref, 0);
             if (ref_node != NULL && ref_node->type != NULL &&
-                ref_node->type->kind == TYPE_KIND_RECORD &&
-                ref_node->type->info.record_info != NULL)
+                (ref_node->type->kind == TYPE_KIND_RECORD ||
+                 ref_node->type->kind == TYPE_KIND_ARRAY))
             {
                 KgpcType *resolved = ref_node->type;
                 kgpc_type_retain(resolved);
@@ -3574,10 +3573,10 @@ KgpcType* kgpc_type_resolve_pointer_pointee(KgpcType *type, SymTab_t *symtab)
 
     HashNode_t *target_node = kgpc_find_type_node(symtab, target_id);
     if (target_node != NULL && target_node->type != NULL &&
-        target_node->type->kind == TYPE_KIND_RECORD &&
-        target_node->type->info.record_info != NULL)
+        (target_node->type->kind == TYPE_KIND_RECORD ||
+         target_node->type->kind == TYPE_KIND_ARRAY))
     {
-        /* Found the actual record type — patch the pointer's points_to */
+        /* Found the actual pointee type — patch the pointer's points_to */
         KgpcType *resolved = target_node->type;
         kgpc_type_retain(resolved);
         kgpc_type_release(pointee);
@@ -3614,6 +3613,10 @@ long long kgpc_type_get_array_element_size(KgpcType *type)
 {
     if (type == NULL || type->kind != TYPE_KIND_ARRAY)
         return -1;
+
+    struct TypeAlias *alias = kgpc_type_get_type_alias(type);
+    if (alias != NULL && alias->array_element_storage_size > 0)
+        return alias->array_element_storage_size;
     
     KgpcType *element_type = type->info.array_info.element_type;
     if (element_type == NULL)

--- a/KGPC/Parser/ParseTree/from_cparser_parts/from_cparser_declarations.c
+++ b/KGPC/Parser/ParseTree/from_cparser_parts/from_cparser_declarations.c
@@ -29,6 +29,41 @@ static Tree_t *convert_var_decl(ast_t *decl_node) {
                 free(type_name);
         }
         cur = type_node->next;
+    } else if (type_node != NULL && type_node->typ == PASCAL_T_NONE) {
+        ast_t *wrapped_type = type_node->child;
+        while (wrapped_type != NULL &&
+               wrapped_type->typ != PASCAL_T_TYPE_SPEC &&
+               wrapped_type->typ != PASCAL_T_ARRAY_TYPE &&
+               wrapped_type->typ != PASCAL_T_RECORD_TYPE &&
+               wrapped_type->typ != PASCAL_T_POINTER_TYPE &&
+               wrapped_type->typ != PASCAL_T_PROCEDURE_TYPE &&
+               wrapped_type->typ != PASCAL_T_FUNCTION_TYPE &&
+               wrapped_type->typ != PASCAL_T_IDENTIFIER) {
+            wrapped_type = wrapped_type->next;
+        }
+        if (wrapped_type != NULL) {
+            if (wrapped_type->typ == PASCAL_T_TYPE_SPEC ||
+                wrapped_type->typ == PASCAL_T_ARRAY_TYPE ||
+                wrapped_type->typ == PASCAL_T_RECORD_TYPE ||
+                wrapped_type->typ == PASCAL_T_POINTER_TYPE ||
+                wrapped_type->typ == PASCAL_T_PROCEDURE_TYPE ||
+                wrapped_type->typ == PASCAL_T_FUNCTION_TYPE) {
+                var_type = convert_type_spec(wrapped_type, &type_id, NULL, &type_info);
+            } else if (wrapped_type->typ == PASCAL_T_IDENTIFIER) {
+                char *type_name = dup_symbol(wrapped_type);
+                if (type_name != NULL) {
+                    var_type = map_type_name(type_name, &type_id);
+                    var_type = apply_shortstring_mode(var_type, type_name);
+                    if (var_type == UNKNOWN_TYPE && type_id == NULL)
+                        type_id = type_name;
+                    else
+                        free(type_name);
+                }
+            }
+            cur = type_node->next;
+        } else {
+            cur = type_node;
+        }
     } else {
         cur = type_node;
     }
@@ -46,6 +81,7 @@ static Tree_t *convert_var_decl(ast_t *decl_node) {
              * since convert_type_spec resets all fields to NULL without freeing */
             destroy_type_info_contents(&type_info);
             var_type = convert_type_spec(search, &type_id, NULL, &type_info);
+            cur = search->next;
         } else if (search != NULL && search->typ == PASCAL_T_IDENTIFIER) {
             char *type_name = dup_symbol(search);
             if (type_name != NULL) {
@@ -57,6 +93,7 @@ static Tree_t *convert_var_decl(ast_t *decl_node) {
                     free(type_name);
                 var_type = mapped;
             }
+            cur = search->next;
         }
     }
 
@@ -233,7 +270,10 @@ static Tree_t *convert_var_decl(ast_t *decl_node) {
         }
 
         /* Skip nodes that should not be treated as initializers */
-        if (is_node_to_skip_as_initializer(init_node)) {
+        if (is_node_to_skip_as_initializer(init_node) &&
+            !(init_node->typ == PASCAL_T_IDENTIFIER &&
+              init_node != type_node &&
+              (type_id != NULL || var_type != UNKNOWN_TYPE))) {
             init_node = NULL;
         }
         
@@ -4165,4 +4205,3 @@ void append_type_decls_from_section(ast_t *type_section, ListNode_t **dest,
         type_decl = type_decl->next;
     }
 }
-

--- a/KGPC/Parser/ParseTree/from_cparser_parts/from_cparser_statements_and_programs.c
+++ b/KGPC/Parser/ParseTree/from_cparser_parts/from_cparser_statements_and_programs.c
@@ -2837,7 +2837,7 @@ Tree_t *tree_from_pascal_ast(ast_t *program_ast) {
                     }
                     ast_t *node_cursor = unwrap_pascal_node(definition);
                     if (node_cursor != NULL) {
-                        if (kgpc_getenv("KGPC_DEBUG_GENERIC_METHODS") != NULL) {
+                    if (kgpc_getenv("KGPC_DEBUG_GENERIC_METHODS") != NULL) {
                             fprintf(stderr, "[KGPC] implementation section node typ=%d\n", node_cursor->typ);
                         }
                         switch (node_cursor->typ) {
@@ -2857,6 +2857,17 @@ Tree_t *tree_from_pascal_ast(ast_t *program_ast) {
                             break;
                         case PASCAL_T_VAR_SECTION:
                             list_builder_extend(&implementation_var_builder, convert_var_section(node_cursor));
+                            break;
+                        case PASCAL_T_INITIALIZATION_SECTION:
+                            initialization_node = node_cursor;
+                            break;
+                        case PASCAL_T_FINALIZATION_SECTION:
+                            finalization_node = node_cursor;
+                            break;
+                        case PASCAL_T_BEGIN_BLOCK:
+                        case PASCAL_T_MAIN_BLOCK:
+                            if (initialization == NULL)
+                                initialization = convert_block(node_cursor);
                             break;
                         case PASCAL_T_PROCEDURE_DECL: {
                             Tree_t *proc = convert_procedure(node_cursor);

--- a/KGPC/Parser/SemanticCheck/SemChecks/SemCheck_Expr_Access.c
+++ b/KGPC/Parser/SemanticCheck/SemChecks/SemCheck_Expr_Access.c
@@ -287,6 +287,27 @@ static void semcheck_compute_array_linearization(SymTab_t *symtab,
         if (FindSymbol(&node, symtab, array_expr->expr_data.id) != 0 && node != NULL)
             array_type = node->type;
     }
+    else if (array_type == NULL && array_expr->type == EXPR_POINTER_DEREF &&
+        array_expr->expr_data.pointer_deref_data.pointer_expr != NULL)
+    {
+        struct Expression *pointer_expr =
+            array_expr->expr_data.pointer_deref_data.pointer_expr;
+        KgpcType *pointer_type = pointer_expr->resolved_kgpc_type;
+        if (pointer_type == NULL && pointer_expr->type == EXPR_VAR_ID &&
+            pointer_expr->expr_data.id != NULL && symtab != NULL)
+        {
+            HashNode_t *node = NULL;
+            if (FindSymbol(&node, symtab, pointer_expr->expr_data.id) != 0 &&
+                node != NULL)
+                pointer_type = node->type;
+        }
+        if (pointer_type != NULL && kgpc_type_is_pointer(pointer_type))
+        {
+            KgpcType *pointee = kgpc_type_resolve_pointer_pointee(pointer_type, symtab);
+            if (pointee != NULL && kgpc_type_is_array(pointee))
+                array_type = pointee;
+        }
+    }
 
     if (array_type == NULL || !kgpc_type_is_array(array_type))
         return;

--- a/KGPC/Parser/SemanticCheck/SemChecks/SemCheck_Expr_Internal.h
+++ b/KGPC/Parser/SemanticCheck/SemChecks/SemCheck_Expr_Internal.h
@@ -22,16 +22,8 @@
 #else
 #define strcasecmp _stricmp
 #define strncasecmp _strnicmp
-static inline char* strndup(const char* s, size_t n)
-{
-    size_t len = strnlen(s, n);
-    char* buf = (char*)malloc(len + 1);
-    if (buf == NULL) return NULL;
-    memcpy(buf, s, len);
-    buf[len] = '\0';
-    return buf;
-}
 #endif
+#include "../../../common_utils.h"
 
 #include "SemCheck_expr.h"
 #include "SemCheck_stmt.h"

--- a/KGPC/Parser/SemanticCheck/SemChecks/SemCheck_Expr_Ops.c
+++ b/KGPC/Parser/SemanticCheck/SemChecks/SemCheck_Expr_Ops.c
@@ -1346,7 +1346,120 @@ int semcheck_signterm(int *type_return,
     /* Checking types */
     if (*type_return == UNKNOWN_TYPE)
         return return_val;
-    if (*type_return == POINTER_TYPE || *type_return == RECORD_TYPE)
+    if (*type_return == RECORD_TYPE)
+    {
+        const char *record_type_name = get_expr_type_name(sign_expr, symtab);
+        if (record_type_name != NULL)
+        {
+            const char *op_suffix = "op_sub";
+            size_t name_len = strlen(record_type_name) + strlen(op_suffix) + 3;
+            char *operator_method = (char *)malloc(name_len);
+            if (operator_method != NULL)
+            {
+                snprintf(operator_method, name_len, "%s__%s",
+                    record_type_name, op_suffix);
+
+                HashNode_t *operator_node = NULL;
+                ListNode_t *operator_candidates = FindAllIdents(symtab, operator_method);
+                if (operator_candidates != NULL)
+                {
+                    HashNode_t *best_match = NULL;
+                    int num_best = 0;
+                    ListNode_t *args_given = CreateListNode(sign_expr, LIST_EXPR);
+                    if (args_given != NULL)
+                    {
+                        int resolve_status = semcheck_resolve_overload(
+                            &best_match,
+                            &num_best,
+                            operator_candidates,
+                            args_given,
+                            symtab,
+                            expr,
+                            max_scope_lev,
+                            1);
+                        if (resolve_status == 0 && best_match != NULL &&
+                            num_best == 1)
+                            operator_node = best_match;
+                        DestroyList(args_given);
+                    }
+
+                    if (operator_node == NULL)
+                    {
+                        for (ListNode_t *cur = operator_candidates; cur != NULL;
+                             cur = cur->next)
+                        {
+                            HashNode_t *candidate = (HashNode_t *)cur->cur;
+                            if (candidate == NULL ||
+                                (candidate->hash_type != HASHTYPE_FUNCTION &&
+                                 candidate->hash_type != HASHTYPE_PROCEDURE) ||
+                                candidate->type == NULL)
+                                continue;
+                            ListNode_t *params =
+                                kgpc_type_get_procedure_params(candidate->type);
+                            if (ListLength(params) == 1)
+                            {
+                                operator_node = candidate;
+                                break;
+                            }
+                        }
+                    }
+                    DestroyList(operator_candidates);
+                }
+
+                if (operator_node == NULL)
+                {
+                    size_t exact_len = strlen(operator_method) +
+                        strlen(record_type_name) + 2;
+                    char *operator_exact = (char *)malloc(exact_len);
+                    if (operator_exact != NULL)
+                    {
+                        snprintf(operator_exact, exact_len, "%s_%s",
+                            operator_method, record_type_name);
+                        FindSymbol(&operator_node, symtab, operator_exact);
+                        free(operator_exact);
+                    }
+                }
+
+                if (operator_node != NULL && operator_node->type != NULL &&
+                    kgpc_type_is_procedure(operator_node->type))
+                {
+                    KgpcType *return_type = kgpc_type_get_return_type(operator_node->type);
+                    if (return_type != NULL)
+                    {
+                        struct Expression *saved_arg = sign_expr;
+                        expr->type = EXPR_FUNCTION_CALL;
+                        memset(&expr->expr_data.function_call_data, 0,
+                            sizeof(expr->expr_data.function_call_data));
+                        expr->expr_data.function_call_data.is_operator_call = 1;
+                        expr->expr_data.function_call_data.id = strdup(operator_method);
+                        expr->expr_data.function_call_data.mangled_id =
+                            operator_node->mangled_id != NULL
+                                ? strdup(operator_node->mangled_id)
+                                : strdup(operator_method);
+                        expr->expr_data.function_call_data.args_expr =
+                            CreateListNode(saved_arg, LIST_EXPR);
+                        expr->expr_data.function_call_data.resolved_func = operator_node;
+                        expr->expr_data.function_call_data.call_hash_type =
+                            HASHTYPE_FUNCTION;
+                        expr->expr_data.function_call_data.call_kgpc_type =
+                            operator_node->type;
+                        kgpc_type_retain(operator_node->type);
+                        expr->expr_data.function_call_data.is_call_info_valid = 1;
+
+                        *type_return = semcheck_tag_from_kgpc(return_type);
+                        semcheck_expr_set_resolved_kgpc_type_shared(expr, return_type);
+                        semcheck_set_result_expr_metadata(expr, symtab, return_type);
+
+                        free(operator_method);
+                        return return_val;
+                    }
+                }
+                free(operator_method);
+            }
+        }
+        return return_val;
+    }
+    if (*type_return == POINTER_TYPE)
         return return_val;
     if(!is_type_ir(type_return))
     {

--- a/KGPC/Parser/SemanticCheck/SemChecks/SemCheck_overload.c
+++ b/KGPC/Parser/SemanticCheck/SemChecks/SemCheck_overload.c
@@ -1345,12 +1345,29 @@ static MatchQuality semcheck_classify_match(int actual_tag, KgpcType *actual_kgp
      * overload (assign_t_ss) over the RawByteString overload (assign_t_rbs). */
     if (is_string_type(formal_tag) && is_string_type(actual_tag))
     {
+        const char *formal_alias = (formal_kgpc != NULL && formal_kgpc->type_alias != NULL)
+            ? formal_kgpc->type_alias->alias_name : NULL;
+        StringKind formal_kind = semcheck_string_kind_from_type_id(formal_alias);
+
+        if (actual_tag == SHORTSTRING_TYPE && formal_tag == STRING_TYPE)
+        {
+            MatchQuality q = semcheck_make_quality(MATCH_PROMOTION);
+            if (formal_kind == STRING_KIND_WIDE)
+            {
+                q.kind = MATCH_CONVERSION;
+                q.string_rank = 1;
+            }
+            else if (formal_kind == STRING_KIND_NARROW)
+            {
+                q.exact_type_id = 1;
+            }
+            return q;
+        }
+
         if (actual_tag == STRING_TYPE && formal_tag == STRING_TYPE)
         {
             /* Both are AnsiString-family (STRING_TYPE).  Check alias names:
              * AnsiString → RawByteString is exact, other cross-aliases are promotion. */
-            const char *formal_alias = (formal_kgpc != NULL && formal_kgpc->type_alias != NULL)
-                ? formal_kgpc->type_alias->alias_name : NULL;
             if (formal_alias != NULL &&
                 pascal_identifier_equals(formal_alias, "RawByteString"))
                 return semcheck_make_quality(MATCH_EXACT);
@@ -2587,7 +2604,10 @@ int semcheck_resolve_overload(HashNode_t **best_match_out,
                             : STRING_KIND_UNKNOWN;
                         if (arg_kind == STRING_KIND_UNKNOWN && arg_expr_kgpc != NULL)
                         {
-                            if (semcheck_is_widechar_like_type(arg_expr_kgpc))
+                            if (kgpc_type_is_shortstring(arg_expr_kgpc) ||
+                                arg_expr_tag == SHORTSTRING_TYPE)
+                                arg_kind = STRING_KIND_NARROW;
+                            else if (semcheck_is_widechar_like_type(arg_expr_kgpc))
                                 arg_kind = STRING_KIND_WIDE;
                             else if (kgpc_type_is_char(arg_expr_kgpc))
                                 arg_kind = STRING_KIND_NARROW;

--- a/KGPC/Parser/SemanticCheck/SemChecks/SemCheck_stmt.c
+++ b/KGPC/Parser/SemanticCheck/SemChecks/SemCheck_stmt.c
@@ -20,16 +20,8 @@
 #include <strings.h>
 #else
 #define strncasecmp _strnicmp
-static inline char* strndup(const char* s, size_t n)
-{
-    size_t len = strnlen(s, n);
-    char* buf = (char*)malloc(len + 1);
-    if (buf == NULL) return NULL;
-    memcpy(buf, s, len);
-    buf[len] = '\0';
-    return buf;
-}
 #endif
+#include "../../../common_utils.h"
 #include "SemCheck_stmt.h"
 #include "SemCheck_expr.h"
 #include "SemCheck_overload.h"

--- a/KGPC/Parser/pascal_frontend.c
+++ b/KGPC/Parser/pascal_frontend.c
@@ -19,6 +19,7 @@
 #include "ast_cache.h"
 #include "../string_intern.h"
 #include "../compilation_context.h"
+#include "../../common/file_time.h"
 
 /* Global storage for user-defined preprocessor configuration */
 #define MAX_USER_INCLUDE_PATHS 64
@@ -38,7 +39,8 @@ static bool g_ast_cache_reads_enabled = true;
 
 /* Modification time of the compiler binary. When set, cached ASTs older
  * than the binary are considered stale and re-parsed. */
-static time_t g_compiler_mtime = 0;
+static struct timespec g_compiler_mtime = { 0, 0 };
+static bool g_compiler_mtime_known = false;
 
 /* Flag set when {$MODE objfpc} is detected in the current parse.
  * Used to automatically inject ObjPas unit dependency. */
@@ -72,9 +74,18 @@ static bool ast_cache_is_fresh(const char *cache_path, const char *source_path)
     if (cache_st.st_mtime < source_st.st_mtime)
         return false;
 
-    /* Cache must be newer than the compiler binary (if known) */
-    if (g_compiler_mtime > 0 && cache_st.st_mtime < g_compiler_mtime)
-        return false;
+    /* Cache must be newer than the compiler binary (if known). Use
+     * nanosecond precision so rebuilds and cache writes in the same second
+     * cannot accidentally reuse stale ASTs. */
+    if (g_compiler_mtime_known)
+    {
+        struct timespec cache_mtime = kgpc_stat_mtime(&cache_st);
+        if (cache_mtime.tv_sec < g_compiler_mtime.tv_sec)
+            return false;
+        if (cache_mtime.tv_sec == g_compiler_mtime.tv_sec &&
+            cache_mtime.tv_nsec < g_compiler_mtime.tv_nsec)
+            return false;
+    }
 
     return true;
 }
@@ -393,11 +404,23 @@ void pascal_frontend_set_ast_cache_dir(const char *dir)
     if (g_ast_cache_dir != NULL)
         free(g_ast_cache_dir);
     g_ast_cache_dir = (dir != NULL) ? strdup(dir) : NULL;
+    if (g_ast_cache_dir != NULL && kgpc_mkdir(g_ast_cache_dir, 0775) != 0)
+    {
+        struct stat st;
+        if (stat(g_ast_cache_dir, &st) != 0 || !S_ISDIR(st.st_mode))
+        {
+            fprintf(stderr, "Warning: AST cache directory '%s' is not usable; disabling AST cache.\n",
+                g_ast_cache_dir);
+            free(g_ast_cache_dir);
+            g_ast_cache_dir = NULL;
+        }
+    }
 }
 
-void pascal_frontend_set_compiler_mtime(time_t mtime)
+void pascal_frontend_set_compiler_mtime(struct timespec mtime)
 {
     g_compiler_mtime = mtime;
+    g_compiler_mtime_known = true;
 }
 
 const char * const *pascal_frontend_get_include_paths(int *count)
@@ -872,6 +895,15 @@ static char *compute_ast_cache_path(const char *source_path)
         if (g_user_defines[i] != NULL)
             hash = fnv1a64_bytes((const unsigned char *)g_user_defines[i],
                                  strlen(g_user_defines[i])) ^ hash;
+    }
+    if (g_compiler_mtime_known)
+    {
+        char compiler_stamp[64];
+        snprintf(compiler_stamp, sizeof(compiler_stamp), "%lld.%09ld",
+                 (long long)g_compiler_mtime.tv_sec,
+                 (long)g_compiler_mtime.tv_nsec);
+        hash = fnv1a64_bytes((const unsigned char *)compiler_stamp,
+                             strlen(compiler_stamp)) ^ hash;
     }
     /* <dir>/<16-hex>.ast_cache\0 */
     size_t total = dir_len + 1 + 16 + 10 + 1;

--- a/KGPC/Parser/pascal_frontend.h
+++ b/KGPC/Parser/pascal_frontend.h
@@ -24,7 +24,7 @@ void pascal_frontend_set_ast_cache_dir(const char *dir);
 
 /* Set the compiler binary's modification time so cached ASTs older than
  * the binary are invalidated automatically. */
-void pascal_frontend_set_compiler_mtime(time_t mtime);
+void pascal_frontend_set_compiler_mtime(struct timespec mtime);
 
 /* Get the list of user-defined include paths for unit search */
 const char * const *pascal_frontend_get_include_paths(int *count);

--- a/KGPC/Units/unixtype.p
+++ b/KGPC/Units/unixtype.p
@@ -29,8 +29,8 @@ type
 
 function fputime(path: PAnsiChar; times: PUTimBuf): cint; external;
 function fpopendir(path: PAnsiChar): pdir; external;
-function fpclosedir(var d: TDir): cint; external;
-function fpreaddir(var d: TDir): pdirent; external;
+function fpclosedir(dirp: pdir): cint; external;
+function fpreaddir(dirp: pdir): pdirent; external;
 function fpreadlink(path: PAnsiChar): String; external;
 function utimensat(dirfd: cint; path: PAnsiChar; var times: TTimespecArr; flags: cint): cint; external;
 function fpfutimens(fd: cint; var times: TTimespecArr): cint; external;

--- a/KGPC/common_utils.h
+++ b/KGPC/common_utils.h
@@ -20,6 +20,7 @@
 #ifndef strncasecmp
 #define strncasecmp _strnicmp
 #endif
+#ifndef HAVE_STRNDUP
 static inline char* kgpc_strndup(const char* s, size_t n)
 {
     size_t len = strnlen(s, n);
@@ -31,6 +32,7 @@ static inline char* kgpc_strndup(const char* s, size_t n)
     return buf;
 }
 #define strndup kgpc_strndup
+#endif
 #endif /* _WIN32 */
 
 /**

--- a/KGPC/main_cparser.c
+++ b/KGPC/main_cparser.c
@@ -63,12 +63,15 @@ static int unsetenv(const char *name)
 #include "stacktrace.h"
 #include "unit_paths.h"
 #include "arena.h"
+#include "file_lock.h"
+#include "file_time.h"
 #include "identifier_utils.h"
 #include "compilation_context.h"
 
 #ifdef _WIN32
 #include <windows.h>
 #include <io.h>
+#include <process.h>
 
 /* Cached getenv() — defined in SemCheck.c */
 extern const char *kgpc_getenv(const char *name);
@@ -76,6 +79,9 @@ extern const char *kgpc_getenv(const char *name);
 #define R_OK 4
 #endif
 #define access _access
+#define kgpc_getpid() _getpid()
+#else
+#define kgpc_getpid() getpid()
 #endif
 
 extern ast_t *ast_nil;
@@ -100,6 +106,7 @@ static char g_codegen_cache_asm_path[4096]; /* path to the cache .s (unit functi
 static int g_codegen_cache_hit = 0; /* 1 if cache hit, 0 if miss */
 static int g_codegen_cache_forced_function_sections = 0;
 static int g_codegen_cache_forced_skip_unit_codegen = 0;
+static int g_codegen_cache_lock_held = 0;
 static int g_saved_argc = 0;
 static char **g_saved_argv = NULL;
 static int g_batch_mode = 0;
@@ -439,10 +446,12 @@ static char *build_default_ast_cache_dir(const char *argv0)
         memset(&st, 0, sizeof(st));
 
     char signature_input[PATH_MAX + 128];
-    snprintf(signature_input, sizeof(signature_input), "%s|%lld|%lld",
+    struct timespec compiler_mtime = kgpc_stat_mtime(&st);
+    snprintf(signature_input, sizeof(signature_input), "%s|%lld|%lld.%09ld",
              compiler_path,
              (long long)st.st_size,
-             (long long)st.st_mtime);
+             (long long)compiler_mtime.tv_sec,
+             (long)compiler_mtime.tv_nsec);
     uint64_t sig = fnv1a64_bytes((const unsigned char *)signature_input, strlen(signature_input));
 
     size_t needed = strlen(compiler_path) + 1 + strlen("kgpc_ast_cache_") + 16 + 1;
@@ -1947,9 +1956,10 @@ static int batch_mode_main(int argc, char **argv)
 #endif /* !_WIN32 */
 
 static void emit_link_args(void); /* forward declaration */
-static void codegen_cache_check(void);
+static void codegen_cache_check(const char *input_file);
 static void codegen_cache_populate(const char *asm_file);
 static void codegen_cache_clear_transient_flags(void);
+static void codegen_cache_release_lock_if_held(void);
 
 /* Compile a single Pascal program.  Used by both normal mode and batch mode.
  * Returns 0 on success, non-zero on error. */
@@ -2158,7 +2168,7 @@ static int compile_single_program(
     if (sem_result <= 0)
     {
         /* Check codegen cache after semcheck (units are fully loaded) */
-        codegen_cache_check();
+        codegen_cache_check(input_file);
 
         fprintf(stderr, "Generating code to file: %s\n", output_file);
 
@@ -2252,10 +2262,13 @@ static void hash_string(unsigned long *hash, const char *s)
     *hash = *hash * 33 + '\0';
 }
 
-/* Compute a cache key from flags, loaded unit names, unit source mtimes, and compiler mtime.
- * The key deliberately excludes the input/output file paths (positional args)
- * since the cached unit functions are the same regardless of which program uses them. */
-static void codegen_cache_compute_key(char *key_buf, size_t key_buf_size)
+/* Compute a cache key from flags, the input source, loaded unit names, unit
+ * source mtimes, and compiler mtime.  Unit code generation is not purely a
+ * function of the unit set in all FPC RTL cases: generic/specialized code and
+ * fallback sections can depend on the program being compiled.  Keep the output
+ * path out of the key, but include the input source identity and mtime so
+ * unrelated programs cannot link each other's cached object. */
+static void codegen_cache_compute_key(const char *input_file, char *key_buf, size_t key_buf_size)
 {
     unsigned long hash = 5381;
 
@@ -2272,6 +2285,19 @@ static void codegen_cache_compute_key(char *key_buf, size_t key_buf_size)
         if (strncmp(arg, "--pp-cache-dir=", 15) == 0)
             continue;
         hash_string(&hash, arg);
+    }
+
+    if (input_file != NULL)
+    {
+        hash_string(&hash, input_file);
+        struct stat st;
+        if (stat(input_file, &st) == 0)
+        {
+            struct timespec mtime = kgpc_stat_mtime(&st);
+            hash = hash * 33 + (unsigned long)st.st_size;
+            hash = hash * 33 + (unsigned long)mtime.tv_sec;
+            hash = hash * 33 + (unsigned long)mtime.tv_nsec;
+        }
     }
 
     /* Hash sorted unit names */
@@ -2319,7 +2345,12 @@ static void codegen_cache_compute_key(char *key_buf, size_t key_buf_size)
             {
                 struct stat st;
                 if (stat(path, &st) == 0)
-                    hash = hash * 33 + (unsigned long)st.st_mtime;
+                {
+                    struct timespec mtime = kgpc_stat_mtime(&st);
+                    hash = hash * 33 + (unsigned long)st.st_size;
+                    hash = hash * 33 + (unsigned long)mtime.tv_sec;
+                    hash = hash * 33 + (unsigned long)mtime.tv_nsec;
+                }
             }
         }
     }
@@ -2334,12 +2365,18 @@ static void codegen_cache_compute_key(char *key_buf, size_t key_buf_size)
             {
                 struct stat st;
                 if (stat(ipath, &st) == 0)
-                    hash = hash * 33 + (unsigned long)st.st_mtime;
+                {
+                    struct timespec mtime = kgpc_stat_mtime(&st);
+                    hash = hash * 33 + (unsigned long)st.st_size;
+                    hash = hash * 33 + (unsigned long)mtime.tv_sec;
+                    hash = hash * 33 + (unsigned long)mtime.tv_nsec;
+                }
             }
         }
     }
 
-    /* Include compiler binary mtime */
+    /* Include compiler binary size + nanosecond mtime so rebuilt KGPCs cannot
+     * reuse object code generated by a previous compiler built in the same second. */
     {
         char exe_path[PATH_MAX];
         ssize_t len = get_executable_path(exe_path, sizeof(exe_path), NULL);
@@ -2347,7 +2384,12 @@ static void codegen_cache_compute_key(char *key_buf, size_t key_buf_size)
         {
             struct stat st;
             if (stat(exe_path, &st) == 0)
-                hash = hash * 33 + (unsigned long)st.st_mtime;
+            {
+                struct timespec mtime = kgpc_stat_mtime(&st);
+                hash = hash * 33 + (unsigned long)st.st_size;
+                hash = hash * 33 + (unsigned long)mtime.tv_sec;
+                hash = hash * 33 + (unsigned long)mtime.tv_nsec;
+            }
         }
     }
 
@@ -2357,7 +2399,7 @@ static void codegen_cache_compute_key(char *key_buf, size_t key_buf_size)
 /* Check if a codegen cache entry exists for the current unit set.
  * Cache hit: enables skip-unit-codegen + function-sections.
  * Cache miss: enables function-sections + codegen_cache_miss_flag. */
-static void codegen_cache_check(void)
+static void codegen_cache_check(const char *input_file)
 {
     if (g_codegen_cache_dir == NULL)
         return;
@@ -2366,11 +2408,24 @@ static void codegen_cache_check(void)
     g_codegen_cache_forced_skip_unit_codegen = 0;
 
     char key[32];
-    codegen_cache_compute_key(key, sizeof(key));
+    codegen_cache_compute_key(input_file, key, sizeof(key));
     snprintf(g_codegen_cache_obj_path, sizeof(g_codegen_cache_obj_path),
              "%s/%s.o", g_codegen_cache_dir, key);
-    snprintf(g_codegen_cache_asm_path, sizeof(g_codegen_cache_asm_path),
-             "%s/%s.s", g_codegen_cache_dir, key);
+    g_codegen_cache_asm_path[0] = '\0';
+    g_codegen_cache_lock_held = 0;
+
+    if (access(g_codegen_cache_obj_path, R_OK) != 0 &&
+        file_lock_acquire(g_codegen_cache_obj_path, 300))
+    {
+        if (access(g_codegen_cache_obj_path, R_OK) == 0)
+        {
+            file_lock_release(g_codegen_cache_obj_path);
+        }
+        else
+        {
+            g_codegen_cache_lock_held = 1;
+        }
+    }
 
     if (access(g_codegen_cache_obj_path, R_OK) == 0)
     {
@@ -2390,6 +2445,8 @@ static void codegen_cache_check(void)
     else
     {
         fprintf(stderr, "Codegen cache miss; will populate: %s\n", g_codegen_cache_obj_path);
+        snprintf(g_codegen_cache_asm_path, sizeof(g_codegen_cache_asm_path),
+                 "%s/%s.%ld.s.tmp", g_codegen_cache_dir, key, (long)kgpc_getpid());
         if (!function_sections_flag())
         {
             set_function_sections_flag();
@@ -2402,6 +2459,7 @@ static void codegen_cache_check(void)
 
 static void codegen_cache_clear_transient_flags(void)
 {
+    codegen_cache_release_lock_if_held();
     clear_codegen_cache_miss_flag();
     if (g_codegen_cache_forced_skip_unit_codegen)
         clear_skip_unit_codegen_flag();
@@ -2409,6 +2467,15 @@ static void codegen_cache_clear_transient_flags(void)
         clear_function_sections_flag();
     g_codegen_cache_forced_skip_unit_codegen = 0;
     g_codegen_cache_forced_function_sections = 0;
+}
+
+static void codegen_cache_release_lock_if_held(void)
+{
+    if (g_codegen_cache_lock_held && g_codegen_cache_obj_path[0] != '\0')
+    {
+        file_lock_release(g_codegen_cache_obj_path);
+        g_codegen_cache_lock_held = 0;
+    }
 }
 
 /* Replace broken sections in cache .s with ud2 stubs.
@@ -2598,10 +2665,13 @@ static void codegen_cache_populate(const char *cache_asm_file)
 
     char err_file[4200];
     snprintf(err_file, sizeof(err_file), "%s.err", cache_asm_file);
+    char tmp_obj_file[4200];
+    snprintf(tmp_obj_file, sizeof(tmp_obj_file), "%s.%ld.tmp",
+             g_codegen_cache_obj_path, (long)kgpc_getpid());
 
     char cmd[8500];
     snprintf(cmd, sizeof(cmd), "as '%s' -o '%s' 2>'%s'",
-             cache_asm_file, g_codegen_cache_obj_path, err_file);
+             cache_asm_file, tmp_obj_file, err_file);
     int rc = system(cmd);
 
     if (rc != 0)
@@ -2620,22 +2690,41 @@ static void codegen_cache_populate(const char *cache_asm_file)
         {
             /* Retry assembly with patched file */
             snprintf(cmd, sizeof(cmd), "as '%s' -o '%s' 2>/dev/null",
-                     cache_asm_file, g_codegen_cache_obj_path);
+                     cache_asm_file, tmp_obj_file);
             rc = system(cmd);
         }
 
         if (rc != 0)
         {
             fprintf(stderr, "WARNING: codegen cache: as failed (rc=%d), cache not populated\n", rc);
-            remove(g_codegen_cache_obj_path);
+            remove(tmp_obj_file);
             g_codegen_cache_obj_path[0] = '\0';
             remove(err_file);
+            remove(cache_asm_file);
+            codegen_cache_release_lock_if_held();
             return;
         }
     }
 
+    if (rename(tmp_obj_file, g_codegen_cache_obj_path) != 0)
+    {
+        if (access(g_codegen_cache_obj_path, R_OK) != 0)
+        {
+            fprintf(stderr, "WARNING: codegen cache: failed to publish %s: %s\n",
+                    g_codegen_cache_obj_path, strerror(errno));
+            g_codegen_cache_obj_path[0] = '\0';
+        }
+        remove(tmp_obj_file);
+        remove(err_file);
+        remove(cache_asm_file);
+        codegen_cache_release_lock_if_held();
+        return;
+    }
+
     remove(err_file);
+    remove(cache_asm_file);
     fprintf(stderr, "Codegen cache populated: %s\n", g_codegen_cache_obj_path);
+    codegen_cache_release_lock_if_held();
 }
 
 static void emit_link_args(void)
@@ -2718,7 +2807,7 @@ int main(int argc, char **argv)
         {
             struct stat exe_st;
             if (stat(exe_path, &exe_st) == 0)
-                pascal_frontend_set_compiler_mtime(exe_st.st_mtime);
+                pascal_frontend_set_compiler_mtime(kgpc_stat_mtime(&exe_st));
         }
     }
 
@@ -3434,7 +3523,7 @@ int main(int argc, char **argv)
     if (sem_result <= 0)
     {
         /* Check codegen cache after semcheck (units are fully loaded) */
-        codegen_cache_check();
+        codegen_cache_check(input_file);
 
         fprintf(stderr, "Generating code to file: %s\n", output_file);
 

--- a/KGPC/runtime.c
+++ b/KGPC/runtime.c
@@ -464,6 +464,34 @@ static void kgpc_init_stdio(void)
     Output_ptr = &kgpc_stdout_file; /* Output = stdout */
 }
 
+/* Re-initialize stdio FILE* pointers unconditionally.
+ * On some platforms (e.g. MSYS/Cygwin with -static linking), the
+ * __attribute__((constructor)) may fire before the C library has fully
+ * set up stdin/stdout/stderr, causing stale FILE* values in the
+ * KGPCTextRec records.  This function refreshes them and is called from
+ * kgpc_init_args() (i.e. from main()) where stdio is guaranteed valid. */
+static void kgpc_reinit_stdio(void)
+{
+    kgpc_stdin_file.handle = fileno(stdin);
+    kgpc_stdout_file.handle = fileno(stdout);
+    kgpc_stderr_file.handle = fileno(stderr);
+    kgpc_stdin_file.private_data = (int64_t)(uintptr_t)stdin;
+    kgpc_stdout_file.private_data = (int64_t)(uintptr_t)stdout;
+    kgpc_stderr_file.private_data = (int64_t)(uintptr_t)stderr;
+
+    stdin_ptr = &kgpc_stdin_file;
+    stdout_ptr = &kgpc_stdout_file;
+    stderr_ptr = &kgpc_stderr_file;
+    Input_ptr = &kgpc_stdin_file;
+    Output_ptr = &kgpc_stdout_file;
+}
+
+__attribute__((constructor))
+static void kgpc_init_stdio_constructor(void)
+{
+    kgpc_init_stdio();
+}
+
 static void kgpc_textrec_init_defaults(KGPCTextRec *file)
 {
     if (file == NULL)
@@ -3224,6 +3252,7 @@ char *kgpc_alloc_empty_string(void)
 void kgpc_init_widestringmanager(void);
 
 void kgpc_fpc_init_os_params(int argc, char **argv, char **envp);
+void kgpc_fpc_init_stack_params(void *stack_probe);
 void kgpc_fpc_init_thread_manager(void);
 void kgpc_fpc_init_fpu(void);
 
@@ -3231,7 +3260,16 @@ void kgpc_init_args(int argc, char **argv, char **envp)
 {
     kgpc_argc = (argc < 0) ? 0 : argc;
     kgpc_argv = argv;
+    /* Ensure stdio pointers (stdin_ptr, stdout_ptr, stderr_ptr) are
+     * initialized before any Pascal code runs.  The __attribute__((constructor))
+     * in kgpc_init_stdio_constructor normally handles this, but on some
+     * platforms (e.g. MSYS/Cygwin with -static linking) the constructor may
+     * execute before the C library's stdio is fully set up, leaving
+     * stderr_ptr pointing to an invalid FILE*.  Re-init unconditionally
+     * from main() where stdio is guaranteed valid. */
+    kgpc_reinit_stdio();
     kgpc_fpc_init_os_params(argc, argv, envp);
+    kgpc_fpc_init_stack_params(&argc);
     kgpc_fpc_init_thread_manager();
     kgpc_init_widestringmanager();
     kgpc_fpc_init_fpu();

--- a/KGPC/runtime_fpc_init.c
+++ b/KGPC/runtime_fpc_init.c
@@ -28,12 +28,24 @@ int32_t  operatingsystem_parameter_argc = 0;
 void    *operatingsystem_parameter_argv = NULL;
 void    *operatingsystem_parameter_envp = NULL;
 
+/* FPC system startup globals normally provided by the target startup code. */
+uintptr_t __stklen = 8u * 1024u * 1024u;
+void *__stkptr = NULL;
+
 /* Called from kgpc_init_args to populate FPC globals */
 void kgpc_fpc_init_os_params(int argc, char **argv, char **envp)
 {
     operatingsystem_parameter_argc = (int32_t)argc;
     operatingsystem_parameter_argv = (void *)argv;
     operatingsystem_parameter_envp = (void *)envp;
+}
+
+void kgpc_fpc_init_stack_params(void *stack_probe)
+{
+    if (__stkptr == NULL)
+        __stkptr = stack_probe;
+    if (__stklen == 0)
+        __stklen = 8u * 1024u * 1024u;
 }
 
 /* ------------------------------------------------------------------ */

--- a/common/file_lock.c
+++ b/common/file_lock.c
@@ -1,0 +1,205 @@
+#include "file_lock.h"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <time.h>
+
+#ifdef _WIN32
+#include <io.h>
+#include <windows.h>
+#define close _close
+#define getpid GetCurrentProcessId
+#define open _open
+#define unlink _unlink
+#define write _write
+#else
+#include <unistd.h>
+#endif
+
+typedef struct HeldLock {
+    char *path;
+    char *lock_path;
+    int count;
+    struct HeldLock *next;
+} HeldLock;
+
+static HeldLock *g_held_locks = NULL;
+
+static bool is_pid_alive(int pid)
+{
+    if (pid <= 0)
+        return false;
+#ifdef _WIN32
+    HANDLE h = OpenProcess(PROCESS_QUERY_INFORMATION, FALSE, (DWORD)pid);
+    if (h == NULL)
+        return false;
+    DWORD exit_code = 0;
+    bool alive = GetExitCodeProcess(h, &exit_code) && exit_code == STILL_ACTIVE;
+    CloseHandle(h);
+    return alive;
+#else
+    return kill(pid, 0) == 0 || errno == EPERM;
+#endif
+}
+
+static bool try_acquire(const char *lock_path)
+{
+#ifdef _WIN32
+    int fd = open(lock_path, _O_CREAT | _O_EXCL | _O_RDWR | _O_BINARY, 0666);
+#else
+    int fd = open(lock_path, O_CREAT | O_EXCL | O_RDWR, 0666);
+#endif
+    if (fd >= 0)
+    {
+        char pid_buf[32];
+        int len = snprintf(pid_buf, sizeof(pid_buf), "%d\n", (int)getpid());
+        if (write(fd, pid_buf, (size_t)len) != len)
+        {
+            close(fd);
+            unlink(lock_path);
+            return false;
+        }
+        close(fd);
+        return true;
+    }
+
+    if (errno == EEXIST)
+    {
+        FILE *f = fopen(lock_path, "r");
+        if (f != NULL)
+        {
+            int pid = 0;
+            int parsed = fscanf(f, "%d", &pid);
+            fclose(f);
+            if ((parsed == 1 && !is_pid_alive(pid)) || parsed != 1)
+            {
+                unlink(lock_path);
+                return try_acquire(lock_path);
+            }
+        }
+    }
+
+    return false;
+}
+
+bool file_lock_acquire(const char *path, int timeout_secs)
+{
+    if (path == NULL || path[0] == '\0')
+        return false;
+
+    for (HeldLock *held = g_held_locks; held != NULL; held = held->next)
+    {
+        if (strcmp(held->path, path) == 0)
+        {
+            held->count++;
+            return true;
+        }
+    }
+
+    size_t lock_len = strlen(path) + 8;
+    char *lock_path = malloc(lock_len);
+    if (lock_path == NULL)
+        return false;
+    snprintf(lock_path, lock_len, "%s.lock", path);
+
+#ifdef _WIN32
+    DWORD start_ms = GetTickCount();
+#else
+    struct timespec start_ts;
+    clock_gettime(CLOCK_MONOTONIC, &start_ts);
+#endif
+
+    long wait_ms = 10;
+    while (!try_acquire(lock_path))
+    {
+        if (timeout_secs > 0)
+        {
+#ifdef _WIN32
+            if (GetTickCount() - start_ms >= (DWORD)timeout_secs * 1000)
+#else
+            struct timespec now_ts;
+            clock_gettime(CLOCK_MONOTONIC, &now_ts);
+            long long elapsed_ns =
+                ((long long)now_ts.tv_sec - (long long)start_ts.tv_sec) * 1000000000LL +
+                ((long long)now_ts.tv_nsec - (long long)start_ts.tv_nsec);
+            if (elapsed_ns >= (long long)timeout_secs * 1000000000LL)
+#endif
+            {
+                free(lock_path);
+                return false;
+            }
+        }
+
+#ifdef _WIN32
+        Sleep((DWORD)wait_ms);
+#else
+        struct timespec sleep_ts;
+        sleep_ts.tv_sec = wait_ms / 1000;
+        sleep_ts.tv_nsec = (wait_ms % 1000) * 1000000L;
+        nanosleep(&sleep_ts, NULL);
+#endif
+        wait_ms *= 2;
+        if (wait_ms > 1000)
+            wait_ms = 1000;
+    }
+
+    HeldLock *held = malloc(sizeof(*held));
+    if (held == NULL)
+    {
+        unlink(lock_path);
+        free(lock_path);
+        return false;
+    }
+    held->path = strdup(path);
+    if (held->path == NULL)
+    {
+        unlink(lock_path);
+        free(lock_path);
+        free(held);
+        return false;
+    }
+    held->lock_path = lock_path;
+    held->count = 1;
+    held->next = g_held_locks;
+    g_held_locks = held;
+
+    return true;
+}
+
+void file_lock_release(const char *path)
+{
+    if (path == NULL || path[0] == '\0')
+        return;
+
+    HeldLock *prev = NULL;
+    HeldLock *held = g_held_locks;
+    while (held != NULL)
+    {
+        if (strcmp(held->path, path) == 0)
+        {
+            held->count--;
+            if (held->count > 0)
+                return;
+
+            if (held->lock_path != NULL)
+                unlink(held->lock_path);
+
+            if (prev != NULL)
+                prev->next = held->next;
+            else
+                g_held_locks = held->next;
+
+            free(held->path);
+            free(held->lock_path);
+            free(held);
+            return;
+        }
+        prev = held;
+        held = held->next;
+    }
+}

--- a/common/file_lock.h
+++ b/common/file_lock.h
@@ -1,0 +1,9 @@
+#ifndef KGPC_FILE_LOCK_H
+#define KGPC_FILE_LOCK_H
+
+#include <stdbool.h>
+
+bool file_lock_acquire(const char *path, int timeout_secs);
+void file_lock_release(const char *path);
+
+#endif /* KGPC_FILE_LOCK_H */

--- a/common/file_time.h
+++ b/common/file_time.h
@@ -1,0 +1,42 @@
+#ifndef KGPC_FILE_TIME_H
+#define KGPC_FILE_TIME_H
+
+#include <sys/stat.h>
+#include <time.h>
+
+#ifdef _WIN32
+#include <direct.h>
+#endif
+
+static inline struct timespec kgpc_stat_mtime(const struct stat *st)
+{
+    struct timespec ts;
+    if (st == NULL)
+    {
+        ts.tv_sec = 0;
+        ts.tv_nsec = 0;
+        return ts;
+    }
+
+#ifdef _WIN32
+    ts.tv_sec = st->st_mtime;
+    ts.tv_nsec = 0;
+#elif defined(__APPLE__) && defined(_DARWIN_FEATURE_64_BIT_INODE)
+    ts = st->st_mtimespec;
+#else
+    ts = st->st_mtim;
+#endif
+    return ts;
+}
+
+static inline int kgpc_mkdir(const char *path, int mode)
+{
+#ifdef _WIN32
+    (void)mode;
+    return _mkdir(path);
+#else
+    return mkdir(path, (mode_t)mode);
+#endif
+}
+
+#endif /* KGPC_FILE_TIME_H */

--- a/cparser/ast_cache.h
+++ b/cparser/ast_cache.h
@@ -22,7 +22,7 @@
 #include <stddef.h>
 #include <stdbool.h>
 
-#define AST_CACHE_VERSION 1
+#define AST_CACHE_VERSION 2
 
 /* Save a parsed AST tree and its preprocessed source buffer to a binary cache file.
  * Returns true on success. */

--- a/cparser/examples/pascal_parser/pascal_declaration.c
+++ b/cparser/examples/pascal_parser/pascal_declaration.c
@@ -2822,11 +2822,11 @@ void init_pascal_unit_parser(combinator_t** p) {
         NULL
     ));
 
-    combinator_t* legacy_initialization_block = optional(map(seq(new_combinator(), PASCAL_T_NONE,
+    combinator_t* legacy_initialization_block = optional(seq(new_combinator(), PASCAL_T_INITIALIZATION_SECTION,
         token(keyword_ci("begin")),
         make_stmt_list_parser(stmt_parser),
         NULL
-    ), discard_ast));
+    ));
 
     combinator_t* unit_semicolon_delim = token(match(";"));
     combinator_t* unit_directives = map(until(unit_semicolon_delim, PASCAL_T_NONE), discard_ast);

--- a/cparser/examples/pascal_parser/pascal_declaration.c
+++ b/cparser/examples/pascal_parser/pascal_declaration.c
@@ -11,8 +11,8 @@
 #include <ctype.h>
 #include <stdbool.h>
 
-// Windows compatibility: strndup is not available on Windows
-#ifdef _WIN32
+// Windows compatibility: strndup is not available on some Windows compilers
+#if defined(_WIN32) && !defined(HAVE_STRNDUP)
 static char* strndup(const char* s, size_t n)
 {
     size_t len = strnlen(s, n);

--- a/cparser/examples/pascal_parser/pascal_parser.c
+++ b/cparser/examples/pascal_parser/pascal_parser.c
@@ -14,6 +14,8 @@
 #ifndef strncasecmp
 #define strncasecmp _strnicmp
 #endif
+#endif
+#if defined(_WIN32) && !defined(HAVE_STRNDUP)
 static char* strndup(const char* s, size_t n)
 {
     size_t len = strlen(s);

--- a/cparser/parser.c
+++ b/cparser/parser.c
@@ -13,6 +13,7 @@
 #include "combinator_internals.h"
 
 #ifdef _WIN32
+#ifndef HAVE_STRNDUP
 static char* strndup(const char* s, size_t n)
 {
     size_t len = strnlen(s, n);
@@ -23,6 +24,7 @@ static char* strndup(const char* s, size_t n)
     buf[len] = '\0';
     return buf;
 }
+#endif
 #endif
 
 //=============================================================================

--- a/docs/FPC_BOOTSTRAP.md
+++ b/docs/FPC_BOOTSTRAP.md
@@ -1,6 +1,6 @@
 # FPC Bootstrap Analysis
 
-## Status: 56 RTL units compile (0 errors); pp.pas compiles with 0 errors (down from 1279)
+## Status: FPC RTL test suite passes; `pp.pas` compiles and links as `pp_bootstrap`
 
 ## Prerequisites
 
@@ -183,9 +183,9 @@ ordering issues.
   -I./FPCSource/packages/rtl-objpas/src/inc
 ```
 
-### pp.pas (current bootstrap attempt)
+### pp.pas (direct KGPC invocation)
 ```bash
-./build/KGPC/kgpc FPCSource/compiler/pp.pas --no-stdlib \
+./build-fpc/KGPC/kgpc FPCSource/compiler/pp.pas tests/output/pp_bootstrap.s --no-stdlib \
   -DCPU64 -DCPUX86_64 -Dx86_64 -DFPC -DLINUX -DUNIX -DFPC_HAS_TYPE_EXTENDED -DSUPPORT_EXTENDED -DFPC_BOOTSTRAP_INDIRECT_ENTRY -Sg \
   -IFPCSource/rtl/objpas \
   -IFPCSource/rtl/objpas/sysutils \
@@ -211,6 +211,35 @@ ordering issues.
   -FuFPCSource/compiler/systems
 ```
 
+Then link the generated assembly with the KGPC runtime:
+```bash
+cc -O2 -no-pie \
+  -o tests/output/pp_bootstrap \
+  tests/output/pp_bootstrap.s \
+  build-fpc/KGPC/libkgpc_runtime.a
+```
+
+The Meson test harness is the preferred way to run the complete bootstrap flow,
+because it also ensures `msgtxt.inc` and `msgidx.inc` exist by compiling and
+running `compiler/utils/msg2inc.pp` when needed:
+```bash
+meson setup build-fpc -Drun_fpc_rtl_tests=true
+ninja -C build-fpc KGPC/kgpc KGPC/libkgpc_runtime.a
+KGPC_FPC_RTL=1 \
+KGPC_FPC_RTL_DIR=FPCSource \
+KGPC_RUNTIME_LIB="$PWD/build-fpc/KGPC/libkgpc_runtime.a" \
+MESON_BUILD_ROOT="$PWD/build-fpc" \
+CC=cc \
+python3 tests/do_not_run_me_directly_but_through_meson.py \
+  TestCompiler.test_fpcrtl_pp_pas_bootstrap
+```
+
+This writes:
+```text
+tests/output/pp_bootstrap.s
+tests/output/pp_bootstrap
+```
+
 Note: `-Dx86_64` is required (FPC's Makefile passes `-dx86_64` for x86_64 targets).
 The x86/x86_64/systems subdirectories match FPC's `-Fux86 -Fix86 -Fux86_64 -Fix86_64 -Fusystems`.
 `-DFPC_HAS_TYPE_EXTENDED -DSUPPORT_EXTENDED` are needed so `systemh.inc` defines `TExtended80Rec`
@@ -221,11 +250,31 @@ The x86/x86_64/systems subdirectories match FPC's `-Fux86 -Fix86 -Fux86_64 -Fix8
 (emitted as `.comm` by codegen). Without it, they're declared `external name` and expected to come
 from ASM startup object files (`si_c.inc` via `{$L}`), which KGPC doesn't support.
 
-### Linking status
+### Compile hello world with the generated `pp_bootstrap`
 
-Compilation succeeds (0 errors), but linking fails with **3033 undefined symbols** (#540).
-Most are class method bodies (destructors, constructors, ppuwrite, etc.) that the codegen
-doesn't emit. See #540 for breakdown.
+Pass the FPC RTL unit paths explicitly. Do not rely on guessed search paths.
+```bash
+./tests/output/pp_bootstrap -n \
+  -FuFPCSource/rtl/linux \
+  -FuFPCSource/rtl/unix \
+  -FuFPCSource/rtl/inc \
+  -FuFPCSource/rtl/objpas \
+  -FuFPCSource/rtl/objpas/sysutils \
+  -FuFPCSource/rtl/objpas/classes \
+  tests/test_cases/helloworld.p
+
+./tests/output/helloworld
+```
+
+Expected output:
+```text
+Hello, World!
+```
+
+The generated compiler also supports a quick startup check:
+```bash
+./tests/output/pp_bootstrap -h
+```
 
 ### FPC RTL (56 units)
 

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,10 @@
 project('kgpc-project', 'c')
 
+cc = meson.get_compiler('c')
+if cc.has_function('strndup', prefix: '#include <string.h>')
+  add_project_arguments('-DHAVE_STRNDUP', language: 'c')
+endif
+
 cparser_core_sources = [
   'cparser/parser.c',
   'cparser/combinators.c',

--- a/meson.build
+++ b/meson.build
@@ -10,6 +10,7 @@ cparser_core_sources = [
   'cparser/combinators.c',
   'cparser/ast_cache.c',
   'common/arena.c',
+  'common/file_lock.c',
 ]
 
 pascal_parser_sources = [

--- a/tests/do_not_run_me_directly_but_through_meson.py
+++ b/tests/do_not_run_me_directly_but_through_meson.py
@@ -199,18 +199,14 @@ if FPC_RTL_MODE:
     _FPC_RTL_AST_CACHE_DIR = os.path.join(
         os.environ.get("MESON_BUILD_ROOT", "builddir"), "fpc_rtl_ast_cache"
     )
-    # Invalidate cache when the compiler binary has been rebuilt
+    # KGPC validates AST cache entries against the compiler binary mtime.
+    # Keep a sentinel for diagnostics, but do not delete the cache directory:
+    # stale entries are rejected by the compiler and can coexist safely.
     _cache_sentinel = os.path.join(_FPC_RTL_AST_CACHE_DIR, ".compiler_mtime")
     _compiler_mtime = ""
     if os.path.exists(KGPC_PATH):
         st = os.stat(KGPC_PATH)
         _compiler_mtime = f"{st.st_mtime_ns}:{st.st_size}"
-    _old_mtime = ""
-    if os.path.exists(_cache_sentinel):
-        with open(_cache_sentinel) as f:
-            _old_mtime = f.read().strip()
-    if _compiler_mtime != _old_mtime and os.path.isdir(_FPC_RTL_AST_CACHE_DIR):
-        shutil.rmtree(_FPC_RTL_AST_CACHE_DIR, ignore_errors=True)
     os.makedirs(_FPC_RTL_AST_CACHE_DIR, exist_ok=True)
     if _compiler_mtime:
         with open(_cache_sentinel, "w") as f:
@@ -248,17 +244,12 @@ if FPC_RTL_MODE:
         os.environ.get("MESON_BUILD_ROOT", "builddir"), "fpc_rtl_codegen_cache"
     )
     # The compiler includes its own mtime in the cache key, so old entries
-    # are never matched. Clean out the directory on compiler rebuild to
-    # avoid unbounded growth.
+    # are never matched after a rebuild. Do not delete the directory here:
+    # cache invalidation belongs in the key/freshness checks, not in test
+    # harness cleanup.
     _cg_sentinel = os.path.join(
         os.environ.get("MESON_BUILD_ROOT", "builddir"), ".codegen_cache_mtime"
     )
-    _cg_old_mtime = ""
-    if os.path.exists(_cg_sentinel):
-        with open(_cg_sentinel) as f:
-            _cg_old_mtime = f.read().strip()
-    if _compiler_mtime != _cg_old_mtime and os.path.isdir(_FPC_RTL_CODEGEN_CACHE_DIR):
-        shutil.rmtree(_FPC_RTL_CODEGEN_CACHE_DIR, ignore_errors=True)
     os.makedirs(_FPC_RTL_CODEGEN_CACHE_DIR, exist_ok=True)
     if _compiler_mtime:
         with open(_cg_sentinel, "w") as f:
@@ -437,6 +428,7 @@ def _store_failure_artifacts(
     raw_stdout=None,
     raw_stderr=None,
     expected_output=None,
+    expected_stderr=None,
     returncode=None,
     exception_text=None,
 ):
@@ -465,6 +457,7 @@ def _store_failure_artifacts(
     _write_artifact_text(dest, "raw-stderr.txt", raw_stderr)
     _write_artifact_text(dest, "normalized-output.txt", normalized_output)
     _write_artifact_text(dest, "expected-output.txt", expected_output)
+    _write_artifact_text(dest, "expected-stderr.txt", expected_stderr)
     if exception_text:
         _write_artifact_text(dest, "exception.txt", exception_text)
 
@@ -3470,6 +3463,9 @@ def _discover_and_add_auto_tests():
         def make_test_method(test_base_name):
             def test_method(self):
                 """Auto-discovered test case."""
+                if test_base_name in FPC_RTL_ONLY_TESTS:
+                    self.skipTest("FPC RTL-only regression test")
+
                 # Skip Unix fork-dependent tests on MinGW (which lacks POSIX fork)
                 # Cygwin and MSYS have fork, pure MinGW does not
                 # Skip tests with hardcoded SysV ABI inline asm on Windows
@@ -3492,10 +3488,12 @@ def _discover_and_add_auto_tests():
                 asm_file = os.path.join(TEST_OUTPUT_DIR, f"{test_base_name}_auto.s")
                 executable_file = os.path.join(TEST_OUTPUT_DIR, f"{test_base_name}_auto{EXE_EXT}")
                 expected_output_file = os.path.join(TEST_CASES_DIR, f"{test_base_name}.expected")
+                expected_stderr_file = os.path.join(TEST_CASES_DIR, f"{test_base_name}.stderr.expected")
                 input_data_file = os.path.join(INPUT_DATA_DIR, f"{test_base_name}.input")
 
                 # Check test result cache
-                if _test_cache_check(input_file, expected_output_file, []):
+                cache_deps = [expected_stderr_file] if os.path.exists(expected_stderr_file) else []
+                if _test_cache_check(input_file, expected_output_file, cache_deps):
                     return  # cached pass — skip
 
                 compiler_output = None
@@ -3503,6 +3501,7 @@ def _discover_and_add_auto_tests():
                 raw_stdout = None
                 raw_stderr = None
                 expected_output = None
+                expected_stderr = None
                 process_returncode = None
 
                 self.record_failure_context(
@@ -3549,6 +3548,16 @@ def _discover_and_add_auto_tests():
                         text = text.replace("\r\r\n", "\r\n")
                     actual_output = text.replace("\r\n", "\n").replace("\r", "")
 
+                    actual_stderr = None
+                    if os.path.exists(expected_stderr_file):
+                        expected_stderr = read_file_content(expected_stderr_file)
+                        stderr_text = raw_stderr
+                        if stderr_text is None:
+                            stderr_text = ""
+                        while "\r\r\n" in stderr_text:
+                            stderr_text = stderr_text.replace("\r\r\n", "\r\n")
+                        actual_stderr = stderr_text.replace("\r\n", "\n").replace("\r", "")
+
                     self.record_failure_context(
                         base_name=test_base_name,
                         compiler_output=compiler_output,
@@ -3556,12 +3565,15 @@ def _discover_and_add_auto_tests():
                         raw_stdout=raw_stdout,
                         raw_stderr=raw_stderr,
                         expected_output=expected_output,
+                        expected_stderr=expected_stderr,
                         returncode=process_returncode,
                     )
 
                     self.assertEqual(actual_output, expected_output)
+                    if expected_stderr is not None:
+                        self.assertEqual(actual_stderr, expected_stderr)
                     self.assertEqual(process_returncode, 0)
-                    _test_cache_store(input_file, expected_output_file, [])
+                    _test_cache_store(input_file, expected_output_file, cache_deps)
                 except subprocess.TimeoutExpired:
                     self.record_failure_context(
                         base_name=test_base_name,
@@ -3598,6 +3610,11 @@ def _discover_and_add_auto_tests():
 # Tests that use KGPC-only extensions not available in FPC RTL mode.
 KGPC_ONLY_TESTS = {
     'random_real_function',  # Random(Real) overload is a KGPC extension
+}
+
+# Tests that target overloads or units only present in the FPC RTL suite.
+FPC_RTL_ONLY_TESTS = {
+    "fpc_bootstrap_hminus_extractfilepath",
 }
 
 # Tests without explicit FPC RTL/package imports are skipped from the FPC RTL

--- a/tests/test_cases/fpc_bootstrap_hminus_extractfilepath.expected
+++ b/tests/test_cases/fpc_bootstrap_hminus_extractfilepath.expected
@@ -1,0 +1,3 @@
+tests/test_cases/
+helloworld.p
+tests/test_cases/helloworld.p

--- a/tests/test_cases/fpc_bootstrap_hminus_extractfilepath.p
+++ b/tests/test_cases/fpc_bootstrap_hminus_extractfilepath.p
@@ -1,0 +1,20 @@
+program fpc_bootstrap_hminus_extractfilepath;
+{$mode objfpc}
+{$H-}
+
+uses
+  SysUtils;
+
+var
+  param_file: string;
+  inputfilepath: string;
+  inputfilename: string;
+
+begin
+  param_file := 'tests/test_cases/helloworld.p';
+  inputfilepath := ExtractFilePath(param_file);
+  inputfilename := ExtractFileName(param_file);
+  WriteLn(inputfilepath);
+  WriteLn(inputfilename);
+  WriteLn(inputfilepath + inputfilename);
+end.

--- a/tests/test_cases/fpc_bootstrap_stderr.expected
+++ b/tests/test_cases/fpc_bootstrap_stderr.expected
@@ -1,2 +1,1 @@
-Error to stderr
 Normal to stdout

--- a/tests/test_cases/fpc_bootstrap_stderr.stderr.expected
+++ b/tests/test_cases/fpc_bootstrap_stderr.stderr.expected
@@ -1,0 +1,1 @@
+Error to stderr

--- a/tests/test_cases/os_runtime_dynlib.p
+++ b/tests/test_cases/os_runtime_dynlib.p
@@ -15,7 +15,7 @@ program OsRuntimeDynlib;
   uses SysUtils, DynLibs, BaseUnix, ctypes;
   {$endif}
 {$else}
-uses SysUtils;
+uses SysUtils, DynLibs;
 {$endif}
 
 const
@@ -61,13 +61,8 @@ begin
 end;
 
 var
-{$if defined(FPC) and not defined(KGPC_COMPILER)}
     Handle: TLibHandle;
     ProcPtr: Pointer;
-{$else}
-    Handle: NativeUInt;
-    ProcPtr: NativeUInt;
-{$endif}
     DynLibOK: boolean;
 begin
 {$ifdef MSWINDOWS}
@@ -75,9 +70,9 @@ begin
 {$else}
     {$if defined(FPC) and not defined(KGPC_COMPILER)}
     Handle := TLibHandle(LoadUnixLibrary());
-    {$else}
-    Handle := LoadUnixLibrary();
-    {$endif}
+{$else}
+    Handle := TLibHandle(LoadUnixLibrary());
+{$endif}
 {$endif}
     DynLibOK := False;
     if Handle <> 0 then
@@ -87,11 +82,7 @@ begin
 {$else}
         ProcPtr := GetProcedureAddress(Handle, 'strlen');
 {$endif}
-{$if defined(FPC) and not defined(KGPC_COMPILER)}
         DynLibOK := (ProcPtr <> nil) and FreeLibrary(Handle);
-{$else}
-        DynLibOK := (ProcPtr <> 0) and FreeLibrary(Handle);
-{$endif}
     end;
     WriteLn('DynLib=', BoolStr(DynLibOK));
 end.


### PR DESCRIPTION
## Summary by Sourcery

Improve FPC bootstrap support, codegen correctness, and caching robustness while adding cross-platform utilities, tightening semantic analysis, and extending the test harness and docs for the FPC RTL flow.

New Features:
- Support record unary minus via operator overloading resolution in semantic analysis.
- Add runtime support for FPC stack globals and more precise stdio initialization, including a reinit path.
- Introduce file-based locking and nanosecond-precision file time helpers for coordinated, robust codegen caching.
- Allow pointer-to-array linearization and indexing in both semantic analysis and code generation.
- Support resolving Tconstexprint arguments and bound finish_module callbacks in code generation.
- Expose additional built-in file variables (StdIn/StdOut/StdErr/ErrOutput) through the code generator.
- Add support for FPC RTL-only regression tests and stderr expectation files in the test harness.

Bug Fixes:
- Avoid treating string literals and non-shortstring string variables as ShortString values during codegen, preventing incorrect conversions.
- Fix element size computation for arrays of ShortString (and aliases) and for certain specialized arrays, improving indexing and layout.
- Correct handling of pointers to records/arrays in KgpcType pointer resolution and array dimension queries.
- Ensure class reference values and non-static class methods use the correct VMT/self semantics in constructors and virtual dispatch.
- Prefer visible variable symbols over non-public constants when resolving identifiers, avoiding incorrect constant folding across units.
- Make for-loop comparison signedness honour signed loop bounds, matching language semantics.
- Handle PASCAL_T_NONE-wrapped types and initialization blocks from cparser correctly when building parse trees and var declarations.
- Fix Unix-type dir function signatures to match FPC expectations for fpclosedir/fpreaddir.
- Prevent stale AST/codegen cache reuse by incorporating compiler nanosecond mtimes and input/source identities into cache keys and freshness checks.
- Avoid deleting AST/codegen cache directories in the test harness, relying instead on compiler-controlled cache invalidation.

Enhancements:
- Extend ShortString and AnsiString handling in codegen and overload resolution, including special cases for known procedures and param types.
- Refine record field size computation using cached layout data in both expression and statement codegen paths.
- Improve VMT handling for class constructors invoked through class references, including runtime VMT receiver and fallback VMT assignment.
- Adjust static-link emission in procedure/function prologues to work correctly with nested functions and instruction list construction.
- Normalize Windows strndup handling via a shared helper and feature-detection macro rather than per-file shims.
- Update the Pascal parser combinators to treat legacy initialization blocks as explicit initialization sections and to expose them to the frontend.
- Tighten AST cache versioning and include compiler timestamp in cache path hashing for safer reuse across compiler builds.

Build:
- Teach Meson to detect strndup availability and define HAVE_STRNDUP, and compile the new common file_lock module.

Documentation:
- Refresh FPC bootstrap documentation to describe the passing RTL test suite, direct pp.pas bootstrap flow, linking, and a hello-world example using the generated pp_bootstrap.

Tests:
- Add new FPC bootstrap regression tests (including ExtractFilePath under {$H-}) and update the dynamic library test to use FPC-compatible types and APIs.
- Extend the Python test harness to cache tests with additional dependencies, capture and assert expected stderr, and skip FPC RTL-only cases when appropriate.