### PR TITLE
Refactor: replace string-matched param_sig with structural TypeRef comparison

### DIFF
--- a/KGPC/CodeGenerator/Intel_x86-64/codegen_symbol_resolution.c
+++ b/KGPC/CodeGenerator/Intel_x86-64/codegen_symbol_resolution.c
@@ -568,16 +568,23 @@ int codegen_resolve_virtual_vmt_index(CodeGenContext *ctx,
                 first_count_match = method;
             count_match_count++;
             int matched = 0;
-            if (call_param_types != NULL && method->param_types != NULL &&
-                method->param_types_count >= 0)
+            int lhs_has = (call_param_types != NULL);
+            int rhs_has = (method->param_types != NULL && method->param_types_count >= 0);
+            if (lhs_has && rhs_has)
             {
                 if (type_ref_array_equal_ci(call_param_types, call_param_types_count,
                                             method->param_types, method->param_types_count))
                     matched = 1;
             }
-            if (!matched && call_param_sig != NULL && method->param_sig != NULL &&
-                strcasecmp(call_param_sig, method->param_sig) == 0)
-                matched = 1;
+            if (!matched && call_param_sig != NULL && method->param_sig != NULL)
+            {
+                if (lhs_has != rhs_has)
+                    kgpc_param_types_strict_miss(
+                        "codegen_symbol_resolution:vmt-slot-picker",
+                        "call", lhs_has, "method", rhs_has);
+                if (strcasecmp(call_param_sig, method->param_sig) == 0)
+                    matched = 1;
+            }
             if (matched)
                 sig_match = method;
         }

--- a/KGPC/CodeGenerator/Intel_x86-64/codegen_symbol_resolution.c
+++ b/KGPC/CodeGenerator/Intel_x86-64/codegen_symbol_resolution.c
@@ -10,6 +10,8 @@
 #include "codegen_string_set.h"
 #include "codegen_symbol_resolution.h"
 #include "../../Parser/ParseTree/type_tags.h"
+#include "../../Parser/ParseTree/from_cparser.h"
+#include "../../Parser/ParseTree/ident_ref.h"
 #include "../../Parser/SemanticCheck/NameMangling.h"
 #include "../../identifier_utils.h"
 #include "../../unit_registry.h"
@@ -19,6 +21,7 @@
 /* Defined in Parser/SemanticCheck/SemCheck_parts/SemCheck_vmt_and_type_decls.c.
  * Build a parameter signature for overload disambiguation. */
 char *semcheck_param_sig_from_params(ListNode_t *params, int skip_first_param);
+TypeRef **semcheck_param_types_from_params(ListNode_t *params, int skip_first_param, int *out_count);
 
 /* Globals defined in codegen.c; accessed here for label collection. */
 extern ListNode_t *g_codegen_available_subprograms;
@@ -517,6 +520,8 @@ int codegen_resolve_virtual_vmt_index(CodeGenContext *ctx,
      * types (e.g. tloopnode.create(tnodetype,4*tnode) vs
      * tfornode.create(4*tnode,boolean)). */
     char *call_param_sig = NULL;
+    TypeRef **call_param_types = NULL;
+    int call_param_types_count = 0;
     if (call_type != NULL && call_type->kind == TYPE_KIND_PROCEDURE)
     {
         ListNode_t *params = call_type->info.proc_info.params;
@@ -534,6 +539,7 @@ int codegen_resolve_virtual_vmt_index(CodeGenContext *ctx,
             }
         }
         call_param_sig = semcheck_param_sig_from_params(params, skip_self);
+        call_param_types = semcheck_param_types_from_params(params, skip_self, &call_param_types_count);
     }
 
     struct MethodInfo *name_match = NULL;
@@ -561,16 +567,25 @@ int codegen_resolve_virtual_vmt_index(CodeGenContext *ctx,
             if (first_count_match == NULL)
                 first_count_match = method;
             count_match_count++;
-            if (call_param_sig != NULL && method->param_sig != NULL &&
-                strcasecmp(call_param_sig, method->param_sig) == 0)
+            int matched = 0;
+            if (call_param_types != NULL && method->param_types != NULL &&
+                method->param_types_count >= 0)
             {
-                sig_match = method;
+                if (type_ref_array_equal_ci(call_param_types, call_param_types_count,
+                                            method->param_types, method->param_types_count))
+                    matched = 1;
             }
+            if (!matched && call_param_sig != NULL && method->param_sig != NULL &&
+                strcasecmp(call_param_sig, method->param_sig) == 0)
+                matched = 1;
+            if (matched)
+                sig_match = method;
         }
     }
 
     if (call_param_sig != NULL)
         free(call_param_sig);
+    param_types_free(call_param_types, call_param_types_count);
 
     if (sig_match != NULL)
         return sig_match->vmt_index;

