### PR TITLE
debug: serialize and deserialize function call arguments in debug AST I/O

### DIFF
--- a/KGPC/debug_deserializer.c
+++ b/KGPC/debug_deserializer.c
@@ -189,18 +189,18 @@ struct Expression *deserialize_expression(FILE *fp) {
                 struct Expression *arg_expr = deserialize_expression(fp);
                 if (arg_expr == NULL) {
                     free(id);
-                    DestroyList(args);
                     free(expr);
                     return NULL;
                 }
-                ListNode_t *arg_node = CreateListNode(arg_expr, LIST_EXPR);
+                ListNode_t *arg_node = (ListNode_t *)malloc(sizeof(ListNode_t));
                 if (arg_node == NULL) {
                     free(id);
-                    destroy_expr(arg_expr);
-                    DestroyList(args);
                     free(expr);
                     return NULL;
                 }
+                arg_node->type = LIST_EXPR;
+                arg_node->cur = arg_expr;
+                arg_node->next = NULL;
                 if (args == NULL)
                     args = arg_node;
                 else

--- a/KGPC/debug_deserializer.c
+++ b/KGPC/debug_deserializer.c
@@ -177,8 +177,38 @@ struct Expression *deserialize_expression(FILE *fp) {
                 free(expr);
                 return NULL;
             }
+            int arg_count = 0;
+            if (fscanf(fp, "%d", &arg_count) != 1 || arg_count < 0) {
+                free(id);
+                free(expr);
+                return NULL;
+            }
+            ListNode_t *args = NULL;
+            ListNode_t *tail = NULL;
+            for (int i = 0; i < arg_count; i++) {
+                struct Expression *arg_expr = deserialize_expression(fp);
+                if (arg_expr == NULL) {
+                    free(id);
+                    DestroyList(args);
+                    free(expr);
+                    return NULL;
+                }
+                ListNode_t *arg_node = CreateListNode(arg_expr, LIST_EXPR);
+                if (arg_node == NULL) {
+                    free(id);
+                    destroy_expr(arg_expr);
+                    DestroyList(args);
+                    free(expr);
+                    return NULL;
+                }
+                if (args == NULL)
+                    args = arg_node;
+                else
+                    tail->next = arg_node;
+                tail = arg_node;
+            }
             expr->expr_data.function_call_data.id = id;
-            expr->expr_data.function_call_data.args_expr = NULL; // Not deserializing args
+            expr->expr_data.function_call_data.args_expr = args;
             expr->expr_data.function_call_data.resolved_func = NULL;
             expr->expr_data.function_call_data.mangled_id = NULL;
             expr->expr_data.function_call_data.is_call_info_valid = 0;

--- a/KGPC/debug_deserializer_tests.c
+++ b/KGPC/debug_deserializer_tests.c
@@ -124,7 +124,7 @@ static void test_deserialize_long_identifier_tokens(void) {
 
     free(serialized);
 
-    serialized = format_text("%d %s\n", EXPR_FUNCTION_CALL, identifier);
+    serialized = format_text("%d %s\n0\n", EXPR_FUNCTION_CALL, identifier);
     if (serialized == NULL) {
         free(identifier);
         return;

--- a/KGPC/debug_serializer.c
+++ b/KGPC/debug_serializer.c
@@ -40,10 +40,19 @@ void serialize_expression_recursive(FILE *fp, struct Expression *expr) {
         case EXPR_SIGN_TERM:
             serialize_expression_recursive(fp, expr->expr_data.sign_term);
             break;
-        case EXPR_FUNCTION_CALL:
+        case EXPR_FUNCTION_CALL: {
             fprintf(fp, "%s\n", expr->expr_data.function_call_data.id);
-            // Not serializing args for now to keep it simple
+            int arg_count = 0;
+            ListNode_t *arg_node = expr->expr_data.function_call_data.args_expr;
+            while (arg_node != NULL) { arg_count++; arg_node = arg_node->next; }
+            fprintf(fp, "%d\n", arg_count);
+            arg_node = expr->expr_data.function_call_data.args_expr;
+            while (arg_node != NULL) {
+                serialize_expression_recursive(fp, (struct Expression *)arg_node->cur);
+                arg_node = arg_node->next;
+            }
             break;
+        }
         case EXPR_TYPECAST:
             fprintf(fp, "%d ", expr->expr_data.typecast_data.target_type);
             if (expr->expr_data.typecast_data.target_type_id != NULL)


### PR DESCRIPTION
Squash of agent work from PR #705; CI passed on the agent branch.

## Summary by Sourcery

Serialize and deserialize function call arguments as part of the debug AST I/O format.

New Features:
- Include function call argument lists in the debug AST serialization output.
- Reconstruct function call argument expressions when deserializing the debug AST.