### PR TITLE
fix: balance builtin type refs in semcheck init

### DIFF
--- a/KGPC/Parser/ParseTree/KgpcType.c
+++ b/KGPC/Parser/ParseTree/KgpcType.c
@@ -906,6 +906,7 @@ KgpcType* create_kgpc_type_from_type_alias(struct TypeAlias *alias, struct SymTa
 
         /* Create array type even if element type is NULL (forward reference) */
         result = create_array_type(element_type, start, end);
+        kgpc_type_release(element_type);
         if (result != NULL) {
             kgpc_type_set_type_alias(result, alias);
             /* Store element type ID for deferred resolution if element_type is NULL */
@@ -1318,6 +1319,8 @@ KgpcType *resolve_type_from_vardecl(Tree_t *var_decl, struct SymTab *symtab, int
                     !(type_node->type->kind == TYPE_KIND_PRIMITIVE &&
                       type_node->type->info.primitive_type_tag == UNKNOWN_TYPE))
                 {
+                    if (owns_type != NULL)
+                        *owns_type = 1;
                     kgpc_type_retain(type_node->type);
                     return type_node->type;
                 }
@@ -1334,6 +1337,8 @@ KgpcType *resolve_type_from_vardecl(Tree_t *var_decl, struct SymTab *symtab, int
                     type_node->type != NULL &&
                     type_node->type->kind == TYPE_KIND_PRIMITIVE)
                 {
+                    if (owns_type != NULL)
+                        *owns_type = 1;
                     kgpc_type_retain(type_node->type);
                     return type_node->type;
                 }
@@ -1401,16 +1406,17 @@ KgpcType *resolve_type_from_vardecl(Tree_t *var_decl, struct SymTab *symtab, int
                 if (pointee_shared)
                     kgpc_type_retain(pointee_type);
                 KgpcType *pointer_type = create_pointer_type(pointee_type);
+                destroy_kgpc_type(pointee_type);
                 if (pointer_type != NULL)
                 {
                     if (owns_type != NULL)
                         *owns_type = 1;
                     return pointer_type;
                 }
-                if (!pointee_shared)
-                    destroy_kgpc_type(pointee_type);
             }
         }
+        if (owns_type != NULL)
+            *owns_type = 1;
         kgpc_type_retain(var_decl->tree_data.var_decl_data.cached_kgpc_type);
         return var_decl->tree_data.var_decl_data.cached_kgpc_type;
     }
@@ -1476,7 +1482,9 @@ KgpcType *resolve_type_from_vardecl(Tree_t *var_decl, struct SymTab *symtab, int
             /* Create a new array KgpcType - caller owns this */
             if (owns_type != NULL)
                 *owns_type = 1;
-            return create_array_type(elem_type, start, end);
+            KgpcType *array_type = create_array_type(elem_type, start, end);
+            destroy_kgpc_type(elem_type);
+            return array_type;
         }
 
         return NULL;
@@ -1502,7 +1510,7 @@ KgpcType *resolve_type_from_vardecl(Tree_t *var_decl, struct SymTab *symtab, int
             size_node->type->kind != TYPE_KIND_RECORD)
         {
             if (owns_type != NULL)
-                *owns_type = 0;
+                *owns_type = 1;
             kgpc_type_retain(size_node->type);
             return size_node->type;
         }
@@ -1570,7 +1578,9 @@ KgpcType *resolve_type_from_vardecl(Tree_t *var_decl, struct SymTab *symtab, int
             kgpc_type_retain(pointee_type);
         if (owns_type != NULL)
             *owns_type = 1;
-        return create_pointer_type(pointee_type);
+        KgpcType *pointer_type = create_pointer_type(pointee_type);
+        destroy_kgpc_type(pointee_type);
+        return pointer_type;
     }
 
     /* Handle named type references using the symbol table */
@@ -1595,9 +1605,9 @@ KgpcType *resolve_type_from_vardecl(Tree_t *var_decl, struct SymTab *symtab, int
                     return alias_type;
                 }
             }
