### PR TITLE
Add safe generated output cleanup script

### DIFF
--- a/docs/FPC_BOOTSTRAP.md
+++ b/docs/FPC_BOOTSTRAP.md
@@ -356,6 +356,23 @@ The generated compiler also supports a quick startup check:
 ./tests/output/pp_bootstrap -h
 ```
 
+### Cleaning generated bootstrap outputs
+
+Bootstrap and FPC RTL runs generate large local artifacts under `tests/output/`.
+Use the cleanup helper to inspect or remove them:
+
+```bash
+scripts/clean_test_outputs.sh
+scripts/clean_test_outputs.sh --yes
+```
+
+To keep the most useful generated compiler artifacts while deleting other test
+outputs:
+
+```bash
+scripts/clean_test_outputs.sh --yes --keep-bootstrap
+```
+
 ### FPC RTL (56 units)
 
 All 56 FPC RTL units now compile with 0 semantic errors via `meson test -C build-fpc "FPC RTL tests"`.

--- a/scripts/clean_test_outputs.sh
+++ b/scripts/clean_test_outputs.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/clean_test_outputs.sh [--yes] [--keep-bootstrap]
+
+Removes generated local test artifacts:
+  - tests/output/
+  - failing-tests/
+  - meson-logs/
+
+By default this is a dry run. Pass --yes to delete files.
+
+Options:
+  --yes             Perform deletion. Without this, only print what would be removed.
+  --keep-bootstrap Keep tests/output/pp_bootstrap, pp_bootstrap.s, and pp_stage2/.
+  -h, --help        Show this help.
+EOF
+}
+
+dry_run=1
+keep_bootstrap=0
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --yes)
+      dry_run=0
+      ;;
+    --keep-bootstrap)
+      keep_bootstrap=1
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+  shift
+done
+
+repo_root=$(git rev-parse --show-toplevel)
+cd "$repo_root"
+
+remove_path() {
+  local path=$1
+  if [ ! -e "$path" ]; then
+    return
+  fi
+
+  if [ "$dry_run" -eq 1 ]; then
+    du -sh "$path" 2>/dev/null || true
+    return
+  fi
+
+  rm -rf -- "$path"
+}
+
+remove_tests_output_contents() {
+  local output_dir="tests/output"
+  if [ ! -d "$output_dir" ]; then
+    return
+  fi
+
+  if [ "$keep_bootstrap" -eq 0 ]; then
+    remove_path "$output_dir"
+    return
+  fi
+
+  if [ "$dry_run" -eq 1 ]; then
+    find "$output_dir" -mindepth 1 \
+      ! -path "$output_dir/pp_bootstrap" \
+      ! -path "$output_dir/pp_bootstrap.s" \
+      ! -path "$output_dir/pp_stage2" \
+      ! -path "$output_dir/pp_stage2/*" \
+      -print | sed 's/^/would remove /'
+    return
+  fi
+
+  find "$output_dir" -mindepth 1 \
+    ! -path "$output_dir/pp_bootstrap" \
+    ! -path "$output_dir/pp_bootstrap.s" \
+    ! -path "$output_dir/pp_stage2" \
+    ! -path "$output_dir/pp_stage2/*" \
+    -exec rm -rf -- {} +
+}
+
+if [ "$dry_run" -eq 1 ]; then
+  echo "Dry run. Pass --yes to delete generated outputs."
+else
+  echo "Deleting generated outputs."
+fi
+
+remove_tests_output_contents
+remove_path "failing-tests"
+remove_path "meson-logs"
+
+if [ "$dry_run" -eq 1 ]; then
+  echo "Dry run complete."
+else
+  echo "Cleanup complete."
+fi


### PR DESCRIPTION
## Summary

- Add `scripts/clean_test_outputs.sh`, dry-run by default and destructive only with `--yes`
- Support `--keep-bootstrap` to preserve `pp_bootstrap`, `pp_bootstrap.s`, and `pp_stage2/`
- Document cleanup commands in `docs/FPC_BOOTSTRAP.md`

Fixes #739.

## Validation

```bash
bash -n scripts/clean_test_outputs.sh
scripts/clean_test_outputs.sh
scripts/clean_test_outputs.sh --keep-bootstrap
```

No files were deleted during validation; both script runs were dry-runs.

## Summary by Sourcery

Add a helper script to safely clean generated test artifacts and document its usage in the FPC bootstrap guide.

Enhancements:
- Introduce a dry-run cleanup script for removing generated test outputs, with an option to preserve key bootstrap artifacts.

Documentation:
- Document the new test output cleanup workflow and options in the FPC bootstrap documentation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a cleanup utility to remove generated test artifacts, with options for dry-run mode and selective preservation of bootstrap outputs.

* **Documentation**
  * Added guidance for using the cleanup utility and its available command options.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kreijstal/Pascal-Compiler/pull/741?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->