### PR TITLE
feat: restrict VMT symtab fallback to whole-program codegen via is_whole_program flag

### DIFF
--- a/KGPC/CodeGenerator/Intel_x86-64/codegen.c
+++ b/KGPC/CodeGenerator/Intel_x86-64/codegen.c
@@ -3699,6 +3699,7 @@ void codegen(Tree_t *tree, const char *input_file_name, CodeGenContext *ctx, Sym
     memset(&g_codegen_callable_exports, 0, sizeof(g_codegen_callable_exports));
 
     ctx->symtab = symtab;
+    ctx->is_whole_program = 1;
     symtab->skip_unit_filter = 1;
 
     codegen_reset_finally_stack(ctx);
@@ -3834,6 +3835,7 @@ void codegen_unit(Tree_t *tree, const char *input_file_name, CodeGenContext *ctx
     memset(&g_codegen_callable_exports, 0, sizeof(g_codegen_callable_exports));
 
     ctx->symtab = symtab;
+    ctx->is_whole_program = 0;
     symtab->skip_unit_filter = 1;
 
     codegen_reset_finally_stack(ctx);

--- a/KGPC/CodeGenerator/Intel_x86-64/codegen.h
+++ b/KGPC/CodeGenerator/Intel_x86-64/codegen.h
@@ -356,6 +356,11 @@ typedef struct CodeGenContext {
 
     /* Virtual register ID counter — reset to 0 at each function entry. */
     int next_vreg_id;
+
+    /* Set to 1 when performing whole-program codegen (codegen()),
+     * 0 when performing direct unit codegen (codegen_unit()).
+     * Used to guard symtab-fallback passes that are only safe at link time. */
+    int is_whole_program;
 } CodeGenContext;
 
 /* Generates a label */

--- a/KGPC/CodeGenerator/Intel_x86-64/codegen_vmt.c
+++ b/KGPC/CodeGenerator/Intel_x86-64/codegen_vmt.c
@@ -1643,7 +1643,7 @@ void codegen_vmt(CodeGenContext *ctx, SymTab_t *symtab, Tree_t *tree,
      * should emit from the unit's own declared types, not arbitrary symtab
      * entries that may include incomplete or transient records.
      * When --skip-unit-codegen is active, codegen_vmt returns early above. */
-    if (tree->type == TREE_PROGRAM_TYPE)
+    if (ctx->is_whole_program)
     {
         for (ScopeNode *scope = symtab->current_scope; scope != NULL; scope = scope->parent)
         {
@@ -1657,6 +1657,14 @@ void codegen_vmt(CodeGenContext *ctx, SymTab_t *symtab, Tree_t *tree,
                 continue;
             codegen_emit_vmts_from_hash_table(ctx, symtab, unit_scope->table, &emitted_classes);
         }
+    }
+    else
+    {
+        /* Direct unit codegen must not use this symtab-scan fallback:
+         * the symbol table may contain incomplete or transient records from
+         * other units.  Emit only from the unit's own declared types above. */
+        assert(tree->type == TREE_UNIT &&
+               "symtab VMT fallback reached in non-unit, non-whole-program context");
     }
 
     /* Emit GUID data for ALL interfaces with GUIDs found in the symbol table.


### PR DESCRIPTION
Squash of agent work; CI passed on the agent branch.

## Summary by Sourcery

Restrict VMT symbol-table fallback code generation to whole-program mode using a new is_whole_program flag on the codegen context.

Enhancements:
- Add an is_whole_program flag to the code generation context to distinguish whole-program from direct unit codegen.
- Guard VMT emission from symbol-table scans so it only runs during whole-program codegen and assert if reached in incompatible contexts.