### PR TITLE
[codex] Address review feedback

### DIFF
--- a/KGPC/CodeGenerator/Intel_x86-64/codegen_expression.c
+++ b/KGPC/CodeGenerator/Intel_x86-64/codegen_expression.c
@@ -407,7 +407,7 @@ HashNode_t *codegen_prefer_visible_var_over_const(CodeGenContext *ctx,
         else if (cand->source_unit_index == 0)
             priority = 2;
         else if (cand->source_unit_index > 0 &&
-                 node->source_unit_index != caller_unit)
+                 cand->source_unit_index != caller_unit)
             priority = 1;
 
         if (priority > best_priority)
@@ -4650,7 +4650,7 @@ static int codegen_sizeof_array_type_kgpc(CodeGenContext *ctx, KgpcType *type,
     {
         KgpcArrayDimensionInfo info;
         if (kgpc_type_get_array_dimension_info(type, ctx->symtab, &info) == 0 &&
-            info.total_size > 0)
+            info.total_size >= 0)
         {
             *size_out = info.total_size;
             return 0;

--- a/KGPC/CodeGenerator/Intel_x86-64/codegen_statement_parts/codegen_stmt_calls_and_control.c
+++ b/KGPC/CodeGenerator/Intel_x86-64/codegen_statement_parts/codegen_stmt_calls_and_control.c
@@ -2034,7 +2034,7 @@ ListNode_t *codegen_var_assignment(struct Statement *stmt, ListNode_t *inst_list
                  * may make function calls and consume all caller-saved /
                  * callee-saved registers in this allocator. */
                 StackNode_t *dest_addr_temp = add_l_t("ptr_short_assign_dest");
-                snprintf(buffer, 50, "\tmovq\t%s, -%d(%%rbp)\n",
+                snprintf(buffer, sizeof(buffer), "\tmovq\t%s, -%d(%%rbp)\n",
                     dest_addr->bit_64, dest_addr_temp->offset);
                 inst_list = add_inst(inst_list, buffer);
                 free_reg(get_reg_stack(), dest_addr);
@@ -2057,7 +2057,7 @@ ListNode_t *codegen_var_assignment(struct Statement *stmt, ListNode_t *inst_list
                     return codegen_fail_register(ctx, inst_list, NULL,
                         "ERROR: Unable to allocate register for pointer-deref shortstring assign.");
                 }
-                snprintf(buffer, 50, "\tmovq\t-%d(%%rbp), %s\n",
+                snprintf(buffer, sizeof(buffer), "\tmovq\t-%d(%%rbp), %s\n",
                     dest_addr_temp->offset, dest_addr_reload->bit_64);
                 inst_list = add_inst(inst_list, buffer);
 

--- a/KGPC/Parser/ParseTree/from_cparser_parts/from_cparser_declarations.c
+++ b/KGPC/Parser/ParseTree/from_cparser_parts/from_cparser_declarations.c
@@ -158,23 +158,29 @@ static Tree_t *convert_var_decl(ast_t *decl_node) {
                     /* Create multiple assignment statements for array elements */
                     ListBuilder stmt_builder;
                     list_builder_init(&stmt_builder);
+                    int conversion_failed = 0;
                     
                     int index = type_info.start;
                     for (ast_t *elem = init_node->child; elem != NULL; elem = elem->next) {
                         struct Expression *elem_expr = convert_expression(elem);
-                        if (elem_expr != NULL) {
-                            struct Expression *index_expr = mk_inum(decl_node->line, index);
-                            struct Expression *base_expr = mk_varid(decl_node->line, strdup(var_name));
-                            struct Expression *array_access = mk_arrayaccess(decl_node->line, base_expr, index_expr);
-                            struct Statement *assign_stmt = mk_varassign(decl_node->line, decl_node->col, array_access, elem_expr);
-                            list_builder_append(&stmt_builder, assign_stmt, LIST_STMT);
+                        if (elem_expr == NULL) {
+                            conversion_failed = 1;
+                            break;
                         }
+                        struct Expression *index_expr = mk_inum(decl_node->line, index);
+                        struct Expression *base_expr = mk_varid(decl_node->line, strdup(var_name));
+                        struct Expression *array_access = mk_arrayaccess(decl_node->line, base_expr, index_expr);
+                        struct Statement *assign_stmt = mk_varassign(decl_node->line, decl_node->col, array_access, elem_expr);
+                        list_builder_append(&stmt_builder, assign_stmt, LIST_STMT);
                         index++;
                     }
                     
                     /* Create compound statement from all assignments */
                     ListNode_t *stmt_list = list_builder_finish(&stmt_builder);
-                    if (stmt_list != NULL) {
+                    if (conversion_failed) {
+                        if (stmt_list != NULL)
+                            DestroyList(stmt_list);
+                    } else if (stmt_list != NULL) {
                         initializer_stmt = mk_compoundstatement(decl_node->line, stmt_list);
                     }
                 } else {
@@ -295,20 +301,26 @@ static Tree_t *convert_var_decl(ast_t *decl_node) {
                 char *var_name = (char *)ids->cur;
                 ListBuilder stmt_builder;
                 list_builder_init(&stmt_builder);
+                int conversion_failed = 0;
                 int index = 0;
                 for (ast_t *elem = init_node->child; elem != NULL; elem = elem->next) {
                     struct Expression *elem_expr = convert_expression(elem);
-                    if (elem_expr != NULL) {
-                        struct Expression *index_expr = mk_inum(decl_node->line, index);
-                        struct Expression *base_expr = mk_varid(decl_node->line, strdup(var_name));
-                        struct Expression *array_access = mk_arrayaccess(decl_node->line, base_expr, index_expr);
-                        struct Statement *assign_stmt = mk_varassign(decl_node->line, decl_node->col, array_access, elem_expr);
-                        list_builder_append(&stmt_builder, assign_stmt, LIST_STMT);
+                    if (elem_expr == NULL) {
+                        conversion_failed = 1;
+                        break;
                     }
+                    struct Expression *index_expr = mk_inum(decl_node->line, index);
+                    struct Expression *base_expr = mk_varid(decl_node->line, strdup(var_name));
+                    struct Expression *array_access = mk_arrayaccess(decl_node->line, base_expr, index_expr);
+                    struct Statement *assign_stmt = mk_varassign(decl_node->line, decl_node->col, array_access, elem_expr);
+                    list_builder_append(&stmt_builder, assign_stmt, LIST_STMT);
                     index++;
                 }
                 ListNode_t *stmt_list = list_builder_finish(&stmt_builder);
-                if (stmt_list != NULL) {
+                if (conversion_failed) {
+                    if (stmt_list != NULL)
+                        DestroyList(stmt_list);
+                } else if (stmt_list != NULL) {
                     initializer_stmt = mk_compoundstatement(decl_node->line, stmt_list);
                 }
             } else {

--- a/KGPC/Parser/SemanticCheck/SemCheck_parts/SemCheck_subprograms.c
+++ b/KGPC/Parser/SemanticCheck/SemCheck_parts/SemCheck_subprograms.c
@@ -1592,8 +1592,6 @@ int semcheck_subprograms(SymTab_t *symtab, ListNode_t *subprograms, int max_scop
                         {
                             if (owns)
                                 destroy_kgpc_type(resolved);
-                            else
-                                kgpc_type_release(resolved);
                             resolved = create_primitive_type(SHORTSTRING_TYPE);
                             owns = 1;
                         }

--- a/KGPC/Parser/SemanticCheck/SemChecks/SemCheck_Expr_Access.c
+++ b/KGPC/Parser/SemanticCheck/SemChecks/SemCheck_Expr_Access.c
@@ -5401,6 +5401,8 @@ int semcheck_funccall(int *type_return,
                 int is_nonstatic_class_method =
                     (!is_static_method &&
                      from_cparser_is_method_class_method(method_owner->type_id, id));
+                int method_is_declared_constructor =
+                    semcheck_method_is_declared_constructor(symtab, method_owner, id);
                 if (is_nonstatic_class_method)
                 {
                     expr->expr_data.function_call_data.is_class_method_call = 1;
@@ -5408,7 +5410,7 @@ int semcheck_funccall(int *type_return,
                         expr->expr_data.function_call_data.self_class_name =
                             strdup(method_owner->type_id);
                 }
-                else
+                else if (is_static_method || method_is_declared_constructor)
                 {
                     if (expr->expr_data.function_call_data.constructor_receiver_expr != NULL)
                     {
@@ -5430,7 +5432,7 @@ int semcheck_funccall(int *type_return,
                      * they don't pass Self - it's implicitly created.
                      * Static factory methods (class function Create: T; static;) do NOT have Self.
                      * We use EXPR_NIL as the placeholder - codegen will allocate memory. */
-                    if (!is_static_method) {
+                    if (method_is_declared_constructor) {
                         struct Expression *self_placeholder = (struct Expression *)calloc(1, sizeof(struct Expression));
                         if (self_placeholder != NULL) {
                             /* Use nil as the placeholder - codegen will handle actual allocation */
@@ -5450,6 +5452,11 @@ int semcheck_funccall(int *type_return,
                             }
                         }
                     }
+                }
+                else if (expr->expr_data.function_call_data.constructor_receiver_expr != NULL)
+                {
+                    destroy_expr(expr->expr_data.function_call_data.constructor_receiver_expr);
+                    expr->expr_data.function_call_data.constructor_receiver_expr = NULL;
                 }
                 
                 /* Update the function call id to the mangled name */
@@ -5480,25 +5487,8 @@ int semcheck_funccall(int *type_return,
                 /* Verify the method was actually declared as a constructor
                  * (using the 'constructor' keyword), not just a function whose
                  * name happens to start with "Create" (e.g. CreateDriver). */
-                int method_is_declared_constructor = 0;
-                if (strncasecmp(method_name, "Create", 6) == 0 && record_info != NULL)
-                {
-                    /* Walk up the class hierarchy looking for a template
-                     * that classifies this method as a constructor. */
-                    struct RecordType *search = record_info;
-                    while (search != NULL)
-                    {
-                        struct MethodTemplate *tmpl =
-                            from_cparser_get_method_template(search, method_name);
-                        if (tmpl != NULL)
-                        {
-                            if (tmpl->kind == METHOD_TEMPLATE_CONSTRUCTOR)
-                                method_is_declared_constructor = 1;
-                            break; /* found a template — use its classification */
-                        }
-                        search = semcheck_lookup_parent_record(symtab, search);
-                    }
-                }
+                method_is_declared_constructor =
+                    semcheck_method_is_declared_constructor(symtab, record_info, method_name);
                 if (method_is_declared_constructor && owner_type != NULL) {
                     if (kgpc_getenv("KGPC_DEBUG_SEMCHECK") != NULL) {
                         fprintf(stderr, "[SemCheck] semcheck_funccall: Setting up return type for constructor %s\n", method_name);

--- a/KGPC/Parser/SemanticCheck/SemChecks/SemCheck_Expr_Internal.h
+++ b/KGPC/Parser/SemanticCheck/SemChecks/SemCheck_Expr_Internal.h
@@ -55,6 +55,25 @@ KgpcType *semcheck_expr_effective_kgpc_type(SymTab_t *symtab,
     struct Expression *expr, int *owned_out);
 int semcheck_class_type_ids_compatible(SymTab_t *symtab,
     const char *formal_id, const char *actual_id);
+struct RecordType *semcheck_lookup_parent_record(SymTab_t *symtab,
+    struct RecordType *record_info);
+static inline int semcheck_method_is_declared_constructor(SymTab_t *symtab,
+    struct RecordType *record_info, const char *method_name)
+{
+    if (symtab == NULL || record_info == NULL || method_name == NULL)
+        return 0;
+
+    for (struct RecordType *search = record_info; search != NULL;
+         search = semcheck_lookup_parent_record(symtab, search))
+    {
+        struct MethodTemplate *tmpl =
+            from_cparser_get_method_template(search, method_name);
+        if (tmpl != NULL)
+            return tmpl->kind == METHOD_TEMPLATE_CONSTRUCTOR;
+    }
+
+    return 0;
+}
 
 /*===========================================================================
  * Type Definitions (internal)

--- a/KGPC/Parser/SemanticCheck/SemChecks/SemCheck_Expr_Types.c
+++ b/KGPC/Parser/SemanticCheck/SemChecks/SemCheck_Expr_Types.c
@@ -200,24 +200,6 @@ static KgpcType *semcheck_create_value_kgpc_type_from_node_local(HashNode_t *typ
     return node_type;
 }
 
-static int semcheck_expr_types_method_is_declared_constructor(SymTab_t *symtab,
-    struct RecordType *record_info, const char *method_name)
-{
-    if (symtab == NULL || record_info == NULL || method_name == NULL)
-        return 0;
-
-    for (struct RecordType *search = record_info; search != NULL;
-         search = semcheck_lookup_parent_record(symtab, search))
-    {
-        struct MethodTemplate *tmpl =
-            from_cparser_get_method_template(search, method_name);
-        if (tmpl != NULL)
-            return tmpl->kind == METHOD_TEMPLATE_CONSTRUCTOR;
-    }
-
-    return 0;
-}
-
 static int semcheck_type_alias_has_enum_literal(const struct TypeAlias *alias,
     const char *field_id)
 {
@@ -4061,7 +4043,7 @@ SKIP_SELF_FIELD_REWRITE:
                         record_type_is_class(record_info) &&
                         !record_info->is_type_helper &&
                         method_name != NULL &&
-                        semcheck_expr_types_method_is_declared_constructor(symtab, record_info, method_name));
+                        semcheck_method_is_declared_constructor(symtab, record_info, method_name));
                     /* Re-run semantic checking as a function call */
                     semcheck_expr_set_resolved_type(expr, UNKNOWN_TYPE);
                     int funccall_result = semcheck_funccall(type_return, symtab, expr, max_scope_lev, mutating);

--- a/KGPC/Parser/SemanticCheck/SemChecks/SemCheck_sizeof.c
+++ b/KGPC/Parser/SemanticCheck/SemChecks/SemCheck_sizeof.c
@@ -139,7 +139,7 @@ static int sizeof_from_array_type_kgpc(SymTab_t *symtab, KgpcType *type, long lo
 
     KgpcArrayDimensionInfo info;
     if (kgpc_type_get_array_dimension_info(type, symtab, &info) == 0 &&
-        info.total_size > 0)
+        info.total_size >= 0)
     {
         *size_out = info.total_size;
         return 0;

--- a/KGPC/runtime.c
+++ b/KGPC/runtime.c
@@ -257,68 +257,64 @@ int threadingalreadyused_void(void)
 }
 
 #if defined(__GNUC__) || defined(__clang__)
-#define KGPC_ATOMIC_INC_RET(target, val) __sync_add_and_fetch(target, val)
-#define KGPC_ATOMIC_DEC_RET(target, val) __sync_sub_and_fetch(target, val)
-#define KGPC_ATOMIC_EXCHANGE(target, val) __atomic_exchange_n(target, val, __ATOMIC_SEQ_CST)
-#define KGPC_ATOMIC_CMP_EXCHANGE(target, val, comp) __sync_val_compare_and_swap(target, comp, val)
+static int32_t kgpc_atomic_add_i32(int32_t *target, int32_t value) { return __sync_add_and_fetch(target, value); }
+static uint32_t kgpc_atomic_add_u32(uint32_t *target, uint32_t value) { return (uint32_t)__sync_add_and_fetch(target, value); }
+static long kgpc_atomic_add_long(long *target, long value) { return __sync_add_and_fetch(target, value); }
+static long long kgpc_atomic_add_i64(long long *target, long long value) { return __sync_add_and_fetch(target, value); }
+static uint64_t kgpc_atomic_add_u64(uint64_t *target, uint64_t value) { return (uint64_t)__sync_add_and_fetch(target, value); }
+static int32_t kgpc_atomic_exchange_i32(int32_t *target, int32_t value) { return __atomic_exchange_n(target, value, __ATOMIC_SEQ_CST); }
+static uint32_t kgpc_atomic_exchange_u32(uint32_t *target, uint32_t value) { return (uint32_t)__atomic_exchange_n(target, value, __ATOMIC_SEQ_CST); }
+static long kgpc_atomic_exchange_long(long *target, long value) { return __atomic_exchange_n(target, value, __ATOMIC_SEQ_CST); }
+static long long kgpc_atomic_exchange_i64(long long *target, long long value) { return __atomic_exchange_n(target, value, __ATOMIC_SEQ_CST); }
+static uint64_t kgpc_atomic_exchange_u64(uint64_t *target, uint64_t value) { return (uint64_t)__atomic_exchange_n(target, value, __ATOMIC_SEQ_CST); }
+static void *kgpc_atomic_exchange_ptr(void **target, void *value) { return __atomic_exchange_n(target, value, __ATOMIC_SEQ_CST); }
+static int32_t kgpc_atomic_cmp_exchange_i32(int32_t *target, int32_t value, int32_t comparand) { return __sync_val_compare_and_swap(target, comparand, value); }
+static uint32_t kgpc_atomic_cmp_exchange_u32(uint32_t *target, uint32_t value, uint32_t comparand) { return (uint32_t)__sync_val_compare_and_swap(target, comparand, value); }
+static int kgpc_atomic_cmp_exchange_int(int *target, int value, int comparand) { return __sync_val_compare_and_swap(target, comparand, value); }
+static long long kgpc_atomic_cmp_exchange_i64(long long *target, long long value, long long comparand) { return __sync_val_compare_and_swap(target, comparand, value); }
+static uint64_t kgpc_atomic_cmp_exchange_u64(uint64_t *target, uint64_t value, uint64_t comparand) { return (uint64_t)__sync_val_compare_and_swap(target, comparand, value); }
+static void *kgpc_atomic_cmp_exchange_ptr(void **target, void *value, void *comparand) { return __sync_val_compare_and_swap(target, comparand, value); }
 #elif defined(_MSC_VER)
 #include <intrin.h>
-#define KGPC_ATOMIC_INC_RET(target, val) \
-    (_Generic((target), \
-        int32_t *: _InterlockedAdd((volatile long *)(target), (long)(val)), \
-        long *: _InterlockedAdd((volatile long *)(target), (long)(val)), \
-        int64_t *: _InterlockedAdd64((volatile long long *)(target), (long long)(val)), \
-        long long *: _InterlockedAdd64((volatile long long *)(target), (long long)(val)), \
-        uint32_t *: (uint32_t)_InterlockedAdd((volatile long *)(target), (long)(val)), \
-        uint64_t *: (uint64_t)_InterlockedAdd64((volatile long long *)(target), (long long)(val))))
-#define KGPC_ATOMIC_DEC_RET(target, val) \
-    (_Generic((target), \
-        int32_t *: _InterlockedAdd((volatile long *)(target), -(long)(val)), \
-        long *: _InterlockedAdd((volatile long *)(target), -(long)(val)), \
-        int64_t *: _InterlockedAdd64((volatile long long *)(target), -(long long)(val)), \
-        long long *: _InterlockedAdd64((volatile long long *)(target), -(long long)(val)), \
-        uint32_t *: (uint32_t)_InterlockedAdd((volatile long *)(target), -(long)(val)), \
-        uint64_t *: (uint64_t)_InterlockedAdd64((volatile long long *)(target), -(long long)(val))))
-#define KGPC_ATOMIC_EXCHANGE(target, val) \
-    (_Generic((target), \
-        int32_t *: _InterlockedExchange((volatile long *)(target), (long)(val)), \
-        long *: _InterlockedExchange((volatile long *)(target), (long)(val)), \
-        int64_t *: _InterlockedExchange64((volatile long long *)(target), (long long)(val)), \
-        long long *: _InterlockedExchange64((volatile long long *)(target), (long long)(val)), \
-        uint32_t *: (uint32_t)_InterlockedExchange((volatile long *)(target), (long)(val)), \
-        uint64_t *: (uint64_t)_InterlockedExchange64((volatile long long *)(target), (long long)(val)), \
-        void **: (void *)_InterlockedExchangePointer((volatile PVOID *)(target), (PVOID)(val))))
-#define KGPC_ATOMIC_CMP_EXCHANGE(target, val, comp) \
-    (_Generic((target), \
-        int32_t *: _InterlockedCompareExchange((volatile long *)(target), (long)(val), (long)(comp)), \
-        long *: _InterlockedCompareExchange((volatile long *)(target), (long)(val), (long)(comp)), \
-        int64_t *: _InterlockedCompareExchange64((volatile long long *)(target), (long long)(val), (long long)(comp)), \
-        long long *: _InterlockedCompareExchange64((volatile long long *)(target), (long long)(val), (long long)(comp)), \
-        uint32_t *: (uint32_t)_InterlockedCompareExchange((volatile long *)(target), (long)(val), (long)(comp)), \
-        uint64_t *: (uint64_t)_InterlockedCompareExchange64((volatile long long *)(target), (long long)(val), (long long)(comp)), \
-        void **: (void *)_InterlockedCompareExchangePointer((volatile PVOID *)(target), (PVOID)(val), (PVOID)(comp))))
+static int32_t kgpc_atomic_add_i32(int32_t *target, int32_t value) { return (int32_t)_InterlockedAdd((volatile long *)target, (long)value); }
+static uint32_t kgpc_atomic_add_u32(uint32_t *target, uint32_t value) { return (uint32_t)_InterlockedAdd((volatile long *)target, (long)value); }
+static long kgpc_atomic_add_long(long *target, long value) { return _InterlockedAdd((volatile long *)target, value); }
+static long long kgpc_atomic_add_i64(long long *target, long long value) { return (long long)_InterlockedAdd64((volatile __int64 *)target, (__int64)value); }
+static uint64_t kgpc_atomic_add_u64(uint64_t *target, uint64_t value) { return (uint64_t)_InterlockedAdd64((volatile __int64 *)target, (__int64)value); }
+static int32_t kgpc_atomic_exchange_i32(int32_t *target, int32_t value) { return (int32_t)_InterlockedExchange((volatile long *)target, (long)value); }
+static uint32_t kgpc_atomic_exchange_u32(uint32_t *target, uint32_t value) { return (uint32_t)_InterlockedExchange((volatile long *)target, (long)value); }
+static long kgpc_atomic_exchange_long(long *target, long value) { return _InterlockedExchange((volatile long *)target, value); }
+static long long kgpc_atomic_exchange_i64(long long *target, long long value) { return (long long)_InterlockedExchange64((volatile __int64 *)target, (__int64)value); }
+static uint64_t kgpc_atomic_exchange_u64(uint64_t *target, uint64_t value) { return (uint64_t)_InterlockedExchange64((volatile __int64 *)target, (__int64)value); }
+static void *kgpc_atomic_exchange_ptr(void **target, void *value) { return _InterlockedExchangePointer((void *volatile *)target, value); }
+static int32_t kgpc_atomic_cmp_exchange_i32(int32_t *target, int32_t value, int32_t comparand) { return (int32_t)_InterlockedCompareExchange((volatile long *)target, (long)value, (long)comparand); }
+static uint32_t kgpc_atomic_cmp_exchange_u32(uint32_t *target, uint32_t value, uint32_t comparand) { return (uint32_t)_InterlockedCompareExchange((volatile long *)target, (long)value, (long)comparand); }
+static int kgpc_atomic_cmp_exchange_int(int *target, int value, int comparand) { return (int)_InterlockedCompareExchange((volatile long *)target, (long)value, (long)comparand); }
+static long long kgpc_atomic_cmp_exchange_i64(long long *target, long long value, long long comparand) { return (long long)_InterlockedCompareExchange64((volatile __int64 *)target, (__int64)value, (__int64)comparand); }
+static uint64_t kgpc_atomic_cmp_exchange_u64(uint64_t *target, uint64_t value, uint64_t comparand) { return (uint64_t)_InterlockedCompareExchange64((volatile __int64 *)target, (__int64)value, (__int64)comparand); }
+static void *kgpc_atomic_cmp_exchange_ptr(void **target, void *value, void *comparand) { return _InterlockedCompareExchangePointer((void *volatile *)target, value, comparand); }
 #else
 #error "Atomic operations require GCC, Clang, or MSVC"
 #endif
 
 int32_t kgpc_interlockedincrement(int32_t *target)
 {
-    return (int32_t)KGPC_ATOMIC_INC_RET(target, 1);
+    return kgpc_atomic_add_i32(target, 1);
 }
 
 int32_t kgpc_interlockeddecrement(int32_t *target)
 {
-    return (int32_t)KGPC_ATOMIC_DEC_RET(target, 1);
+    return kgpc_atomic_add_i32(target, -1);
 }
 
 int64_t kgpc_interlockedincrement64(int64_t *target)
 {
-    return (int64_t)KGPC_ATOMIC_INC_RET(target, 1);
+    return (int64_t)kgpc_atomic_add_i64((long long *)target, 1);
 }
 
 int64_t kgpc_interlockeddecrement64(int64_t *target)
 {
-    return (int64_t)KGPC_ATOMIC_DEC_RET(target, 1);
+    return (int64_t)kgpc_atomic_add_i64((long long *)target, -1);
 }
 
 void kgpc_interlocked_exchange_add_i32(int32_t *target, int32_t value, int32_t *result)
@@ -2819,7 +2815,17 @@ void kgpc_new(void **target, size_t size)
     if (kgpc_guard_new_is_enabled())
     {
         size_t page_size = kgpc_guard_page_size();
+        if (size > SIZE_MAX - (page_size - 1))
+        {
+            fprintf(stderr, "KGPC runtime: requested allocation is too large.\n");
+            exit(EXIT_FAILURE);
+        }
         size_t rounded = ((size + page_size - 1) / page_size) * page_size;
+        if (rounded > SIZE_MAX - page_size)
+        {
+            fprintf(stderr, "KGPC runtime: requested allocation is too large.\n");
+            exit(EXIT_FAILURE);
+        }
         size_t total = rounded + page_size;
         unsigned char *raw = kgpc_guard_reserve(total, rounded, page_size);
         unsigned char *user = raw + rounded - size;
@@ -2913,18 +2919,12 @@ static size_t kgpc_guard_page_size(void)
     SYSTEM_INFO system_info;
     GetSystemInfo(&system_info);
     if (system_info.dwPageSize == 0)
-    {
-        fprintf(stderr, "KGPC runtime: Windows reported an invalid page size.\n");
-        exit(EXIT_FAILURE);
-    }
+        return 4096u;
     return (size_t)system_info.dwPageSize;
 #else
     long page_size_long = sysconf(_SC_PAGESIZE);
     if (page_size_long <= 0)
-    {
-        fprintf(stderr, "KGPC runtime: sysconf(_SC_PAGESIZE) failed.\n");
-        exit(EXIT_FAILURE);
-    }
+        return 4096u;
     return (size_t)page_size_long;
 #endif
 }
@@ -8033,46 +8033,50 @@ void *kgpc_get_frame_p(void *frame)
 
 /* FPC atomic intrinsics — these are [internproc] builtins in FPC that have
  * no Pascal body.  KGPC emits calls to the mangled names below. */
-long atomicincrement_i_i(long *target, long value) { return (long)KGPC_ATOMIC_INC_RET(target, value); }
-uint32_t atomicincrement_u32_u32(uint32_t *target, uint32_t value) { return (uint32_t)KGPC_ATOMIC_INC_RET(target, value); }
+long atomicincrement_i_i(long *target, long value) { return kgpc_atomic_add_long(target, value); }
+uint32_t atomicincrement_u32_u32(uint32_t *target, uint32_t value) { return kgpc_atomic_add_u32(target, value); }
 
 /* [internproc] AtomicIncrement(var Target): 1-param overload, increments by 1 */
-long atomicincrement_i(long *target) { return (long)KGPC_ATOMIC_INC_RET(target, 1); }
-uint32_t atomicincrement_u32(uint32_t *target) { return (uint32_t)KGPC_ATOMIC_INC_RET(target, 1); }
+long atomicincrement_i(long *target) { return kgpc_atomic_add_long(target, 1); }
+uint32_t atomicincrement_u32(uint32_t *target) { return kgpc_atomic_add_u32(target, 1); }
 
 /* LongInt (32-bit signed) overloads for compiler intrinsics. */
-int32_t atomicincrement_li(int32_t *target) { return (int32_t)KGPC_ATOMIC_INC_RET(target, 1); }
-int32_t atomicincrement_li_li(int32_t *target, int32_t value) { return (int32_t)KGPC_ATOMIC_INC_RET(target, value); }
+int32_t atomicincrement_li(int32_t *target) { return kgpc_atomic_add_i32(target, 1); }
+int32_t atomicincrement_li_li(int32_t *target, int32_t value) { return kgpc_atomic_add_i32(target, value); }
 
-long atomicdecrement_i(long *target) { return (long)KGPC_ATOMIC_DEC_RET(target, 1); }
-uint32_t atomicdecrement_u32(uint32_t *target) { return (uint32_t)KGPC_ATOMIC_DEC_RET(target, 1); }
-int32_t atomicdecrement_li(int32_t *target) { return (int32_t)KGPC_ATOMIC_DEC_RET(target, 1); }
-int32_t atomicdecrement_li_li(int32_t *target, int32_t value) { return (int32_t)KGPC_ATOMIC_DEC_RET(target, value); }
+long atomicdecrement_i(long *target) { return kgpc_atomic_add_long(target, -1); }
+uint32_t atomicdecrement_u32(uint32_t *target) { return kgpc_atomic_add_u32(target, (uint32_t)-1); }
+int32_t atomicdecrement_li(int32_t *target) { return kgpc_atomic_add_i32(target, -1); }
+int32_t atomicdecrement_li_li(int32_t *target, int32_t value) { return kgpc_atomic_add_i32(target, -value); }
 
-int32_t atomicexchange_li_li(int32_t *target, int32_t new_val) { return (int32_t)KGPC_ATOMIC_EXCHANGE(target, new_val); }
-int32_t atomiccmpexchange_li_li_li(int32_t *target, int32_t new_val, int32_t comparand) { return (int32_t)KGPC_ATOMIC_CMP_EXCHANGE(target, new_val, comparand); }
-void *atomiccmpexchange_p_p_p(void **target, void *new_val, void *comparand) { return (void *)KGPC_ATOMIC_CMP_EXCHANGE(target, new_val, comparand); }
-void *atomicexchange_p_p(void **target, void *new_val) { return (void *)KGPC_ATOMIC_EXCHANGE(target, new_val); }
+int32_t atomicexchange_li_li(int32_t *target, int32_t new_val) { return kgpc_atomic_exchange_i32(target, new_val); }
+int32_t atomiccmpexchange_li_li_li(int32_t *target, int32_t new_val, int32_t comparand) { return kgpc_atomic_cmp_exchange_i32(target, new_val, comparand); }
+void *atomiccmpexchange_p_p_p(void **target, void *new_val, void *comparand) {
+    return kgpc_atomic_cmp_exchange_ptr(target, new_val, comparand);
+}
+void *atomicexchange_p_p(void **target, void *new_val) {
+    return kgpc_atomic_exchange_ptr(target, new_val);
+}
 
 /* [internproc] AtomicExchange for integer types */
-long atomicexchange_i_i(long *target, long new_val) { return (long)KGPC_ATOMIC_EXCHANGE(target, new_val); }
-uint32_t atomicexchange_u32_u32(uint32_t *target, uint32_t new_val) { return (uint32_t)KGPC_ATOMIC_EXCHANGE(target, new_val); }
+long atomicexchange_i_i(long *target, long new_val) { return kgpc_atomic_exchange_long(target, new_val); }
+uint32_t atomicexchange_u32_u32(uint32_t *target, uint32_t new_val) { return kgpc_atomic_exchange_u32(target, new_val); }
 
 /* Int64 overloads of atomic intrinsics */
-long long atomicincrement_i64(long long *target) { return (long long)KGPC_ATOMIC_INC_RET(target, 1); }
-uint64_t atomicincrement_u64(uint64_t *target) { return (uint64_t)KGPC_ATOMIC_INC_RET(target, 1); }
-long long atomicincrement_i64_i64(long long *target, long long value) { return (long long)KGPC_ATOMIC_INC_RET(target, value); }
-uint64_t atomicincrement_u64_u64(uint64_t *target, uint64_t value) { return (uint64_t)KGPC_ATOMIC_INC_RET(target, value); }
+long long atomicincrement_i64(long long *target) { return kgpc_atomic_add_i64(target, 1); }
+uint64_t atomicincrement_u64(uint64_t *target) { return kgpc_atomic_add_u64(target, 1); }
+long long atomicincrement_i64_i64(long long *target, long long value) { return kgpc_atomic_add_i64(target, value); }
+uint64_t atomicincrement_u64_u64(uint64_t *target, uint64_t value) { return kgpc_atomic_add_u64(target, value); }
 
-long long atomicdecrement_i64(long long *target) { return (long long)KGPC_ATOMIC_DEC_RET(target, 1); }
-uint64_t atomicdecrement_u64(uint64_t *target) { return (uint64_t)KGPC_ATOMIC_DEC_RET(target, 1); }
+long long atomicdecrement_i64(long long *target) { return kgpc_atomic_add_i64(target, -1); }
+uint64_t atomicdecrement_u64(uint64_t *target) { return kgpc_atomic_add_u64(target, (uint64_t)-1); }
 
-long long atomicexchange_i64_i64(long long *target, long long new_val) { return (long long)KGPC_ATOMIC_EXCHANGE(target, new_val); }
-uint64_t atomicexchange_u64_u64(uint64_t *target, uint64_t new_val) { return (uint64_t)KGPC_ATOMIC_EXCHANGE(target, new_val); }
+long long atomicexchange_i64_i64(long long *target, long long new_val) { return kgpc_atomic_exchange_i64(target, new_val); }
+uint64_t atomicexchange_u64_u64(uint64_t *target, uint64_t new_val) { return kgpc_atomic_exchange_u64(target, new_val); }
 
-long long atomiccmpexchange_i64_i64_i64(long long *target, long long new_val, long long comparand) { return (long long)KGPC_ATOMIC_CMP_EXCHANGE(target, new_val, comparand); }
-uint32_t atomiccmpexchange_u32_u32_u32(uint32_t *target, uint32_t new_val, uint32_t comparand) { return (uint32_t)KGPC_ATOMIC_CMP_EXCHANGE(target, new_val, comparand); }
-uint64_t atomiccmpexchange_u64_u64_u64(uint64_t *target, uint64_t new_val, uint64_t comparand) { return (uint64_t)KGPC_ATOMIC_CMP_EXCHANGE(target, new_val, comparand); }
+long long atomiccmpexchange_i64_i64_i64(long long *target, long long new_val, long long comparand) { return kgpc_atomic_cmp_exchange_i64(target, new_val, comparand); }
+uint32_t atomiccmpexchange_u32_u32_u32(uint32_t *target, uint32_t new_val, uint32_t comparand) { return kgpc_atomic_cmp_exchange_u32(target, new_val, comparand); }
+uint64_t atomiccmpexchange_u64_u64_u64(uint64_t *target, uint64_t new_val, uint64_t comparand) { return kgpc_atomic_cmp_exchange_u64(target, new_val, comparand); }
 
 /* FPC_INTERLOCKEDEXCHANGEADD / FPC_INTERLOCKEDCOMPAREEXCHANGE64:
  * Now provided by the compiler-emitted FPC Pascal code (via [Public,Alias] in
@@ -8158,7 +8162,7 @@ void _haltproc(int exitcode)
 
 /* atomiccmpexchange_i_i_i: [internproc] AtomicCmpExchange intrinsic.
    No Pascal body exists — this is a compiler intrinsic. */
-int atomiccmpexchange_i_i_i(int *target, int new_val, int comparand) { return (int)KGPC_ATOMIC_CMP_EXCHANGE(target, new_val, comparand); }
+int atomiccmpexchange_i_i_i(int *target, int new_val, int comparand) { return kgpc_atomic_cmp_exchange_int(target, new_val, comparand); }
 
 /* =====================================================================
  * TUnicodeStringManager (widestringmanager) initialization.

--- a/common/file_lock.c
+++ b/common/file_lock.c
@@ -49,42 +49,45 @@ static bool is_pid_alive(int pid)
 
 static bool try_acquire(const char *lock_path)
 {
+    for (;;)
+    {
 #ifdef _WIN32
-    int fd = open(lock_path, _O_CREAT | _O_EXCL | _O_RDWR | _O_BINARY, 0666);
+        int fd = open(lock_path, _O_CREAT | _O_EXCL | _O_RDWR | _O_BINARY, 0666);
 #else
-    int fd = open(lock_path, O_CREAT | O_EXCL | O_RDWR, 0666);
+        int fd = open(lock_path, O_CREAT | O_EXCL | O_RDWR, 0666);
 #endif
-    if (fd >= 0)
-    {
-        char pid_buf[32];
-        int len = snprintf(pid_buf, sizeof(pid_buf), "%d\n", (int)getpid());
-        if (write(fd, pid_buf, (size_t)len) != len)
+        if (fd >= 0)
         {
-            close(fd);
-            unlink(lock_path);
-            return false;
-        }
-        close(fd);
-        return true;
-    }
-
-    if (errno == EEXIST)
-    {
-        FILE *f = fopen(lock_path, "r");
-        if (f != NULL)
-        {
-            int pid = 0;
-            int parsed = fscanf(f, "%d", &pid);
-            fclose(f);
-            if ((parsed == 1 && !is_pid_alive(pid)) || parsed != 1)
+            char pid_buf[32];
+            int len = snprintf(pid_buf, sizeof(pid_buf), "%d\n", (int)getpid());
+            if (write(fd, pid_buf, (size_t)len) != len)
             {
+                close(fd);
                 unlink(lock_path);
-                return try_acquire(lock_path);
+                return false;
+            }
+            close(fd);
+            return true;
+        }
+
+        if (errno == EEXIST)
+        {
+            FILE *f = fopen(lock_path, "r");
+            if (f != NULL)
+            {
+                int pid = 0;
+                int parsed = fscanf(f, "%d", &pid);
+                fclose(f);
+                if ((parsed == 1 && !is_pid_alive(pid)) || parsed != 1)
+                {
+                    unlink(lock_path);
+                    continue;
+                }
             }
         }
-    }
 
-    return false;
+        return false;
+    }
 }
 
 bool file_lock_acquire(const char *path, int timeout_secs)

--- a/cparser/examples/pascal_parser/pascal_parser.c
+++ b/cparser/examples/pascal_parser/pascal_parser.c
@@ -18,8 +18,9 @@
 #if defined(_WIN32) && !defined(HAVE_STRNDUP)
 static char* strndup(const char* s, size_t n)
 {
-    size_t len = strlen(s);
-    if (n < len) len = n;
+    size_t len = 0;
+    while (len < n && s[len] != '\0')
+        len++;
     char* result = (char*)malloc(len + 1);
     if (result) { memcpy(result, s, len); result[len] = '\0'; }
     return result;

--- a/cparser/examples/pascal_parser/pascal_preprocessor.c
+++ b/cparser/examples/pascal_parser/pascal_preprocessor.c
@@ -2492,12 +2492,14 @@ static bool eval_const_term(PascalPreprocessor *pp, const char **cursor, const c
             *cursor += 3;
             int64_t right;
             if (!eval_const_factor(pp, cursor, end, &right, depth)) return false;
+            if (right < 0 || right >= 64) return false;
             *value <<= right;
         } else if (*cursor + 3 <= end && ascii_strncasecmp(*cursor, "SHR", 3) == 0 &&
                    (*cursor + 3 >= end || !isalnum((unsigned char)(*cursor)[3]))) {
             *cursor += 3;
             int64_t right;
             if (!eval_const_factor(pp, cursor, end, &right, depth)) return false;
+            if (right < 0 || right >= 64) return false;
             *value >>= right;
         } else {
             break;
@@ -3378,8 +3380,16 @@ static bool parse_term(const char **cursor,
                 if (rhs == 0) return set_error(error_message, "division by zero");
                 *value %= rhs;
                 break;
-            case OP_SHL: *value <<= rhs; break;
-            case OP_SHR: *value = (int64_t)((uint64_t)*value >> rhs); break;
+            case OP_SHL:
+                if (rhs < 0 || rhs >= 64)
+                    return set_error(error_message, "invalid shift count");
+                *value <<= rhs;
+                break;
+            case OP_SHR:
+                if (rhs < 0 || rhs >= 64)
+                    return set_error(error_message, "invalid shift count");
+                *value = (int64_t)((uint64_t)*value >> rhs);
+                break;
             case OP_AND: *value = (*value & rhs); break;
             default: break;
         }

--- a/scripts/parse-copilot-log.py
+++ b/scripts/parse-copilot-log.py
@@ -118,32 +118,6 @@ def _collect_text(lines: list[Line], i: int) -> tuple[str, int]:
     return "\n".join(parts), i - start
 
 
-def _build_args(lines: list[Line], i: int) -> tuple[ArgsNode, int]:
-    """Parse 4-space indented key: value lines."""
-    args = ArgsNode()
-    pairs: list[tuple[str, str]] = []
-    key: str | None = None
-    val: list[str] = []
-
-    while i < len(lines):
-        ln = lines[i]
-        if ln.indent < 4:
-            break
-        m = re.match(r'^(\w[\w_]*?)\s*:\s*(.*)', ln.text)
-        if m and ln.indent == 4:
-            if key:
-                pairs.append((key, "\n".join(val).strip()))
-            key, val = m.group(1), [m.group(2).strip()] if m.group(2).strip() else []
-        elif key and ln.indent >= 4:
-            if ln.text.strip():
-                val.append(ln.text.strip())
-        i += 1
-    if key:
-        pairs.append((key, "\n".join(val).strip()))
-    args.pairs = pairs
-    return args, i - start   # but wait, we haven't updated i — let me fix
-
-
 def build_args(lines: list[Line], i: int) -> tuple[ArgsNode, int]:
     """Parse 4-space indented key: value pairs starting at line i.
     Returns (ArgsNode, lines_consumed_from_i)."""
@@ -276,6 +250,21 @@ def parse(lines: list[Line]) -> RootNode:
                 if body:
                     parts.append(body)
                 i += 1
+
+            if i < len(lines) and lines[i].indent == 0 and lines[i].text == "function:":
+                tool_start = i
+                tool, consumed = _build_tool(lines, i)
+                tool.start_line = tool_start
+                root.children.append(AgentNode(
+                    thinking=ThinkingNode(
+                        text="\n".join(parts).strip(),
+                        start_line=start, end_line=i),
+                    tool_calls=[tool],
+                    start_line=start, end_line=i + consumed,
+                ))
+                i += consumed
+                continue
+
             root.children.append(AgentNode(
                 thinking=ThinkingNode(
                     text="\n".join(parts).strip(),

--- a/tests/do_not_run_me_directly_but_through_meson.py
+++ b/tests/do_not_run_me_directly_but_through_meson.py
@@ -3582,6 +3582,7 @@ def _discover_and_add_auto_tests():
                         raw_stdout=raw_stdout,
                         raw_stderr=raw_stderr,
                         expected_output=expected_output,
+                        expected_stderr=expected_stderr,
                         returncode=process_returncode,
                         exception_text=traceback.format_exc(),
                     )
@@ -3594,6 +3595,7 @@ def _discover_and_add_auto_tests():
                         raw_stdout=raw_stdout,
                         raw_stderr=raw_stderr,
                         expected_output=expected_output,
+                        expected_stderr=expected_stderr,
                         returncode=process_returncode,
                     )
                     raise

--- a/tests/test_cases/class_field_virtual_function_repro.expected
+++ b/tests/test_cases/class_field_virtual_function_repro.expected
@@ -1,0 +1,4 @@
+assigned
+name=x
+createfile=true
+after=x

--- a/tests/test_cases/class_field_virtual_function_repro.p
+++ b/tests/test_cases/class_field_virtual_function_repro.p
@@ -1,0 +1,50 @@
+program class_field_virtual_function_repro;
+{$mode objfpc}
+type
+  TFile = class
+    Name: string;
+    constructor Create(const fn: string);
+    function CreateFile: Boolean; virtual;
+  end;
+
+  TCompilerFile = class(TFile)
+  end;
+
+  TModule = class
+    FileObj: TCompilerFile;
+    procedure Build(const s: string);
+  end;
+
+constructor TFile.Create(const fn: string);
+begin
+  Name := fn;
+end;
+
+function TFile.CreateFile: Boolean;
+begin
+  Result := Name = 'x';
+end;
+
+procedure TModule.Build(const s: string);
+begin
+  FileObj := TCompilerFile.Create(s);
+  if FileObj = nil then
+    WriteLn('nil')
+  else
+  begin
+    WriteLn('assigned');
+    WriteLn('name=', FileObj.Name);
+    if FileObj.CreateFile then
+      WriteLn('createfile=true')
+    else
+      WriteLn('createfile=false');
+    WriteLn('after=', FileObj.Name);
+  end;
+end;
+
+var
+  m: TModule;
+begin
+  m := TModule.Create;
+  m.Build('x');
+end.

--- a/tests/test_cases/pp_pas_bootstrap.expected
+++ b/tests/test_cases/pp_pas_bootstrap.expected
@@ -265,6 +265,7 @@
       -XLA       Define library substitutions for linking
       -XLD       Exclude default order of standard libraries
       -XLO       Define order of library linking
+      -XLL       Link using ld.lld GNU compatible LLVM linker (Linux and some BSD targets, experimental)
       -Xm        Generate link map
       -XM<x>     Set the name of the 'main' program routine (default is 'main')
       -Xn        Use target system native linker instead of GNU ld (Solaris, AIX)

--- a/tests/test_cases/pp_pas_bootstrap.expected
+++ b/tests/test_cases/pp_pas_bootstrap.expected
@@ -265,7 +265,6 @@
       -XLA       Define library substitutions for linking
       -XLD       Exclude default order of standard libraries
       -XLO       Define order of library linking
-      -XLL       Link using ld.lld GNU compatible LLVM linker (Linux and some BSD targets, experimental)
       -Xm        Generate link map
       -XM<x>     Set the name of the 'main' program routine (default is 'main')
       -Xn        Use target system native linker instead of GNU ld (Solaris, AIX)


### PR DESCRIPTION
## Summary

Addresses actionable review feedback from the recent merged PR audit:

- hardens guarded runtime allocation size calculations and restores page-size fallback behavior
- removes MSVC-incompatible `_Generic` atomic macros while preserving pointer interlocked operations
- validates Pascal preprocessor `SHL`/`SHR` shift counts
- fixes Copilot log parser thinking/tool-call grouping and removes the broken unused `_build_args` helper
- avoids releasing borrowed KgpcType references during ShortString parameter remapping
- fixes visible-symbol prioritization and zero-sized array sizing paths
- avoids silently emitting partial tuple initializer assignments when element conversion fails
- preserves `expected_stderr` in timeout/exception failure artifacts
- refreshes the `pp_pas_bootstrap` golden output for the checked-out FPC source

## Validation

- `ninja -C build`
- `python3 -m py_compile scripts/parse-copilot-log.py tests/do_not_run_me_directly_but_through_meson.py`
- `meson test -C build --no-rebuild "cparser unit tests" "pascal parser unit tests"`
- `meson test -C build --no-rebuild "Compiler tests"` (883 subtests passed)
- `meson test -C build --no-rebuild "FPC RTL tests"` (236 subtests passed)

Untracked local files were left out of the commit: `.claude/`, `skip3_err.txt`, `skip_time.txt`.

## Summary by Sourcery

Address runtime safety issues, Pascal semantic/codegen edge cases, Copilot log parsing, and test diagnostics based on recent review feedback.

Bug Fixes:
- Restore guarded allocation page-size fallback and add overflow checks in the KGPC runtime allocator.
- Replace MSVC-incompatible generic atomic macros with explicit helper functions while preserving atomic semantics across compilers.
- Fix file lock acquisition to reliably clean up stale PID lockfiles without unbounded recursion.
- Ensure Pascal tuple/array-style initializers are not partially emitted when element expression conversion fails.
- Correct constructor detection and handling for class methods so implicit Self allocation and receiver expressions behave as expected.
- Fix visible-symbol prioritization and zero-sized array size calculations in x86-64 code generation and sizeof handling.
- Validate Pascal preprocessor SHL/SHR shift counts and report errors on invalid shift amounts.
- Fix Windows strndup shim to respect the specified maximum length and avoid overrunning the input string.
- Ensure shortstring parameter remapping does not release borrowed KgpcType references.
- Preserve expected_stderr contents in timeout and exception test failure artifacts.
- Avoid truncation issues in shortstring assignment x86-64 codegen by using the full buffer size for snprintf.

Enhancements:
- Refactor atomic operations behind typed helper functions shared between FPC intrinsics and runtime APIs.
- Centralize Pascal method constructor classification in a shared helper used by semantic checks for record access and function calls.
- Simplify Copilot log parsing to correctly group tool calls following assistant thinking blocks.

Tests:
- Add a regression test for class field virtual method calls to ensure correct constructor behavior and virtual dispatch semantics.