### PR TITLE
fix: remove owns_params guard in destroy_stmt/destroy_expr

### DIFF
--- a/KGPC/Parser/ParseTree/tree.c
+++ b/KGPC/Parser/ParseTree/tree.c
@@ -1512,12 +1512,7 @@ void destroy_stmt(struct Statement *stmt)
           }
           if (stmt->stmt_data.procedure_call_data.call_kgpc_type != NULL)
           {
-              KgpcType *call_type = stmt->stmt_data.procedure_call_data.call_kgpc_type;
-              if (!(call_type->kind == TYPE_KIND_PROCEDURE &&
-                    call_type->info.proc_info.owns_params))
-              {
-                  destroy_kgpc_type(call_type);
-              }
+              destroy_kgpc_type(stmt->stmt_data.procedure_call_data.call_kgpc_type);
               stmt->stmt_data.procedure_call_data.call_kgpc_type = NULL;
           }
           if (stmt->stmt_data.procedure_call_data.placeholder_method_name != NULL)
@@ -1778,15 +1773,7 @@ void destroy_expr(struct Expression *expr)
           }
           if (expr->expr_data.function_call_data.call_kgpc_type != NULL)
           {
-              KgpcType *call_type = expr->expr_data.function_call_data.call_kgpc_type;
-              /* Cached call signatures may reference parameter declaration trees
-               * owned by parse/type metadata. Let the original owner reclaim those
-               * procedure types instead of freeing them from expression teardown. */
-              if (!(call_type->kind == TYPE_KIND_PROCEDURE &&
-                    call_type->info.proc_info.owns_params))
-              {
-                  destroy_kgpc_type(call_type);
-              }
+              destroy_kgpc_type(expr->expr_data.function_call_data.call_kgpc_type);
               expr->expr_data.function_call_data.call_kgpc_type = NULL;
           }
           if (expr->expr_data.function_call_data.placeholder_method_name != NULL)

--- a/KGPC/Parser/SemanticCheck/SemCheck_parts/SemCheck_subprograms.c
+++ b/KGPC/Parser/SemanticCheck/SemCheck_parts/SemCheck_subprograms.c
@@ -1438,6 +1438,9 @@ int predeclare_subprogram(SymTab_t *symtab, Tree_t *subprogram, int max_scope_le
             subprogram->tree_data.subprogram_data.args_var,
             return_kgpc_type  /* functions have a return type */
         );
+        /* Release caller's owned ref — create_procedure_type retained its own */
+        destroy_kgpc_type(return_kgpc_type);
+        return_kgpc_type = NULL;
         if (func_type != NULL) {
             func_type->info.proc_info.definition = subprogram;
             if (subprogram->tree_data.subprogram_data.return_type_id != NULL)


### PR DESCRIPTION
## Summary

- All call sites setting `call_kgpc_type` in both stmt and expr nodes call `kgpc_type_retain()` first
- The `owns_params` guard in `destroy_stmt`/`destroy_expr` was incorrectly blocking the paired `destroy_kgpc_type()` release for builtin PROCEDURE types (e.g., writeln)
- This caused a 72-byte direct leak (the writeln proc_type) per compiled program

## Root cause

The guard in commit `72169f5e` was added to prevent crashes during FPC RTL teardown. But the crash it was preventing was a different bug — not a double-free from the balanced retain/release pattern. All `call_kgpc_type` assignments in `SemCheck_stmt_proccall.c` and `SemCheck_stmt.c` call `kgpc_type_retain()` before storing, so the paired `destroy_kgpc_type()` in teardown is always correct.

## Test plan
- [x] All compiler tests pass (`meson test -C build "Compiler tests"`)
- [x] ASan leak count reduced from 518 → 446 bytes (writeln 72-byte leak resolved)
- [x] No new test failures introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Always destroy stored call_kgpc_type for procedure/function call statements and expressions instead of skipping procedure types with owns_params flags that were leaving them leaked.