--- a/KGPC/CodeGenerator/Intel_x86-64/codegen_vmt.c
+++ b/KGPC/CodeGenerator/Intel_x86-64/codegen_vmt.c
@@ -52,6 +52,9 @@ struct TypeRef **semcheck_param_types_from_params(ListNode_t *params, int skip_f
 void param_types_free(struct TypeRef **types, int count);
 int type_ref_array_equal_ci(struct TypeRef *const *lhs, int lhs_count,
                             struct TypeRef *const *rhs, int rhs_count);
+void kgpc_param_types_strict_miss(const char *site,
+                                  const char *lhs_label, int lhs_has_types,
+                                  const char *rhs_label, int rhs_has_types);
 
 static void codegen_collect_inferred_interfaces(SymTab_t *symtab,
     const struct RecordType *record, const char *class_label,
@@ -720,6 +723,10 @@ static void codegen_emit_class_vmt(CodeGenContext *ctx, SymTab_t *symtab,
                                                 cand_types, cand_count))
                         sig_match = 1;
                     param_types_free(cand_types, cand_count);
+                } else if (template_param_sig != NULL) {
+                    kgpc_param_types_strict_miss(
+                        "codegen_vmt:template-cand-match",
+                        "template", 0, "cand-params(sema)", 1);
                 }
                 if (!sig_match && template_param_sig != NULL) {
                     char *cand_sig = semcheck_param_sig_from_params(
@@ -794,15 +801,21 @@ static void codegen_emit_class_vmt(CodeGenContext *ctx, SymTab_t *symtab,
                 if (first_match_idx < 0)
                     first_match_idx = method_idx;
                 int sig_eq = 0;
-                if (template_param_types != NULL && method->param_types != NULL &&
-                    method->param_types_count >= 0) {
+                int lhs_has = (template_param_types != NULL);
+                int rhs_has = (method->param_types != NULL && method->param_types_count >= 0);
+                if (lhs_has && rhs_has) {
                     if (type_ref_array_equal_ci(template_param_types, template_param_types_count,
                                                 method->param_types, method->param_types_count))
                         sig_eq = 1;
                 }
-                if (!sig_eq && template_param_sig != NULL && method->param_sig != NULL &&
-                    strcasecmp(template_param_sig, method->param_sig) == 0)
-                    sig_eq = 1;
+                if (!sig_eq && template_param_sig != NULL && method->param_sig != NULL) {
+                    if (lhs_has != rhs_has)
+                        kgpc_param_types_strict_miss(
+                            "codegen_vmt:template-MethodInfo-pair",
+                            "template", lhs_has, "MethodInfo", rhs_has);
+                    if (strcasecmp(template_param_sig, method->param_sig) == 0)
+                        sig_eq = 1;
+                }
                 if (sig_eq) {
                     sig_match_idx = method_idx;
                     break;

--- a/KGPC/CodeGenerator/Intel_x86-64/codegen_vmt.c
+++ b/KGPC/CodeGenerator/Intel_x86-64/codegen_vmt.c
@@ -47,6 +47,11 @@
 /* Defined in Parser/SemanticCheck/SemCheck_parts/SemCheck_vmt_and_type_decls.c.
  * Build a parameter signature string for overload disambiguation. */
 char *semcheck_param_sig_from_params(ListNode_t *params, int skip_first_param);
+struct TypeRef;
+struct TypeRef **semcheck_param_types_from_params(ListNode_t *params, int skip_first_param, int *out_count);
+void param_types_free(struct TypeRef **types, int count);
+int type_ref_array_equal_ci(struct TypeRef *const *lhs, int lhs_count,
+                            struct TypeRef *const *rhs, int rhs_count);
 
 static void codegen_collect_inferred_interfaces(SymTab_t *symtab,
     const struct RecordType *record, const char *class_label,
@@ -642,12 +647,18 @@ static void codegen_emit_class_vmt(CodeGenContext *ctx, SymTab_t *symtab,
              * producing spurious mismatches.  Compare param signatures
              * (which already exclude Self) instead. */
             char *template_param_sig = NULL;
+            struct TypeRef **template_param_types = NULL;
+            int template_param_types_count = 0;
             KgpcType *tmpl_proc_type =
                 from_cparser_method_template_to_proctype(tmpl, record_info, symtab);
             if (tmpl_proc_type != NULL && tmpl_proc_type->kind == TYPE_KIND_PROCEDURE) {
                 template_param_sig = semcheck_param_sig_from_params(
                     tmpl_proc_type->info.proc_info.params,
                     tmpl->is_static ? 0 : 1);
+                template_param_types = semcheck_param_types_from_params(
+                    tmpl_proc_type->info.proc_info.params,
+                    tmpl->is_static ? 0 : 1,
+                    &template_param_types_count);
             }
             if (tmpl_proc_type != NULL)
                 destroy_kgpc_type(tmpl_proc_type);
@@ -700,7 +711,17 @@ static void codegen_emit_class_vmt(CodeGenContext *ctx, SymTab_t *symtab,
                 }
 
                 int sig_match = 0;
-                if (template_param_sig != NULL) {
+                if (template_param_types != NULL) {
+                    int cand_count = 0;
+                    struct TypeRef **cand_types = semcheck_param_types_from_params(
+                        cand->type->info.proc_info.params,
+                        tmpl->is_static ? 0 : 1, &cand_count);
+                    if (type_ref_array_equal_ci(template_param_types, template_param_types_count,
+                                                cand_types, cand_count))
+                        sig_match = 1;
+                    param_types_free(cand_types, cand_count);
+                }
+                if (!sig_match && template_param_sig != NULL) {
                     char *cand_sig = semcheck_param_sig_from_params(
                         cand->type->info.proc_info.params,
                         tmpl->is_static ? 0 : 1);
@@ -737,6 +758,7 @@ static void codegen_emit_class_vmt(CodeGenContext *ctx, SymTab_t *symtab,
             free(base_name);
             if (resolved_id == NULL) {
                 free(template_param_sig);
+                param_types_free(template_param_types, template_param_types_count);
                 continue;
             }
 
@@ -771,8 +793,17 @@ static void codegen_emit_class_vmt(CodeGenContext *ctx, SymTab_t *symtab,
                     continue;
                 if (first_match_idx < 0)
                     first_match_idx = method_idx;
-                if (template_param_sig != NULL && method->param_sig != NULL &&
-                    strcasecmp(template_param_sig, method->param_sig) == 0) {
+                int sig_eq = 0;
+                if (template_param_types != NULL && method->param_types != NULL &&
+                    method->param_types_count >= 0) {
+                    if (type_ref_array_equal_ci(template_param_types, template_param_types_count,
+                                                method->param_types, method->param_types_count))
+                        sig_eq = 1;
+                }
+                if (!sig_eq && template_param_sig != NULL && method->param_sig != NULL &&
+                    strcasecmp(template_param_sig, method->param_sig) == 0)
+                    sig_eq = 1;
+                if (sig_eq) {
                     sig_match_idx = method_idx;
                     break;
                 }
@@ -797,6 +828,7 @@ static void codegen_emit_class_vmt(CodeGenContext *ctx, SymTab_t *symtab,
             }
 
             free(template_param_sig);
+            param_types_free(template_param_types, template_param_types_count);
         }
 
         if (claimed_resolved_ids != NULL) {

--- a/KGPC/Parser/ParseTree/from_cparser.h
+++ b/KGPC/Parser/ParseTree/from_cparser.h
@@ -18,6 +18,11 @@ int from_cparser_get_error_count(void);
 /* Forward declaration for symbol table - avoid circular dependency */
 struct SymTab;
 
+/* Forward declarations for TypeRef-array helpers used in struct fields below. */
+struct TypeRef;
+void param_types_free(struct TypeRef **types, int count);
+struct TypeRef **param_types_clone(struct TypeRef *const *src, int count);
+
 /* Method binding information */
 typedef struct {
     char *class_name;

--- a/KGPC/Parser/ParseTree/from_cparser.h
+++ b/KGPC/Parser/ParseTree/from_cparser.h
@@ -27,7 +27,9 @@ typedef struct {
     int is_static;         /* 1 if method is static (no Self parameter) */
     int is_class_method;   /* 1 if declared with 'class' keyword (Self = VMT pointer) */
     int param_count; /* Number of explicit parameters (excludes implicit Self), -1 if unknown */
-    char *param_sig; /* Mangled signature of parameter types, or NULL if unknown */
+    char *param_sig; /* Mangled signature of parameter types, or NULL if unknown -- diagnostic only */
+    struct TypeRef **param_types; /* Structural parameter types, parallel to param_sig (preferred for compares) */
+    int param_types_count; /* Number of entries in param_types (-1 if unknown) */
 } ClassMethodBinding;
 
 /* Convert an AST type specification to a KgpcType object.

--- a/KGPC/Parser/ParseTree/from_cparser.h
+++ b/KGPC/Parser/ParseTree/from_cparser.h
@@ -69,6 +69,9 @@ int from_cparser_class_has_method_name(const char *class_name, const char *metho
 int from_cparser_is_method_virtual(const char *class_name, const char *method_name);
 int from_cparser_is_method_virtual_with_signature(const char *class_name, const char *method_name,
     int param_count, const char *param_sig);
+int from_cparser_is_method_virtual_with_types(const char *class_name, const char *method_name,
+    int param_count,
+    struct TypeRef *const *param_types, int param_types_count);
 
 void from_cparser_enable_pending_specializations(void);
 void from_cparser_disable_pending_specializations(void);

--- a/KGPC/Parser/ParseTree/from_cparser_internal.h
+++ b/KGPC/Parser/ParseTree/from_cparser_internal.h
@@ -293,6 +293,9 @@ char *generate_anonymous_method_name(int is_function);
 int is_external_directive(const char *directive);
 int is_method_static_with_signature(const char *class_name, const char *method_name,
                                            int param_count, const char *param_sig);
+int is_method_static_with_types(const char *class_name, const char *method_name,
+                                int param_count,
+                                struct TypeRef *const *param_types, int param_types_count);
 int is_operator_token_name(const char *name);
 bool is_safe_to_continue(VisitedSet *visited, ast_t *node);
 int kgpc_debug_decl_scan_enabled(void);
@@ -306,6 +309,7 @@ char *method_param_type_suffix(Tree_t *param_decl);
 char *param_type_signature_from_method_impl(ast_t *method_node);
 char *param_type_signature_from_params_ast(ast_t *params_ast);
 struct TypeRef **param_types_from_params_ast(ast_t *params_ast, int *out_count);
+struct TypeRef **param_types_from_method_impl(ast_t *method_node, int *out_count);
 void param_types_free(struct TypeRef **types, int count);
 struct TypeRef **param_types_clone(struct TypeRef *const *src, int count);
 int parse_guid_literal(const char *guid, uint32_t *d1, uint16_t *d2, uint16_t *d3, uint8_t d4[8]);

--- a/KGPC/Parser/ParseTree/from_cparser_internal.h
+++ b/KGPC/Parser/ParseTree/from_cparser_internal.h
@@ -305,6 +305,9 @@ void mark_var_decl_static_storage(Tree_t *decl);
 char *method_param_type_suffix(Tree_t *param_decl);
 char *param_type_signature_from_method_impl(ast_t *method_node);
 char *param_type_signature_from_params_ast(ast_t *params_ast);
+struct TypeRef **param_types_from_params_ast(ast_t *params_ast, int *out_count);
+void param_types_free(struct TypeRef **types, int count);
+struct TypeRef **param_types_clone(struct TypeRef *const *src, int count);
 int parse_guid_literal(const char *guid, uint32_t *d1, uint16_t *d2, uint16_t *d3, uint8_t d4[8]);
 int parse_range_bound(const char *s);
 QualifiedIdent *qualified_ident_from_ast(ast_t *node);
@@ -313,7 +316,8 @@ void cmb_index_alias_as_qualified(const char *unqualified_name, const char *qual
 void register_class_method_ex(const char *class_name, const char *method_name,
                                       int is_virtual, int is_override, int is_static,
                                       int is_class_method,
-                                      int param_count, char *param_sig);
+                                      int param_count, char *param_sig,
+                                      struct TypeRef **param_types, int param_types_count);
 void register_const_int(const char *name, int value);
 void register_const_section(ast_t *const_section);
 void register_pending_generic_alias(Tree_t *decl, TypeInfo *type_info);

--- a/KGPC/Parser/ParseTree/from_cparser_parts/from_cparser_declarations.c
+++ b/KGPC/Parser/ParseTree/from_cparser_parts/from_cparser_declarations.c
@@ -2500,10 +2500,13 @@ static Tree_t *convert_type_decl_ex(ast_t *type_decl_node, ListNode_t **method_c
                         if (!template->is_interface_delegation) {
                             int param_count = from_cparser_count_params_ast(template->params_ast);
                             char *param_sig = param_type_signature_from_params_ast(template->params_ast);
+                            int param_types_count = 0;
+                            TypeRef **param_types = param_types_from_params_ast(template->params_ast, &param_types_count);
                             register_class_method_ex(id, template->name,
                                 template->is_virtual, template->is_override, template->is_static,
                                 template->is_class_method,
-                                param_count, param_sig);
+                                param_count, param_sig,
+                                param_types, param_types_count);
                         }
                         if (kgpc_getenv("KGPC_DEBUG_CLASS_METHODS") != NULL)
                             fprintf(stderr, "[KGPC] Registered record method %s.%s (static=%d)\n",
@@ -2530,10 +2533,13 @@ static Tree_t *convert_type_decl_ex(ast_t *type_decl_node, ListNode_t **method_c
                         if (!template->is_interface_delegation) {
                             int param_count = from_cparser_count_params_ast(template->params_ast);
                             char *param_sig = param_type_signature_from_params_ast(template->params_ast);
+                            int param_types_count = 0;
+                            TypeRef **param_types = param_types_from_params_ast(template->params_ast, &param_types_count);
                             register_class_method_ex(id, template->name,
                                 template->is_virtual, template->is_override, template->is_static,
                                 template->is_class_method,
-                                param_count, param_sig);
+                                param_count, param_sig,
+                                param_types, param_types_count);
                         }
                         if (kgpc_getenv("KGPC_DEBUG_CLASS_METHODS") != NULL)
                             fprintf(stderr, "[KGPC] Registered helper method %s.%s (static=%d)\n",

--- a/KGPC/Parser/ParseTree/from_cparser_parts/from_cparser_generics.c
+++ b/KGPC/Parser/ParseTree/from_cparser_parts/from_cparser_generics.c
@@ -687,10 +687,13 @@ static Tree_t *instantiate_method_template(struct MethodTemplate *method_templat
     {
         int param_count = from_cparser_count_params_ast(method_template->params_ast);
         char *param_sig = param_type_signature_from_params_ast(method_template->params_ast);
+        int param_types_count = 0;
+        TypeRef **param_types = param_types_from_params_ast(method_template->params_ast, &param_types_count);
         register_class_method_ex(record->type_id, method_template->name,
             method_template->is_virtual, method_template->is_override,
             method_template->is_static, method_template->is_class_method,
-            param_count, param_sig);
+            param_count, param_sig,
+            param_types, param_types_count);
     }
 
     ast_t *method_copy = copy_ast(method_template->method_impl_ast);

--- a/KGPC/Parser/ParseTree/from_cparser_parts/from_cparser_init_and_registry.c
+++ b/KGPC/Parser/ParseTree/from_cparser_parts/from_cparser_init_and_registry.c
@@ -1781,7 +1781,7 @@ void register_class_method_ex(const char *class_name, const char *method_name,
     if (class_name == NULL || method_name == NULL)
         return;
 
-    ClassMethodBinding *binding = (ClassMethodBinding *)malloc(sizeof(ClassMethodBinding));
+    ClassMethodBinding *binding = (ClassMethodBinding *)calloc(1, sizeof(ClassMethodBinding));
     if (binding == NULL)
         return;
 

--- a/KGPC/Parser/ParseTree/from_cparser_parts/from_cparser_init_and_registry.c
+++ b/KGPC/Parser/ParseTree/from_cparser_parts/from_cparser_init_and_registry.c
@@ -1736,6 +1736,93 @@ char *param_type_signature_from_params_ast(ast_t *params_ast) {
     return sig;
 }
 
+/* Parallel TypeRef-array builder.  Returns a heap-allocated array of N TypeRef*
+ * pointers (caller owns each TypeRef* and the outer array) and writes the
+ * element count to *out_count.  Returns NULL with *out_count=0 when params_ast
+ * is empty.  Each TypeRef is produced from convert_type_spec on the param's
+ * type node, so generic args and qualified names are preserved structurally. */
+static TypeRef *param_type_ref_from_type_node(ast_t *type_node) {
+    if (type_node == NULL)
+        return NULL;
+    char *type_id = NULL;
+    TypeInfo type_info;
+    memset(&type_info, 0, sizeof(TypeInfo));
+    convert_type_spec(type_node, &type_id, NULL, &type_info);
+    TypeRef *type_ref = type_info.type_ref;
+    type_info.type_ref = NULL;
+    if (type_ref == NULL)
+        type_ref = type_ref_from_info_or_id(&type_info, type_id);
+    destroy_type_info_contents(&type_info);
+    if (type_id != NULL)
+        free(type_id);
+    return type_ref;
+}
+
+TypeRef **param_types_from_params_ast(ast_t *params_ast, int *out_count) {
+    if (out_count != NULL)
+        *out_count = 0;
+    if (params_ast == NULL)
+        return NULL;
+    ast_t *param = params_ast;
+    if (param->typ == PASCAL_T_PARAM_LIST)
+        param = param->child;
+
+    int capacity = 0;
+    int count = 0;
+    TypeRef **arr = NULL;
+    for (; param != NULL; param = param->next) {
+        if (param->typ != PASCAL_T_PARAM)
+            continue;
+        int name_count = count_param_names_in_param(param);
+        if (name_count <= 0)
+            continue;
+        ast_t *type_node = find_param_type_spec(param);
+        TypeRef *base = param_type_ref_from_type_node(type_node);
+        for (int i = 0; i < name_count; ++i) {
+            if (count == capacity) {
+                int new_cap = (capacity == 0) ? 4 : capacity * 2;
+                TypeRef **grown = (TypeRef **)realloc(arr, (size_t)new_cap * sizeof(TypeRef *));
+                if (grown == NULL) {
+                    /* Roll back on OOM. */
+                    for (int j = 0; j < count; ++j)
+                        type_ref_free(arr[j]);
+                    free(arr);
+                    type_ref_free(base);
+                    if (out_count != NULL)
+                        *out_count = 0;
+                    return NULL;
+                }
+                arr = grown;
+                capacity = new_cap;
+            }
+            arr[count++] = (i == 0) ? base : type_ref_clone(base);
+        }
+        /* If name_count==0 (skipped above), base is leaked; not reached. */
+    }
+    if (out_count != NULL)
+        *out_count = count;
+    return arr;
+}
+
+void param_types_free(TypeRef **types, int count) {
+    if (types == NULL)
+        return;
+    for (int i = 0; i < count; ++i)
+        type_ref_free(types[i]);
+    free(types);
+}
+
+TypeRef **param_types_clone(TypeRef *const *src, int count) {
+    if (src == NULL || count <= 0)
+        return NULL;
+    TypeRef **dst = (TypeRef **)calloc((size_t)count, sizeof(TypeRef *));
+    if (dst == NULL)
+        return NULL;
+    for (int i = 0; i < count; ++i)
+        dst[i] = type_ref_clone(src[i]);
+    return dst;
+}
+
 int count_params_in_method_impl(ast_t *method_node) {
     if (method_node == NULL)
         return -1;
@@ -1777,13 +1864,22 @@ char *param_type_signature_from_method_impl(ast_t *method_node) {
 void register_class_method_ex(const char *class_name, const char *method_name,
                                       int is_virtual, int is_override, int is_static,
                                       int is_class_method,
-                                      int param_count, char *param_sig) {
-    if (class_name == NULL || method_name == NULL)
+                                      int param_count, char *param_sig,
+                                      TypeRef **param_types, int param_types_count) {
+    if (class_name == NULL || method_name == NULL) {
+        if (param_sig != NULL)
+            free(param_sig);
+        param_types_free(param_types, param_types_count);
         return;
+    }
 
     ClassMethodBinding *binding = (ClassMethodBinding *)calloc(1, sizeof(ClassMethodBinding));
-    if (binding == NULL)
+    if (binding == NULL) {
+        if (param_sig != NULL)
+            free(param_sig);
+        param_types_free(param_types, param_types_count);
         return;
+    }
 
     binding->class_name = (char *)string_intern(class_name);
     binding->method_name = (char *)string_intern(method_name);
@@ -1793,6 +1889,8 @@ void register_class_method_ex(const char *class_name, const char *method_name,
     binding->is_class_method = is_class_method;
     binding->param_count = param_count;
     binding->param_sig = param_sig;
+    binding->param_types = param_types;
+    binding->param_types_count = (param_types != NULL) ? param_types_count : -1;
 
     ListNode_t *node = NULL;
     if (binding->class_name != NULL && binding->method_name != NULL)
@@ -1802,6 +1900,7 @@ void register_class_method_ex(const char *class_name, const char *method_name,
         /* class_name and method_name are interned -- do not free */
         if (binding->param_sig != NULL)
             free(binding->param_sig);
+        param_types_free(binding->param_types, binding->param_types_count);
         free(binding);
         return;
     }
@@ -1824,7 +1923,7 @@ void register_class_method_ex(const char *class_name, const char *method_name,
 void from_cparser_register_method_template(const char *class_name, const char *method_name,
     int is_virtual, int is_override, int is_static, int param_count) {
     register_class_method_ex(class_name, method_name, is_virtual, is_override, is_static,
-        0, param_count, NULL);
+        0, param_count, NULL, NULL, -1);
 }
 
 

--- a/KGPC/Parser/ParseTree/from_cparser_parts/from_cparser_init_and_registry.c
+++ b/KGPC/Parser/ParseTree/from_cparser_parts/from_cparser_init_and_registry.c
@@ -1861,6 +1861,42 @@ char *param_type_signature_from_method_impl(ast_t *method_node) {
     return sig;
 }
 
+TypeRef **param_types_from_method_impl(ast_t *method_node, int *out_count) {
+    if (out_count != NULL)
+        *out_count = 0;
+    if (method_node == NULL)
+        return NULL;
+    TypeRef **out = NULL;
+    int total = 0;
+    for (ast_t *cur = method_node->child; cur != NULL; cur = cur->next) {
+        ast_t *node = unwrap_pascal_node(cur);
+        if (node == NULL)
+            node = cur;
+        if (node->typ != PASCAL_T_PARAM_LIST && node->typ != PASCAL_T_PARAM)
+            continue;
+        int chunk_count = 0;
+        TypeRef **chunk = param_types_from_params_ast(node, &chunk_count);
+        if (chunk == NULL || chunk_count == 0) {
+            param_types_free(chunk, chunk_count);
+            continue;
+        }
+        TypeRef **grown = (TypeRef **)realloc(out, (size_t)(total + chunk_count) * sizeof(TypeRef *));
+        if (grown == NULL) {
+            param_types_free(out, total);
+            param_types_free(chunk, chunk_count);
+            return NULL;
+        }
+        out = grown;
+        for (int i = 0; i < chunk_count; ++i)
+            out[total + i] = chunk[i];
+        free(chunk); /* steal entries, free outer */
+        total += chunk_count;
+    }
+    if (out_count != NULL)
+        *out_count = total;
+    return out;
+}
+
 void register_class_method_ex(const char *class_name, const char *method_name,
                                       int is_virtual, int is_override, int is_static,
                                       int is_class_method,
@@ -1970,6 +2006,47 @@ static int is_method_static(const char *class_name, const char *method_name) {
     if (has_instance)
         return 0;
     return has_static;
+}
+
+int is_method_static_with_types(const char *class_name, const char *method_name,
+                                int param_count,
+                                TypeRef *const *param_types, int param_types_count) {
+    if (class_name == NULL || method_name == NULL)
+        return 0;
+    if (param_types == NULL && param_count < 0)
+        return is_method_static(class_name, method_name);
+
+    const char *cn = string_intern(class_name);
+    const char *mn = string_intern(method_name);
+    if (cn == NULL || mn == NULL)
+        return 0;
+    CMBIndexEntry *entry = cmb_index_find(cn);
+    if (entry == NULL)
+        return is_method_static(class_name, method_name);
+    int has_static = 0, has_instance = 0, has_match = 0;
+    for (int i = 0; i < entry->count; i++) {
+        ClassMethodBinding *b = entry->bindings[i];
+        if (b->method_name != mn)
+            continue;
+        int matches = 0;
+        if (param_types != NULL && b->param_types != NULL && b->param_types_count >= 0) {
+            if (type_ref_array_equal_ci(b->param_types, b->param_types_count,
+                                        param_types, param_types_count))
+                matches = 1;
+        } else if (param_count >= 0 && b->param_count == param_count) {
+            matches = 1;
+        }
+        if (matches) {
+            has_match = 1;
+            if (b->is_static) has_static = 1;
+            else has_instance = 1;
+        }
+    }
+    if (has_match) {
+        if (has_instance) return 0;
+        return has_static;
+    }
+    return is_method_static(class_name, method_name);
 }
 
 int is_method_static_with_signature(const char *class_name, const char *method_name,
@@ -2132,6 +2209,47 @@ int from_cparser_is_method_virtual(const char *class_name, const char *method_na
         }
     }
     return 0;
+}
+
+int from_cparser_is_method_virtual_with_types(const char *class_name, const char *method_name,
+    int param_count,
+    TypeRef *const *param_types, int param_types_count)
+{
+    if (class_name == NULL || method_name == NULL)
+        return 0;
+    if (param_types == NULL && param_count < 0)
+        return from_cparser_is_method_virtual(class_name, method_name);
+
+    const char *mn = string_intern(method_name);
+    if (mn == NULL)
+        return 0;
+
+    int has_match = 0, has_virtual = 0;
+    const char *cn = string_intern(class_name);
+    if (cn != NULL) {
+        CMBIndexEntry *entry = cmb_index_find(cn);
+        if (entry != NULL) {
+            for (int i = 0; i < entry->count; i++) {
+                ClassMethodBinding *b = entry->bindings[i];
+                if (b->method_name != mn) continue;
+                int matches = 0;
+                if (param_types != NULL && b->param_types != NULL && b->param_types_count >= 0) {
+                    if (type_ref_array_equal_ci(b->param_types, b->param_types_count,
+                                                param_types, param_types_count))
+                        matches = 1;
+                } else if (param_count >= 0 && b->param_count == param_count) {
+                    matches = 1;
+                }
+                if (matches) {
+                    has_match = 1;
+                    if (b->is_virtual || b->is_override) has_virtual = 1;
+                }
+            }
+        }
+    }
+    if (has_match)
+        return has_virtual;
+    return from_cparser_is_method_virtual(class_name, method_name);
 }
 
 int from_cparser_is_method_virtual_with_signature(const char *class_name, const char *method_name,

--- a/KGPC/Parser/ParseTree/from_cparser_parts/from_cparser_init_and_registry.c
+++ b/KGPC/Parser/ParseTree/from_cparser_parts/from_cparser_init_and_registry.c
@@ -2068,6 +2068,10 @@ int is_method_static_with_signature(const char *class_name, const char *method_n
     int has_static = 0;
     int has_instance = 0;
     int has_match = 0;
+    if (param_sig != NULL)
+        kgpc_param_types_strict_miss(
+            "is_method_static_with_signature:legacy-call",
+            "query", 0, "bindings", 1);
     for (int i = 0; i < entry->count; i++) {
         ClassMethodBinding *binding = entry->bindings[i];
         if (binding->method_name == mn) {
@@ -2267,6 +2271,10 @@ int from_cparser_is_method_virtual_with_signature(const char *class_name, const 
 
     int has_match = 0;
     int has_virtual = 0;
+    if (param_sig != NULL)
+        kgpc_param_types_strict_miss(
+            "from_cparser_is_method_virtual_with_signature:legacy-call",
+            "query", 0, "bindings", 1);
 
     /* Helper: check bindings for a given interned class name. */
     #define CHECK_INDEX_FOR(interned_cname) \

--- a/KGPC/Parser/ParseTree/from_cparser_parts/from_cparser_records.c
+++ b/KGPC/Parser/ParseTree/from_cparser_parts/from_cparser_records.c
@@ -955,10 +955,13 @@ static void collect_class_members(ast_t *node, const char *class_name,
                                 if (!template->is_interface_delegation) {
                                     int param_count = from_cparser_count_params_ast(template->params_ast);
                                     char *param_sig = param_type_signature_from_params_ast(template->params_ast);
+                                    int param_types_count = 0;
+                                    TypeRef **param_types = param_types_from_params_ast(template->params_ast, &param_types_count);
                                     register_class_method_ex(class_name, template->name,
                                         template->is_virtual, template->is_override, template->is_static,
                                         template->is_class_method,
-                                        param_count, param_sig);
+                                        param_count, param_sig,
+                                        param_types, param_types_count);
                                 }
                                 if (method_builder != NULL)
                                     list_builder_append(method_builder, template, LIST_METHOD_TEMPLATE);
@@ -1052,10 +1055,13 @@ static void collect_class_members(ast_t *node, const char *class_name,
                 if (!template->is_interface_delegation) {
                     int param_count = from_cparser_count_params_ast(template->params_ast);
                     char *param_sig = param_type_signature_from_params_ast(template->params_ast);
+                    int param_types_count = 0;
+                    TypeRef **param_types = param_types_from_params_ast(template->params_ast, &param_types_count);
                     register_class_method_ex(class_name, template->name,
                         template->is_virtual, template->is_override, template->is_static,
                         template->is_class_method,
-                        param_count, param_sig);
+                        param_count, param_sig,
+                        param_types, param_types_count);
                 }
 
                 if (method_builder != NULL)

--- a/KGPC/Parser/ParseTree/from_cparser_parts/from_cparser_statements_and_programs.c
+++ b/KGPC/Parser/ParseTree/from_cparser_parts/from_cparser_statements_and_programs.c
@@ -2270,8 +2270,11 @@ void from_cparser_cleanup(void)
     while (class_method_bindings != NULL) {
         ListNode_t *next = class_method_bindings->next;
         ClassMethodBinding *binding = (ClassMethodBinding *)class_method_bindings->cur;
-        if (binding != NULL && binding->param_sig != NULL)
-            free(binding->param_sig);
+        if (binding != NULL) {
+            if (binding->param_sig != NULL)
+                free(binding->param_sig);
+            param_types_free(binding->param_types, binding->param_types_count);
+        }
         free(binding); /* ClassMethodBinding struct */
         free(class_method_bindings);
         class_method_bindings = next;

--- a/KGPC/Parser/ParseTree/from_cparser_parts/from_cparser_statements_and_programs.c
+++ b/KGPC/Parser/ParseTree/from_cparser_parts/from_cparser_statements_and_programs.c
@@ -1100,6 +1100,8 @@ Tree_t *convert_method_impl(ast_t *method_node) {
     int is_class_method_impl = from_cparser_is_method_class_method(effective_class, method_name);
     int method_param_count = count_params_in_method_impl(method_node);
     char *method_param_sig = param_type_signature_from_method_impl(method_node);
+    int method_param_types_count = 0;
+    TypeRef **method_param_types = param_types_from_method_impl(method_node, &method_param_types_count);
     int method_declares_operator = method_decl_uses_operator_keyword;
     if (method_node != NULL && method_name != NULL)
     {
@@ -1112,9 +1114,14 @@ Tree_t *convert_method_impl(ast_t *method_node) {
         if (impl_template.is_class_method)
             is_class_method_impl = 1;
     }
-    if (!is_static_method)
-        is_static_method = is_method_static_with_signature(effective_class, method_name,
-            method_param_count, method_param_sig);
+    if (!is_static_method) {
+        if (method_param_types != NULL)
+            is_static_method = is_method_static_with_types(effective_class, method_name,
+                method_param_count, method_param_types, method_param_types_count);
+        else
+            is_static_method = is_method_static_with_signature(effective_class, method_name,
+                method_param_count, method_param_sig);
+    }
     /* A static class method (class function ... static) has no Self */
     if (is_class_method_impl && is_static_method)
         is_static_method = 1;
@@ -1138,6 +1145,7 @@ Tree_t *convert_method_impl(ast_t *method_node) {
         free(effective_class_last);
         if (method_param_sig != NULL)
             free(method_param_sig);
+        param_types_free(method_param_types, method_param_types_count);
         return NULL;
     }
     
@@ -1515,6 +1523,7 @@ Tree_t *convert_method_impl(ast_t *method_node) {
         free(effective_class_outer);
         if (method_param_sig != NULL)
             free(method_param_sig);
+        param_types_free(method_param_types, method_param_types_count);
         g_current_method_name = prev_method_name_ctx;
         return NULL;
     }
@@ -1536,6 +1545,7 @@ Tree_t *convert_method_impl(ast_t *method_node) {
     free(effective_class_outer);
     if (method_param_sig != NULL)
         free(method_param_sig);
+    param_types_free(method_param_types, method_param_types_count);
     g_current_method_name = prev_method_name_ctx;
     return tree;
 }

--- a/KGPC/Parser/ParseTree/ident_ref.c
+++ b/KGPC/Parser/ParseTree/ident_ref.c
@@ -390,6 +390,37 @@ char *type_ref_render_mangled(const TypeRef *ref)
     return type_ref_render_joined(ref, ".", "$");
 }
 
+int type_ref_equal_ci(const TypeRef *lhs, const TypeRef *rhs)
+{
+    if (lhs == NULL || rhs == NULL)
+        return lhs == rhs;
+    if (lhs->is_class_reference != rhs->is_class_reference)
+        return 0;
+    if (!qualified_ident_equals_ci(lhs->name, rhs->name))
+        return 0;
+    if (lhs->num_generic_args != rhs->num_generic_args)
+        return 0;
+    for (int i = 0; i < lhs->num_generic_args; ++i)
+        if (!type_ref_equal_ci(lhs->generic_args[i], rhs->generic_args[i]))
+            return 0;
+    return 1;
+}
+
+int type_ref_array_equal_ci(TypeRef *const *lhs, int lhs_count,
+                            TypeRef *const *rhs, int rhs_count)
+{
+    if (lhs_count != rhs_count)
+        return 0;
+    if (lhs_count == 0)
+        return 1;
+    if (lhs == NULL || rhs == NULL)
+        return 0;
+    for (int i = 0; i < lhs_count; ++i)
+        if (!type_ref_equal_ci(lhs[i], rhs[i]))
+            return 0;
+    return 1;
+}
+
 char *type_ref_render_source(const TypeRef *ref)
 {
     if (ref == NULL || ref->name == NULL)

--- a/KGPC/Parser/ParseTree/ident_ref.c
+++ b/KGPC/Parser/ParseTree/ident_ref.c
@@ -2,6 +2,7 @@
 #include "../../identifier_utils.h"
 
 #include <ctype.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -419,6 +420,30 @@ int type_ref_array_equal_ci(TypeRef *const *lhs, int lhs_count,
         if (!type_ref_equal_ci(lhs[i], rhs[i]))
             return 0;
     return 1;
+}
+
+int kgpc_param_types_strict_check_enabled(void)
+{
+    static int cached = -1;
+    if (cached < 0)
+        cached = (getenv("KGPC_REQUIRE_STRUCTURAL_PARAM_TYPES") != NULL) ? 1 : 0;
+    return cached;
+}
+
+void kgpc_param_types_strict_miss(const char *site,
+                                  const char *lhs_label, int lhs_has_types,
+                                  const char *rhs_label, int rhs_has_types)
+{
+    fprintf(stderr,
+            "[param_types-miss] site=%s lhs=%s(types=%s) rhs=%s(types=%s)\n",
+            site != NULL ? site : "<unknown>",
+            lhs_label != NULL ? lhs_label : "?",
+            lhs_has_types ? "yes" : "NO",
+            rhs_label != NULL ? rhs_label : "?",
+            rhs_has_types ? "yes" : "NO");
+    fflush(stderr);
+    if (kgpc_param_types_strict_check_enabled())
+        abort();
 }
 
 char *type_ref_render_source(const TypeRef *ref)

--- a/KGPC/Parser/ParseTree/ident_ref.h
+++ b/KGPC/Parser/ParseTree/ident_ref.h
@@ -34,4 +34,14 @@ char *type_ref_render_mangled(const TypeRef *ref);
 char *type_ref_render_source(const TypeRef *ref);
 const char *type_ref_base_name(const TypeRef *ref);
 
+/* Pascal case-insensitive structural equality on TypeRef.  Both NULL match.
+ * Compares qualified name (case-insensitive), is_class_reference flag, and
+ * recursively compares generic argument lists. */
+int type_ref_equal_ci(const TypeRef *lhs, const TypeRef *rhs);
+
+/* Same comparison applied element-wise to two parallel TypeRef arrays.
+ * NULL arrays with count 0 are treated as equal. */
+int type_ref_array_equal_ci(TypeRef *const *lhs, int lhs_count,
+                            TypeRef *const *rhs, int rhs_count);
+
 #endif /* KGPC_IDENT_REF_H */

--- a/KGPC/Parser/ParseTree/ident_ref.h
+++ b/KGPC/Parser/ParseTree/ident_ref.h
@@ -44,4 +44,21 @@ int type_ref_equal_ci(const TypeRef *lhs, const TypeRef *rhs);
 int type_ref_array_equal_ci(TypeRef *const *lhs, int lhs_count,
                             TypeRef *const *rhs, int rhs_count);
 
+/* Returns nonzero when KGPC_REQUIRE_STRUCTURAL_PARAM_TYPES is set in the
+ * environment.  When set, callers should treat any fallback to the
+ * rendered-mangled-string compare as a population bug and abort with a
+ * diagnostic naming the site, so the missing population path can be
+ * traced to its source and fixed structurally. */
+int kgpc_param_types_strict_check_enabled(void);
+
+/* Reports an asymmetry where the structural-compare primary path could not
+ * run because one or both sides lack populated param_types[].  Prints
+ * "[param_types-miss] site=<site> lhs=<details> rhs=<details>" to stderr
+ * once per call (no rate-limiting; callers should gate themselves on the
+ * env helper above).  If KGPC_REQUIRE_STRUCTURAL_PARAM_TYPES is set, this
+ * is followed by abort(). */
+void kgpc_param_types_strict_miss(const char *site,
+                                  const char *lhs_label, int lhs_has_types,
+                                  const char *rhs_label, int rhs_has_types);
+
 #endif /* KGPC_IDENT_REF_H */

--- a/KGPC/Parser/ParseTree/tree.c
+++ b/KGPC/Parser/ParseTree/tree.c
@@ -8,6 +8,7 @@
 #include "type_tags.h"
 #include "KgpcType.h"
 #include "ident_ref.h"
+#include "from_cparser.h"
 #include "../SemanticCheck/HashTable/HashTable.h"  /* For HashType enum */
 #include <stdlib.h>
 #include <stdio.h>
@@ -2052,6 +2053,7 @@ void destroy_record_type(struct RecordType *record_type)
                 free(method->name);
                 free(method->mangled_name);
                 free(method->param_sig);
+                param_types_free(method->param_types, method->param_types_count);
                 free(method->resolved_mangled_id);
                 free(method);
             }

--- a/KGPC/Parser/ParseTree/tree_types.h
+++ b/KGPC/Parser/ParseTree/tree_types.h
@@ -158,7 +158,9 @@ struct MethodInfo
     int is_override;          /* 1 if declared override */
     int vmt_index;            /* Index in VMT (-1 if not virtual) */
     int param_count;          /* Parameter count (excluding implicit Self) */
-    char *param_sig;          /* Optional parameter signature string */
+    char *param_sig;          /* Optional parameter signature string -- diagnostic only */
+    struct TypeRef **param_types; /* Structural parameter types parallel to param_sig (preferred for compares) */
+    int param_types_count;    /* Entries in param_types; -1 if unknown */
     char *resolved_mangled_id; /* Fully resolved mangled ID for codegen (set by semcheck) */
 };
 

--- a/KGPC/Parser/SemanticCheck/SemCheck_parts/SemCheck_vmt_and_type_decls.c
+++ b/KGPC/Parser/SemanticCheck/SemCheck_parts/SemCheck_vmt_and_type_decls.c
@@ -1,6 +1,7 @@
 #include "../SemCheck_internal.h"
 
 char *semcheck_param_sig_from_params(ListNode_t *params, int skip_first_param);
+TypeRef **semcheck_param_types_from_params(ListNode_t *params, int skip_first_param, int *out_count);
 static void semcheck_ensure_implicit_tobject_parent(struct RecordType *record_info,
                                                     const char *class_name)
 {
@@ -126,8 +127,9 @@ if (record_info->parent_class_name != NULL) {
             {
                 ListNode_t *matches = FindAllIdents(symtab, base_name);
                 HashNode_t *best = NULL;
-                if (binding->param_sig != NULL)
+                if (binding->param_sig != NULL || binding->param_types != NULL)
                 {
+                    int have_binding_types = (binding->param_types != NULL && binding->param_types_count >= 0);
                     for (ListNode_t *m = matches; m != NULL; m = m->next)
                     {
                         HashNode_t *cand = (HashNode_t *)m->cur;
@@ -135,16 +137,31 @@ if (record_info->parent_class_name != NULL) {
                             cand->type->kind != TYPE_KIND_PROCEDURE)
                             continue;
                         int skip_self = (!binding->is_static);
-                        char *sig = semcheck_param_sig_from_params(
-                            cand->type->info.proc_info.params, skip_self);
-                        if (sig != NULL && strcasecmp(sig, binding->param_sig) == 0)
+                        int matched = 0;
+                        if (have_binding_types)
+                        {
+                            int cand_count = 0;
+                            TypeRef **cand_types = semcheck_param_types_from_params(
+                                cand->type->info.proc_info.params, skip_self, &cand_count);
+                            if (type_ref_array_equal_ci(binding->param_types, binding->param_types_count,
+                                                        cand_types, cand_count))
+                                matched = 1;
+                            param_types_free(cand_types, cand_count);
+                        }
+                        if (!matched && binding->param_sig != NULL)
+                        {
+                            char *sig = semcheck_param_sig_from_params(
+                                cand->type->info.proc_info.params, skip_self);
+                            if (sig != NULL && strcasecmp(sig, binding->param_sig) == 0)
+                                matched = 1;
+                            if (sig != NULL)
+                                free(sig);
+                        }
+                        if (matched)
                         {
                             best = cand;
-                            free(sig);
                             break;
                         }
-                        if (sig != NULL)
-                            free(sig);
                     }
                 }
                 if (best == NULL && binding->param_count >= 0)
@@ -427,8 +444,19 @@ if (record_info->parent_class_name != NULL) {
             if (cand == NULL || cand->type == NULL ||
                 cand->type->kind != TYPE_KIND_PROCEDURE)
                 continue;
-            /* Match by param signature if available */
-            if (mi->param_sig != NULL) {
+            /* Match by param signature if available.  Prefer structural TypeRef
+             * comparison when both sides have populated param_types; fall back to
+             * the rendered-mangled-string compare otherwise. */
+            if (mi->param_types != NULL && mi->param_types_count >= 0) {
+                int cand_count = 0;
+                TypeRef **cand_types = semcheck_param_types_from_params(
+                    cand->type->info.proc_info.params, 1, &cand_count);
+                int sig_match = type_ref_array_equal_ci(
+                    mi->param_types, mi->param_types_count, cand_types, cand_count);
+                param_types_free(cand_types, cand_count);
+                if (!sig_match)
+                    continue;
+            } else if (mi->param_sig != NULL) {
                 char *cand_sig = semcheck_param_sig_from_params(
                     cand->type->info.proc_info.params, 1);
                 int sig_match = (cand_sig != NULL && strcasecmp(cand_sig, mi->param_sig) == 0);
@@ -791,6 +819,77 @@ char *semcheck_param_sig_from_params(ListNode_t *params, int skip_first_param)
     }
 
     return sig;
+}
+
+/* Structural counterpart of semcheck_param_sig_from_params.  Walks a Tree_t
+ * parameter list and returns an owned TypeRef** array (one entry per declared
+ * parameter name, cloning the param's type_ref); writes the count to
+ * *out_count.  Returns NULL with *out_count=0 when the list is empty. */
+TypeRef **semcheck_param_types_from_params(ListNode_t *params, int skip_first_param, int *out_count)
+{
+    if (out_count != NULL)
+        *out_count = 0;
+    if (params == NULL)
+        return NULL;
+
+    int capacity = 0;
+    int count = 0;
+    TypeRef **arr = NULL;
+    ListNode_t *cur = params;
+    int skipped = 0;
+    while (cur != NULL)
+    {
+        Tree_t *param = (Tree_t *)cur->cur;
+        cur = cur->next;
+        if (skip_first_param && !skipped)
+        {
+            skipped = 1;
+            continue;
+        }
+        if (param == NULL)
+            continue;
+
+        TypeRef *base = NULL;
+        int name_count = 1;
+        if (param->type == TREE_VAR_DECL)
+        {
+            base = param->tree_data.var_decl_data.type_ref;
+            if (param->tree_data.var_decl_data.ids != NULL)
+                name_count = ListLength(param->tree_data.var_decl_data.ids);
+        }
+        else if (param->type == TREE_ARR_DECL)
+        {
+            base = param->tree_data.arr_decl_data.type_ref;
+            if (param->tree_data.arr_decl_data.ids != NULL)
+                name_count = ListLength(param->tree_data.arr_decl_data.ids);
+        }
+        if (name_count <= 0)
+            name_count = 1;
+
+        for (int i = 0; i < name_count; ++i)
+        {
+            if (count == capacity)
+            {
+                int new_cap = (capacity == 0) ? 4 : capacity * 2;
+                TypeRef **grown = (TypeRef **)realloc(arr, (size_t)new_cap * sizeof(TypeRef *));
+                if (grown == NULL)
+                {
+                    for (int j = 0; j < count; ++j)
+                        type_ref_free(arr[j]);
+                    free(arr);
+                    if (out_count != NULL)
+                        *out_count = 0;
+                    return NULL;
+                }
+                arr = grown;
+                capacity = new_cap;
+            }
+            arr[count++] = (base != NULL) ? type_ref_clone(base) : NULL;
+        }
+    }
+    if (out_count != NULL)
+        *out_count = count;
+    return arr;
 }
 
 int semcheck_resolve_scoped_enum_literal(SymTab_t *symtab, const char *type_name,

--- a/KGPC/Parser/SemanticCheck/SemCheck_parts/SemCheck_vmt_and_type_decls.c
+++ b/KGPC/Parser/SemanticCheck/SemCheck_parts/SemCheck_vmt_and_type_decls.c
@@ -130,6 +130,10 @@ if (record_info->parent_class_name != NULL) {
                 if (binding->param_sig != NULL || binding->param_types != NULL)
                 {
                     int have_binding_types = (binding->param_types != NULL && binding->param_types_count >= 0);
+                    if (!have_binding_types)
+                        kgpc_param_types_strict_miss(
+                            "SemCheck_vmt:FindAllIdents-lookup",
+                            "binding", 0, "cand-params(sema)", 1);
                     for (ListNode_t *m = matches; m != NULL; m = m->next)
                     {
                         HashNode_t *cand = (HashNode_t *)m->cur;
@@ -234,14 +238,19 @@ if (record_info->parent_class_name != NULL) {
                     if (strcasecmp(info->name, binding->method_name) != 0)
                         continue;
                     int signature_matches = 0;
-                    if (binding->param_types != NULL && binding->param_types_count >= 0 &&
-                        info->param_types != NULL && info->param_types_count >= 0) {
+                    int lhs_has = (binding->param_types != NULL && binding->param_types_count >= 0);
+                    int rhs_has = (info->param_types != NULL && info->param_types_count >= 0);
+                    if (lhs_has && rhs_has) {
                         /* Structural match: compare parameter TypeRefs element-wise
                          * case-insensitively, instead of string-matching mangled names. */
                         if (type_ref_array_equal_ci(binding->param_types, binding->param_types_count,
                                                     info->param_types, info->param_types_count))
                             signature_matches = 1;
                     } else if (binding->param_sig != NULL && info->param_sig != NULL) {
+                        if (lhs_has != rhs_has)
+                            kgpc_param_types_strict_miss(
+                                "SemCheck_vmt:strict-override-match",
+                                "binding", lhs_has, "info", rhs_has);
                         if (strcasecmp(binding->param_sig, info->param_sig) == 0)
                             signature_matches = 1;
                     } else if (binding->param_count >= 0 && info->param_count >= 0) {
@@ -457,6 +466,9 @@ if (record_info->parent_class_name != NULL) {
                 if (!sig_match)
                     continue;
             } else if (mi->param_sig != NULL) {
+                kgpc_param_types_strict_miss(
+                    "SemCheck_vmt:resolved-id-cand-filter",
+                    "MethodInfo", 0, "cand-params(sema)", 1);
                 char *cand_sig = semcheck_param_sig_from_params(
                     cand->type->info.proc_info.params, 1);
                 int sig_match = (cand_sig != NULL && strcasecmp(cand_sig, mi->param_sig) == 0);

--- a/KGPC/Parser/SemanticCheck/SemCheck_parts/SemCheck_vmt_and_type_decls.c
+++ b/KGPC/Parser/SemanticCheck/SemCheck_parts/SemCheck_vmt_and_type_decls.c
@@ -77,6 +77,8 @@ if (record_info->parent_class_name != NULL) {
 	                                max_vmt_index = cloned->vmt_index;
 	                            cloned->param_count = parent_method->param_count;
                             cloned->param_sig = parent_method->param_sig ? strdup(parent_method->param_sig) : NULL;
+                            cloned->param_types = param_types_clone(parent_method->param_types, parent_method->param_types_count);
+                            cloned->param_types_count = (cloned->param_types != NULL) ? parent_method->param_types_count : -1;
                             cloned->resolved_mangled_id = parent_method->resolved_mangled_id ? strdup(parent_method->resolved_mangled_id) : NULL;
 
                             /* For generic specializations, inherited methods must use
@@ -101,6 +103,7 @@ if (record_info->parent_class_name != NULL) {
                                 free(cloned->name);
                                 free(cloned->mangled_name);
                                 free(cloned->param_sig);
+                                param_types_free(cloned->param_types, cloned->param_types_count);
                                 free(cloned);
                             }
                         }
@@ -214,7 +217,14 @@ if (record_info->parent_class_name != NULL) {
                     if (strcasecmp(info->name, binding->method_name) != 0)
                         continue;
                     int signature_matches = 0;
-                    if (binding->param_sig != NULL && info->param_sig != NULL) {
+                    if (binding->param_types != NULL && binding->param_types_count >= 0 &&
+                        info->param_types != NULL && info->param_types_count >= 0) {
+                        /* Structural match: compare parameter TypeRefs element-wise
+                         * case-insensitively, instead of string-matching mangled names. */
+                        if (type_ref_array_equal_ci(binding->param_types, binding->param_types_count,
+                                                    info->param_types, info->param_types_count))
+                            signature_matches = 1;
+                    } else if (binding->param_sig != NULL && info->param_sig != NULL) {
                         if (strcasecmp(binding->param_sig, info->param_sig) == 0)
                             signature_matches = 1;
                     } else if (binding->param_count >= 0 && info->param_count >= 0) {
@@ -295,6 +305,10 @@ if (record_info->parent_class_name != NULL) {
                         info->param_count = binding->param_count;
                     if (info->param_sig == NULL && binding->param_sig != NULL)
                         info->param_sig = strdup(binding->param_sig);
+                    if (info->param_types == NULL && binding->param_types != NULL) {
+                        info->param_types = param_types_clone(binding->param_types, binding->param_types_count);
+                        info->param_types_count = (info->param_types != NULL) ? binding->param_types_count : -1;
+                    }
                 }
             }
             
@@ -315,6 +329,8 @@ if (record_info->parent_class_name != NULL) {
                     new_method->is_override = 0;
                     new_method->param_count = binding->param_count;
                     new_method->param_sig = binding->param_sig ? strdup(binding->param_sig) : NULL;
+                    new_method->param_types = param_types_clone(binding->param_types, binding->param_types_count);
+                    new_method->param_types_count = (new_method->param_types != NULL) ? binding->param_types_count : -1;
                     new_method->resolved_mangled_id = NULL;
                     /* FPC VMT has 12 metadata slots (96 bytes) before virtual methods:
                      * vInstanceSize, vInstanceSize2, vParentRef, vClassName,
@@ -344,6 +360,7 @@ if (record_info->parent_class_name != NULL) {
                         free(new_method->name);
                         free(new_method->mangled_name);
                         free(new_method->param_sig);
+                        param_types_free(new_method->param_types, new_method->param_types_count);
                         free(new_method);
                     }
                 }

--- a/KGPC/Parser/SemanticCheck/SemCheck_parts/SemCheck_vmt_and_type_decls.c
+++ b/KGPC/Parser/SemanticCheck/SemCheck_parts/SemCheck_vmt_and_type_decls.c
@@ -66,7 +66,7 @@ if (record_info->parent_class_name != NULL) {
                 while (parent_vmt != NULL) {
                     struct MethodInfo *parent_method = (struct MethodInfo *)parent_vmt->cur;
                     if (parent_method != NULL) {
-                        struct MethodInfo *cloned = (struct MethodInfo *)malloc(sizeof(struct MethodInfo));
+                        struct MethodInfo *cloned = (struct MethodInfo *)calloc(1, sizeof(struct MethodInfo));
                         if (cloned != NULL) {
                             cloned->name = parent_method->name ? strdup(parent_method->name) : NULL;
                             cloned->mangled_name = parent_method->mangled_name ? strdup(parent_method->mangled_name) : NULL;
@@ -307,7 +307,7 @@ if (record_info->parent_class_name != NULL) {
                  * (e.g., FPC system unit with unsupported features).
                  * Treat as a new virtual method instead of an error. */
                 
-                struct MethodInfo *new_method = (struct MethodInfo *)malloc(sizeof(struct MethodInfo));
+                struct MethodInfo *new_method = (struct MethodInfo *)calloc(1, sizeof(struct MethodInfo));
                 if (new_method != NULL) {
                     new_method->name = binding->method_name ? strdup(binding->method_name) : NULL;
                     new_method->mangled_name = mangled ? strdup(mangled) : NULL;


### PR DESCRIPTION
## Summary
- Replaces `strcasecmp(param_sig, ...)` with `type_ref_array_equal_ci` at all 8 overload/virtual-resolution comparison sites in KGPC's parser, semcheck, and codegen.
- Each `ClassMethodBinding` and `MethodInfo` now carries a `TypeRef **param_types` parallel to the diagnostic `param_sig` string; populated at every creation/clone path; freed at every destroy site.
- Adds an env-gated tripwire (`KGPC_REQUIRE_STRUCTURAL_PARAM_TYPES=1`) that aborts on any structural-compare miss so future un-populated paths are detected, not silently papered over.

Branch state (4 commits on top of `master`):

```
9da26516 ident_ref: add env-gated strict tripwire so fallback to strcasecmp(param_sig) becomes a detectable bug
e82cf113 public method-query API: add typed counterparts and route the only signature-bearing caller through them
eb728cf3 overload/VMT resolution: 5 more strcasecmp(param_sig) sites switch to structural compare
998bc4cb codegen vmt override-match: switch from strcasecmp(param_sig) to structural TypeRef array compare
aa6489d7 ident_ref/bindings: scaffolding to replace string-matched param_sig with structural TypeRef comparison
```

## Test plan
- [x] Compiler builds clean
- [x] Compiler test suite passes
- [x] Runtime overload test `/tmp/struct_compare_overload.p` (two virtuals differing only by parameter type) dispatches each call to the correct `TChild` override, exercising the new structural path
- [x] All 1116 `tests/test_cases/*.p` produce zero `[param_types-miss]` reports - structural path is hit at every comparison
- [x] Strict-mode gate `KGPC_REQUIRE_STRUCTURAL_PARAM_TYPES=1` verified to abort on a forced miss
- [ ] CI: Pascal Compiler CI
- [ ] CI: MSYS2 CI
- [ ] CI: Cross-Compilation CI (Wine + quasi-msys2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Switch method overload and virtual resolution from string-based parameter signature matching to structural TypeRef-based comparison across parser, semantic analysis, and codegen.

New Features:
- Introduce structural TypeRef and TypeRef-array equality helpers for case-insensitive parameter type comparison.
- Add environment-gated strict checking that logs and optionally aborts when structural parameter type data is missing at comparison sites.

Enhancements:
- Track per-method structural parameter type arrays alongside existing signature strings in ClassMethodBinding and MethodInfo metadata.
- Extend parser and semantic checker to build, clone, and free parameter TypeRef arrays for methods and their templates, including inherited and synthesized methods.
- Update VMT construction, override matching, and virtual call resolution to prefer structural parameter type comparison, falling back to legacy string signatures only when needed.

Tests:
- Rely on existing compiler and test suite coverage to exercise the new structural comparison paths and the strict-mode gate.