### PR TITLE
Fix Pascal compiler leak cleanup

### DIFF
--- a/KGPC/CodeGenerator/Intel_x86-64/codegen.c
+++ b/KGPC/CodeGenerator/Intel_x86-64/codegen.c
@@ -2196,6 +2196,8 @@ void codegen_register_const_decls(ListNode_t *const_decls, SymTab_t *symtab)
                     set_type->size_in_bytes = 4;
             }
             PushSetConstOntoScope(symtab, (char *)id, set_bytes, (int)set_size, set_type);
+            if (set_type != NULL)
+                destroy_kgpc_type(set_type);
             continue;
         }
 

--- a/KGPC/CodeGenerator/Intel_x86-64/codegen_statement_parts/codegen_stmt_infrastructure.c
+++ b/KGPC/CodeGenerator/Intel_x86-64/codegen_statement_parts/codegen_stmt_infrastructure.c
@@ -62,6 +62,26 @@ static int codegen_local_type_tag_size(int type_tag)
     return get_type_tag_size(type_tag);
 }
 
+static void codegen_destroy_synthetic_record_access_keep_record(
+    struct Expression *field_access)
+{
+    if (field_access == NULL)
+        return;
+    if (field_access->type == EXPR_RECORD_ACCESS)
+        field_access->expr_data.record_access_data.record_expr = NULL;
+    destroy_expr(field_access);
+}
+
+static void codegen_destroy_synthetic_array_access_keep_array(
+    struct Expression *array_access)
+{
+    if (array_access == NULL)
+        return;
+    if (array_access->type == EXPR_ARRAY_ACCESS)
+        array_access->expr_data.array_access_data.array_expr = NULL;
+    destroy_expr(array_access);
+}
+
 void codegen_hydrate_array_literal_from_lhs(struct Expression *lhs_expr,
     struct Expression *rhs_expr, CodeGenContext *ctx)
 {
@@ -2398,10 +2418,14 @@ ListNode_t *codegen_address_for_expr(struct Expression *expr, ListNode_t *inst_l
                         if (assign_stmt == NULL)
                             goto cleanup;
                         inst_list = codegen_var_assignment(assign_stmt, inst_list, ctx);
-                        free(assign_stmt);
+                        assign_stmt->stmt_data.var_assign_data.var = NULL;
+                        assign_stmt->stmt_data.var_assign_data.expr = NULL;
+                        destroy_stmt(assign_stmt);
+                        codegen_destroy_synthetic_array_access_keep_array(array_access);
                         element_node = element_node->next;
                         ++index;
                     }
+                    codegen_destroy_synthetic_record_access_keep_record(field_access);
                     field_node = field_node->next;
                     continue;
                 }
@@ -2411,10 +2435,16 @@ ListNode_t *codegen_address_for_expr(struct Expression *expr, ListNode_t *inst_l
                 if (assign_stmt == NULL)
                     goto cleanup;
                 inst_list = codegen_var_assignment(assign_stmt, inst_list, ctx);
-                free(assign_stmt);
+                assign_stmt->stmt_data.var_assign_data.var = NULL;
+                assign_stmt->stmt_data.var_assign_data.expr = NULL;
+                destroy_stmt(assign_stmt);
+                codegen_destroy_synthetic_record_access_keep_record(field_access);
             }
             field_node = field_node->next;
         }
+
+        destroy_expr(temp_var);
+        temp_var = NULL;
 
         Register_t *addr_reg = get_free_reg(get_reg_stack(), &inst_list);
         if (addr_reg == NULL)

