### PR TITLE
fix: release creator ref after pushing proc_type in semcheck_type_decls

### DIFF
--- a/KGPC/Parser/SemanticCheck/SemCheck_parts/SemCheck_vmt_and_type_decls.c
+++ b/KGPC/Parser/SemanticCheck/SemCheck_parts/SemCheck_vmt_and_type_decls.c
@@ -1953,6 +1953,7 @@ int semcheck_type_decls(SymTab_t *symtab, ListNode_t *type_decls)
                                                 }
                                             }
                                             mangled = NULL;
+                                            destroy_kgpc_type(proc_type);
                                         }
                                     }
                                     else if (existing != NULL)


### PR DESCRIPTION
## Summary

- `from_cparser_method_template_to_proctype` returns `proc_type` with `ref_count=1` (caller owns the creator's ref)
- The subsequent `PushFunctionOntoScope_Typed`/`PushProcedureOntoScope_Typed` call does `kgpc_type_retain` internally, bringing ref to 2
- Missing `destroy_kgpc_type(proc_type)` after the push left ref_count=2 at scope teardown, so the type was never freed
- This caused a direct ASAN leak of 5 objects (360 bytes) for every class method registered in `semcheck_type_decls`

## Test plan
- [ ] `meson test -C build` — full suite must pass
- [ ] `meson test -C build-fpc "FPC RTL tests"` — FPC RTL suite must pass  
- [ ] `meson test -C build-asan` — leak bytes must decrease (5 fewer objects × 72 bytes each per class method registered)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Release the creator reference for procedure types after pushing them onto the scope in semantic type declaration checking to prevent a refcount leak.