### PR TITLE
stackmng: implement register spill-to-memory in get_register_by_id

### DIFF
--- a/KGPC/CodeGenerator/Intel_x86-64/codegen_expr_access.c
+++ b/KGPC/CodeGenerator/Intel_x86-64/codegen_expr_access.c
@@ -1096,7 +1096,7 @@ static Register_t *codegen_clone_register_if_rcx(ListNode_t **inst_list, CodeGen
     Register_t *replacement = NULL;
     for (size_t i = 0; i < sizeof(preferred_regs) / sizeof(preferred_regs[0]); ++i)
     {
-        if (get_register_by_id(get_reg_stack(), preferred_regs[i], &replacement) == 0 && replacement != NULL)
+        if (get_register_by_id(get_reg_stack(), preferred_regs[i], &replacement, inst_list) == 0 && replacement != NULL)
             break;
         replacement = NULL;
     }

--- a/KGPC/CodeGenerator/Intel_x86-64/stackmng/stackmng.c
+++ b/KGPC/CodeGenerator/Intel_x86-64/stackmng/stackmng.c
@@ -892,10 +892,11 @@ RegStack_t *init_reg_stack()
 /* NOTE: Getters return number greater than 0 if it had to kick a value out to temp */
 /* The returned int is the temp offset to restore the value */
 /* TODO: Doesn't actually kick variable out to temp yet */
-int get_register_by_id(RegStack_t *regstack, RegisterId_t reg_id, Register_t **return_reg)
+int get_register_by_id(RegStack_t *regstack, RegisterId_t reg_id, Register_t **return_reg, ListNode_t **inst_list)
 {
     assert(regstack != NULL);
     assert(return_reg != NULL);
+    assert(inst_list != NULL);
 
     ListNode_t *cur_reg, *prev_reg;
     Register_t *reg;
@@ -923,7 +924,42 @@ int get_register_by_id(RegStack_t *regstack, RegisterId_t reg_id, Register_t **r
         cur_reg = cur_reg->next;
     }
 
-    assert(0 && "Kicking out values in registers not currently supported!");
+    cur_reg = regstack->registers_allocated;
+    while (cur_reg != NULL)
+    {
+        reg = (Register_t *)cur_reg->cur;
+        if (reg->reg_id == reg_id)
+        {
+            char spill_label[64];
+            snprintf(spill_label, sizeof(spill_label), "spill_%s", reg->bit_64 + 1);
+            StackNode_t *spill_slot = find_in_temp(spill_label);
+            if (spill_slot == NULL)
+                spill_slot = add_l_t_bytes(spill_label, (int)sizeof(void *));
+            if (spill_slot == NULL)
+            {
+                *return_reg = NULL;
+                return -1;
+            }
+            reg->spill_location = spill_slot;
+
+            char spill_code[128];
+            snprintf(spill_code, sizeof(spill_code), "\t# Spill %s (by-id)\n\tmovq\t%s, -%d(%%rbp)\n",
+                reg->bit_64, reg->bit_64, spill_slot->offset);
+            *inst_list = add_inst(*inst_list, spill_code);
+
+            if (reg->spill_callback != NULL)
+                reg->spill_callback(reg, spill_slot, reg->spill_context);
+            register_clear_spill_callback(reg);
+
+            reg->last_use_seq = ++regstack->use_sequence;
+            *return_reg = reg;
+            return 0;
+        }
+        cur_reg = cur_reg->next;
+    }
+
+    *return_reg = NULL;
+    return -1;
 }
 
 void free_reg(RegStack_t *reg_stack, Register_t *reg)

--- a/KGPC/CodeGenerator/Intel_x86-64/stackmng/stackmng.h
+++ b/KGPC/CodeGenerator/Intel_x86-64/stackmng/stackmng.h
@@ -105,7 +105,7 @@ RegStack_t *init_reg_stack();
 
 /* NOTE: Getters return number greater than 1 if it had to kick a value out to temp */
 /* The returned int is the temp offset to restore the value */
-int get_register_by_id(RegStack_t *, RegisterId_t reg_id, Register_t **);
+int get_register_by_id(RegStack_t *, RegisterId_t reg_id, Register_t **, ListNode_t **inst_list);
 void restore_register_64bit(RegStack_t *, Register_t *, int temp_offset);
 void restore_register_32bit(RegStack_t *, Register_t *, int temp_offset);
 void free_reg(RegStack_t *, Register_t *);


### PR DESCRIPTION
Squash of agent work from PR #706; CI passed on the agent branch.

## Summary by Sourcery

Implement spilling of a specific register to a stack-backed temporary when requested by ID and update the API to thread through the instruction list for emitted spill code.

New Features:
- Add support in get_register_by_id for spilling an allocated register to a named temporary stack slot and emitting the corresponding spill instruction sequence.

Enhancements:
- Extend get_register_by_id to accept and use an instruction list pointer so spill code can be appended to the current instruction stream.
- Ensure get_register_by_id returns an error and clears the output register pointer when the requested register or spill slot cannot be obtained.