--- a/KGPC/Parser/ParseTree/KgpcType.c
+++ b/KGPC/Parser/ParseTree/KgpcType.c
@@ -617,6 +617,98 @@ static HashNode_t *kgpc_find_type_node_with_unit_flag(SymTab_t *symtab,
 /* Forward declarations for TypeAlias copy functions */
 static struct TypeAlias* copy_type_alias(const struct TypeAlias *src);
 static void free_copied_type_alias(struct TypeAlias *alias);
+/* Track heap-owned KgpcType instances so any objects left with positive
+ * reference counts after normal AST/symbol-table teardown can be released.
+ * This is only a final cleanup aid; regular ownership still goes through
+ * destroy_kgpc_type()/kgpc_type_release(). */
+static KgpcType **g_live_kgpc_types = NULL;
+static size_t g_live_kgpc_type_count = 0;
+static size_t g_live_kgpc_type_capacity = 0;
+static int g_live_kgpc_type_cleaning = 0;
+
+static void kgpc_type_register_live(KgpcType *type)
+{
+    if (type == NULL || g_live_kgpc_type_cleaning)
+        return;
+    if (g_live_kgpc_type_count == g_live_kgpc_type_capacity)
+    {
+        size_t new_capacity = g_live_kgpc_type_capacity == 0 ? 256 : g_live_kgpc_type_capacity * 2;
+        KgpcType **new_items = (KgpcType **)realloc(g_live_kgpc_types,
+            new_capacity * sizeof(KgpcType *));
+        if (new_items == NULL)
+            return;
+        g_live_kgpc_types = new_items;
+        g_live_kgpc_type_capacity = new_capacity;
+    }
+    g_live_kgpc_types[g_live_kgpc_type_count++] = type;
+}
+
+static void kgpc_type_unregister_live(KgpcType *type)
+{
+    if (type == NULL || g_live_kgpc_types == NULL)
+        return;
+    for (size_t i = 0; i < g_live_kgpc_type_count; ++i)
+    {
+        if (g_live_kgpc_types[i] == type)
+        {
+            g_live_kgpc_types[i] = g_live_kgpc_types[g_live_kgpc_type_count - 1];
+            g_live_kgpc_types[g_live_kgpc_type_count - 1] = NULL;
+            --g_live_kgpc_type_count;
+            return;
+        }
+    }
+}
+
+void kgpc_type_cleanup_remaining(void)
+{
+    g_live_kgpc_type_cleaning = 1;
+    while (g_live_kgpc_type_count > 0)
+    {
+        KgpcType *type = g_live_kgpc_types[--g_live_kgpc_type_count];
+        g_live_kgpc_types[g_live_kgpc_type_count] = NULL;
+        if (type == NULL)
+            continue;
+
+        switch (type->kind)
+        {
+            case TYPE_KIND_PROCEDURE:
+                if (type->info.proc_info.owns_params)
+                    destroy_list(type->info.proc_info.params);
+                else
+                    DestroyList(type->info.proc_info.params);
+                type->info.proc_info.params = NULL;
+                free(type->info.proc_info.return_type_id);
+                type->info.proc_info.return_type_id = NULL;
+                type->info.proc_info.return_type = NULL;
+                break;
+            case TYPE_KIND_ARRAY:
+                free(type->info.array_info.element_type_id);
+                type->info.array_info.element_type_id = NULL;
+                type->info.array_info.element_type = NULL;
+                break;
+            case TYPE_KIND_POINTER:
+                type->info.points_to = NULL;
+                break;
+            case TYPE_KIND_PRIMITIVE:
+            case TYPE_KIND_RECORD:
+            case TYPE_KIND_ARRAY_OF_CONST:
+                break;
+        }
+
+        if (type->type_alias != NULL)
+        {
+            type->type_alias->kgpc_type = NULL;
+            free_copied_type_alias(type->type_alias);
+            type->type_alias = NULL;
+        }
+        free(type);
+    }
+    free(g_live_kgpc_types);
+    g_live_kgpc_types = NULL;
+    g_live_kgpc_type_capacity = 0;
+    g_live_kgpc_type_cleaning = 0;
+}
+
 int kgpc_type_is_real_family_tag(int primitive_tag)
 {
     return is_real_family_type(primitive_tag);
@@ -635,6 +727,7 @@ KgpcType* create_primitive_type(int primitive_tag) {
     type->kind = TYPE_KIND_PRIMITIVE;
     type->info.primitive_type_tag = primitive_tag;
     type->ref_count = 1;
+    kgpc_type_register_live(type);
     // Size will be determined later in semcheck
     return type;
 }
@@ -645,6 +738,7 @@ KgpcType* create_primitive_type_with_size(int primitive_tag, int storage_size) {
     type->kind = TYPE_KIND_PRIMITIVE;
     type->info.primitive_type_tag = primitive_tag;
     type->ref_count = 1;
+    kgpc_type_register_live(type);
     
     /* Create a minimal type_alias just to hold the storage_size */
     struct TypeAlias *alias = (struct TypeAlias *)calloc(1, sizeof(struct TypeAlias));
@@ -672,6 +766,7 @@ KgpcType* create_pointer_type(KgpcType *points_to) {
     if (points_to != NULL)
         kgpc_type_retain(points_to);
     type->ref_count = 1;
+    kgpc_type_register_live(type);
     return type;
 }
 
@@ -688,6 +783,7 @@ KgpcType* create_procedure_type(ListNode_t *params, KgpcType *return_type) {
     type->info.proc_info.return_type_id = NULL;
     type->info.proc_info.is_method_pointer = 0;
     type->ref_count = 1;
+    kgpc_type_register_live(type);
     
     #ifdef DEBUG_KGPC_TYPE_CREATION
     fprintf(stderr, "DEBUG: create_procedure_type: params=%p, return_type=%p (is_function=%d)\n",
@@ -708,6 +804,7 @@ KgpcType* create_array_type(KgpcType *element_type, int start_index, int end_ind
     type->info.array_info.end_index = end_index;
     type->info.array_info.element_type_id = NULL; // Initialize deferred resolution field
     type->ref_count = 1;
+    kgpc_type_register_live(type);
     return type;
 }
 
@@ -717,6 +814,7 @@ KgpcType* create_array_of_const_type(void) {
     type->kind = TYPE_KIND_ARRAY_OF_CONST;
     type->info.array_of_const_info.element_size = sizeof(kgpc_tvarrec);
     type->ref_count = 1;
+    kgpc_type_register_live(type);
     return type;
 }
 
@@ -726,6 +824,7 @@ KgpcType* create_record_type(struct RecordType *record_info) {
     type->kind = TYPE_KIND_RECORD;
     type->info.record_info = record_info; // Record is owned by the AST
     type->ref_count = 1;
+    kgpc_type_register_live(type);
     return type;
 }
 
@@ -742,6 +841,7 @@ KgpcType* kgpc_type_clone_shallow_owned(const KgpcType *src)
     clone->size_in_bytes = src->size_in_bytes;
     clone->alignment_in_bytes = src->alignment_in_bytes;
     clone->ref_count = 1;
+    kgpc_type_register_live(clone);
 
     if (src->type_alias != NULL)
         kgpc_type_set_type_alias(clone, src->type_alias);
@@ -1163,6 +1263,7 @@ void destroy_kgpc_type(KgpcType *type) {
         type->type_alias = NULL;
     }
     
+    kgpc_type_unregister_live(type);
     free(type);
 }
 

--- a/KGPC/Parser/ParseTree/KgpcType.h
+++ b/KGPC/Parser/ParseTree/KgpcType.h
@@ -129,6 +129,7 @@ KgpcType* create_kgpc_type_from_type_alias(struct TypeAlias *alias, struct SymTa
 void destroy_kgpc_type(KgpcType *type);
 void kgpc_type_retain(KgpcType *type);
 void kgpc_type_release(KgpcType *type);
+void kgpc_type_cleanup_remaining(void);
 
 // Utility functions
 int are_types_compatible_for_assignment(KgpcType *lhs_type, KgpcType *rhs_type, struct SymTab *symtab);

--- a/KGPC/Parser/ParseTree/tree.c
+++ b/KGPC/Parser/ParseTree/tree.c
@@ -1525,6 +1525,8 @@ void destroy_stmt(struct Statement *stmt)
               free(stmt->stmt_data.procedure_call_data.call_qualifier);
           if (stmt->stmt_data.procedure_call_data.self_class_name != NULL)
               free(stmt->stmt_data.procedure_call_data.self_class_name);
+          if (stmt->stmt_data.procedure_call_data.constructor_class_name != NULL)
+              free(stmt->stmt_data.procedure_call_data.constructor_class_name);
           break;
 
         case STMT_EXPR:

--- a/KGPC/Parser/SemanticCheck/SemChecks/SemCheck_Expr_Builtins.c
+++ b/KGPC/Parser/SemanticCheck/SemChecks/SemCheck_Expr_Builtins.c
@@ -1505,8 +1505,9 @@ int semcheck_prepare_dynarray_high_call(int *type_return, SymTab_t *symtab,
     if (expr->expr_data.function_call_data.call_kgpc_type == NULL)
     {
         KgpcType *ret_type = create_primitive_type(LONGINT_TYPE);
-        /* create_procedure_type takes ownership of ret_type */
         KgpcType *func_type = create_procedure_type(NULL, ret_type);
+        if (ret_type != NULL)
+            destroy_kgpc_type(ret_type);
         if (func_type != NULL)
             expr->expr_data.function_call_data.call_kgpc_type = func_type;
     }

--- a/KGPC/Parser/SemanticCheck/SemChecks/SemCheck_funccall_method.c
+++ b/KGPC/Parser/SemanticCheck/SemChecks/SemCheck_funccall_method.c
@@ -459,6 +459,7 @@ if (!ctx->was_unit_qualified &&
                         }
                         if (filtered_candidates != NULL)
                         {
+                            DestroyList(method_candidates);
                             method_candidates = filtered_candidates;
                             any_has_self = 0;
                         }
@@ -469,6 +470,7 @@ if (!ctx->was_unit_qualified &&
                         ctx->expr->expr_data.function_call_data.args_expr = old_head->next;
                         old_head->next = NULL;  /* Detach to prevent dangling reference */
                         ctx->args_given = ctx->expr->expr_data.function_call_data.args_expr;
+                        destroy_list(old_head);
 
                         if (kgpc_getenv("KGPC_DEBUG_SEMCHECK") != NULL) {
                             fprintf(stderr, "[SemCheck] semcheck_funccall: Removed type arg for static method call\n");
@@ -483,6 +485,7 @@ if (!ctx->was_unit_qualified &&
                         ctx->expr->expr_data.function_call_data.args_expr = old_head->next;
                         old_head->next = NULL;
                         ctx->args_given = ctx->expr->expr_data.function_call_data.args_expr;
+                        destroy_list(old_head);
 
                         if (kgpc_getenv("KGPC_DEBUG_SEMCHECK") != NULL) {
                             fprintf(stderr, "[SemCheck] semcheck_funccall: Removed instance arg for static method call\n");
@@ -774,6 +777,7 @@ if (!ctx->was_unit_qualified &&
                             }
                             if (filtered_candidates != NULL)
                             {
+                                DestroyList(method_candidates);
                                 method_candidates = filtered_candidates;
                                 any_has_self = 0;
                             }
@@ -783,6 +787,7 @@ if (!ctx->was_unit_qualified &&
                             ctx->expr->expr_data.function_call_data.args_expr = old_head->next;
                             old_head->next = NULL;
                             ctx->args_given = ctx->expr->expr_data.function_call_data.args_expr;
+                            destroy_list(old_head);
                         }
 
                         if (ctx->mangled_name != NULL)
@@ -1130,6 +1135,7 @@ if (ctx->id != NULL &&
                 ListNode_t *old_head = ctx->args_given;
                 ctx->expr->expr_data.function_call_data.args_expr = old_head->next;
                 old_head->next = NULL;  /* Detach to prevent dangling reference */
+                destroy_list(old_head);
                 ListNode_t *user_args = ctx->expr->expr_data.function_call_data.args_expr;
                 ctx->args_given = user_args;  /* Update args_given to reflect removed type arg */
 

--- a/KGPC/Parser/SemanticCheck/SemChecks/SemCheck_stmt_main.c
+++ b/KGPC/Parser/SemanticCheck/SemChecks/SemCheck_stmt_main.c
@@ -906,21 +906,25 @@ int semcheck_stmt_main(SymTab_t *symtab, struct Statement *stmt, int max_scope_l
                                 semcheck_stmt_method_is_declared_constructor(symtab,
                                     parent_owner_record, method_name_for_constructor_check))
                             {
-                                stmt->stmt_data.procedure_call_data.is_constructor_call = 1;
-
-                                if (parent_owner_record->parent_class_name == NULL ||
-                                    pascal_identifier_equals(method_name_for_constructor_check, "Create"))
+                                if (call_expr != NULL && call_expr->type == EXPR_FUNCTION_CALL)
                                 {
-                                    free(stmt->stmt_data.procedure_call_data.constructor_class_name);
-                                    stmt->stmt_data.procedure_call_data.constructor_class_name =
-                                        strdup("Self");
-                                    if (stmt->stmt_data.procedure_call_data.constructor_class_name == NULL)
+                                    call_expr->expr_data.function_call_data.is_constructor_call = 1;
+
+                                    if (parent_owner_record->parent_class_name == NULL ||
+                                        pascal_identifier_equals(method_name_for_constructor_check, "Create"))
                                     {
-                                        semcheck_error_with_context_at(stmt->line_num, stmt->col_num,
-                                            stmt->source_index,
-                                            "Error on line %d, out of memory while resolving inherited constructor call.\n\n",
-                                            stmt->line_num);
-                                        return ++return_val;
+                                        if (call_expr->expr_data.function_call_data.constructor_receiver_expr != NULL)
+                                            destroy_expr(call_expr->expr_data.function_call_data.constructor_receiver_expr);
+                                        call_expr->expr_data.function_call_data.constructor_receiver_expr =
+                                            mk_varid(stmt->line_num, strdup("Self"));
+                                        if (call_expr->expr_data.function_call_data.constructor_receiver_expr == NULL)
+                                        {
+                                            semcheck_error_with_context_at(stmt->line_num, stmt->col_num,
+                                                stmt->source_index,
+                                                "Error on line %d, out of memory while resolving inherited constructor call.\n\n",
+                                                stmt->line_num);
+                                            return ++return_val;
+                                        }
                                     }
                                 }
                             }
@@ -968,6 +972,16 @@ int semcheck_stmt_main(SymTab_t *symtab, struct Statement *stmt, int max_scope_l
                         semcheck_stmt_set_call_kgpc_type(&temp_call, NULL,
                             temp_call.stmt_data.procedure_call_data.is_call_info_valid == 1);
                         temp_call.stmt_data.procedure_call_data.is_call_info_valid = 0;
+                        free(temp_call.stmt_data.procedure_call_data.cached_owner_class);
+                        temp_call.stmt_data.procedure_call_data.cached_owner_class = NULL;
+                        free(temp_call.stmt_data.procedure_call_data.cached_method_name);
+                        temp_call.stmt_data.procedure_call_data.cached_method_name = NULL;
+                        free(temp_call.stmt_data.procedure_call_data.self_class_name);
+                        temp_call.stmt_data.procedure_call_data.self_class_name = NULL;
+                        free(temp_call.stmt_data.procedure_call_data.constructor_class_name);
+                        temp_call.stmt_data.procedure_call_data.constructor_class_name = NULL;
+                        free(temp_call.stmt_data.procedure_call_data.call_qualifier);
+                        temp_call.stmt_data.procedure_call_data.call_qualifier = NULL;
                     }
                 }
                 else

--- a/KGPC/Parser/SemanticCheck/SemChecks/SemCheck_stmt_proccall.c
+++ b/KGPC/Parser/SemanticCheck/SemChecks/SemCheck_stmt_proccall.c
@@ -2368,6 +2368,7 @@ skip_method_placeholder_resolution:
                                         }
                                         cur = cur->next;
                                     }
+                                    DestroyList(parent_candidates);
                                 }
                                 
                                 free(parent_mangled_name);

--- a/KGPC/Units/classes.p
+++ b/KGPC/Units/classes.p
@@ -36,6 +36,7 @@ type
     FCount: integer;
     FSorted: boolean;
     constructor Create;
+    destructor Destroy; override;
     procedure Add(const S: string); override;
     procedure AddDelimitedText(const S: string; ADelimiter: Char; AStrictDelimiter: Boolean); overload;
     procedure AddDelimitedText(const S: string); overload;
@@ -163,6 +164,13 @@ constructor TStringList.Create;
 begin
   inherited Create;
   FCount := 0;
+  SetLength(FItems, 0);
+end;
+
+destructor TStringList.Destroy;
+begin
+  SetLength(FItems, 0);
+  inherited Destroy;
 end;
 
 procedure TStringList.Add(const S: string);

--- a/KGPC/main_cparser.c
+++ b/KGPC/main_cparser.c
@@ -3715,6 +3715,7 @@ ast_nil = NULL;
         unit_search_paths_destroy(&g_unit_paths);
         unit_registry_reset();
         arena_destroy(arena);
+        kgpc_type_cleanup_remaining();
         return exit_code > 0 ? exit_code : 1;
     }
 
@@ -3723,6 +3724,7 @@ ast_nil = NULL;
     unit_search_paths_destroy(&g_unit_paths);
     unit_registry_reset();
     arena_destroy(arena);
+    kgpc_type_cleanup_remaining();
     emit_profile_stage("total pipeline", current_time_seconds() - pipeline_total_start);
     return exit_code;
 }

--- a/KGPC/runtime.c
+++ b/KGPC/runtime.c
@@ -2481,6 +2481,14 @@ void kgpc_dynarray_setlength(void *descriptor_ptr, int64_t new_length, int64_t e
     size_t old_length = descriptor->length > 0 ? (size_t)descriptor->length : 0;
     size_t target_length = (size_t)new_length;
 
+    if (target_length == 0)
+    {
+        free(descriptor->data);
+        descriptor->data = NULL;
+        descriptor->length = 0;
+        return;
+    }
+
     size_t alloc_length = target_length;
     if (alloc_length < SIZE_MAX)
         alloc_length += 1; /* Provide a spare slot to tolerate off-by-one accesses. */


### PR DESCRIPTION
## Summary
- release synthetic AST/type objects introduced during codegen and semcheck paths
- add final KgpcType cleanup for remaining live type objects
- clean dynamic array zero-length runtime storage

## Validation
- meson compile -C build kgpc kgpc_runtime

## Summary by Sourcery

Tighten memory and resource management across the Pascal compiler to clean up leaked types, AST nodes, strings, and dynamic array storage.

Bug Fixes:
- Track heap-allocated KgpcType instances and add a final cleanup pass invoked at compiler shutdown to release any remaining live type objects.
- Fix ownership and destruction of temporary AST nodes and lists in semantic checking and code generation paths to avoid leaks and dangling references.
- Ensure TStringList properly initializes and clears its backing dynamic array and that runtime dynamic arrays free their storage when resized to zero length.