-            /* Return a shared reference from the symbol table - caller doesn't own it */
+            /* Return a retained reference to the shared symbol-table type. */
             if (owns_type != NULL)
-                *owns_type = 0;
+                *owns_type = 1;
             kgpc_type_retain(type_node->type);
             return type_node->type;
         }

--- a/KGPC/Parser/SemanticCheck/SemCheck_parts/SemCheck_init_and_inheritance.c
+++ b/KGPC/Parser/SemanticCheck/SemCheck_parts/SemCheck_init_and_inheritance.c
@@ -1382,7 +1382,11 @@ int predeclare_types(SymTab_t *symtab, ListNode_t *type_decls)
                         {
                             KgpcType *inline_kgpc = create_record_type(alias->inline_record_type);
                             if (record_type_is_class(alias->inline_record_type))
-                                inline_kgpc = create_pointer_type(inline_kgpc);
+                            {
+                                KgpcType *record_kgpc = inline_kgpc;
+                                inline_kgpc = create_pointer_type(record_kgpc);
+                                destroy_kgpc_type(record_kgpc);
+                            }
 
                             if (tree->tree_data.type_decl_data.kgpc_type == NULL)
                             {
@@ -1407,7 +1411,11 @@ int predeclare_types(SymTab_t *symtab, ListNode_t *type_decls)
                         /* Also register the alias name itself */
                         KgpcType *alias_kgpc = create_record_type(alias->inline_record_type);
                         if (record_type_is_class(alias->inline_record_type))
-                            alias_kgpc = create_pointer_type(alias_kgpc);
+                        {
+                            KgpcType *record_kgpc = alias_kgpc;
+                            alias_kgpc = create_pointer_type(record_kgpc);
+                            destroy_kgpc_type(record_kgpc);
+                        }
                         kgpc_type_set_type_alias(alias_kgpc, alias);
                         int alias_result = PushTypeOntoScope_Typed(symtab, (char *)type_id, alias_kgpc);
                         if (alias_result > 0)

--- a/KGPC/Parser/SemanticCheck/SemCheck_parts/SemCheck_vmt_and_type_decls.c
+++ b/KGPC/Parser/SemanticCheck/SemCheck_parts/SemCheck_vmt_and_type_decls.c
@@ -2067,7 +2067,11 @@ int semcheck_type_decls(SymTab_t *symtab, ListNode_t *type_decls)
                     {
                         KgpcType *inline_kgpc = create_record_type(alias_info->inline_record_type);
                         if (record_type_is_class(alias_info->inline_record_type))
-                            inline_kgpc = create_pointer_type(inline_kgpc);
+                        {
+                            KgpcType *record_kgpc = inline_kgpc;
+                            inline_kgpc = create_pointer_type(record_kgpc);
+                            destroy_kgpc_type(record_kgpc);
+                        }
                         kgpc_type_set_type_alias(inline_kgpc, alias_info);
                         if (tree->tree_data.type_decl_data.kgpc_type != NULL)
                             destroy_kgpc_type(tree->tree_data.type_decl_data.kgpc_type);


### PR DESCRIPTION
Closes #713.

Cherry-pick of copilot/fix-ref-count-leak-semcheck-init onto current master.

Fixes KgpcType ref-count leaks in the semcheck predeclaration paths:
- After create_array_type/create_pointer_type, releases the elem_type/pointee_type retain that create_* acquires
- Fixes owns_type flags so callers know they own the returned type and must free it

## Summary by Sourcery

Fix KgpcType lifetime management and ownership semantics in type resolution and semantic-check initialization paths to prevent reference-count leaks and ensure callers correctly own returned types.

Bug Fixes:
- Release temporary element and pointee types after constructing array and pointer KgpcTypes to avoid reference-count leaks.
- Correct owns_type flags in resolve_type_from_vardecl so callers consistently know when they are responsible for freeing returned types.
- Avoid leaking inline record KgpcTypes when wrapping class records in pointer types during type predeclaration and type-decl semantic checking.

Enhancements:
- Standardize retention of shared symbol-table types so resolve_type_from_vardecl always returns a retained, caller-owned reference where indicated.