### PR TITLE
Use asmmode metadata for inline asm syntax

### DIFF
--- a/KGPC/CodeGenerator/Intel_x86-64/codegen_statement_parts/codegen_stmt_dispatch.c
+++ b/KGPC/CodeGenerator/Intel_x86-64/codegen_statement_parts/codegen_stmt_dispatch.c
@@ -690,44 +690,8 @@ ListNode_t *codegen_stmt(struct Statement *stmt, ListNode_t *inst_list, CodeGenC
             const char *src = stmt->stmt_data.asm_block_data.code;
             if (src != NULL)
             {
-                /* Detect Intel-syntax inline assembly (emitted by {$asmmode intel} blocks).
-                 * KGPC targets AT&T syntax; Intel-syntax asm needs wrapping with
-                 * .intel_syntax noprefix / .att_syntax prefix directives.
-                 *
-                 * Detection heuristics (any match → Intel syntax):
-                 *   1. Memory operand keywords: "dword ptr", "qword ptr", etc.
-                 *   2. Bracket memory operands: [...] (AT&T uses parentheses)
-                 *   3. Bare register operands without '%' prefix in operand position
-                 * Heuristic 2 is the strongest signal since AT&T never uses [] for
-                 * memory addressing, while Intel always does. */
-                int is_intel_syntax = 0;
-                if (pascal_strcasestr(src, "dword ptr") != NULL ||
-                    pascal_strcasestr(src, "qword ptr") != NULL ||
-                    pascal_strcasestr(src, "byte ptr")  != NULL ||
-                    pascal_strcasestr(src, "word ptr")  != NULL)
-                    is_intel_syntax = 1;
-
-                /* Check for Intel-style bracket memory operands: [reg], [reg+off] etc.
-                 * AT&T syntax uses parentheses for memory: (%reg), off(%reg) etc.
-                 * Skip [...] inside comments {...} and strings. */
-                if (!is_intel_syntax) {
-                    int in_brace_comment = 0;
-                    for (const char *p = src; *p != '\0'; p++) {
-                        if (*p == '{') { in_brace_comment = 1; continue; }
-                        if (*p == '}') { in_brace_comment = 0; continue; }
-                        if (in_brace_comment) continue;
-                        if (*p == '[') {
-                            /* Skip Pascal asm clobber lists: end ['eax','edx']
-                             * These have [ followed by ' — Intel memory operands
-                             * use [reg] or [reg+offset], never ['...'] */
-                            if (*(p + 1) == '\'')
-                                continue;
-                            /* Found a bracket — this is Intel memory syntax */
-                            is_intel_syntax = 1;
-                            break;
-                        }
-                    }
-                }
+                int is_intel_syntax =
+                    stmt->stmt_data.asm_block_data.syntax_mode == ASM_SYNTAX_INTEL;
 
                 /* --- Common preprocessing: strip Pascal comments --- */
                 size_t src_len = strlen(src);

--- a/KGPC/Parser/ParseTree/from_cparser_parts/from_cparser_statements_and_programs.c
+++ b/KGPC/Parser/ParseTree/from_cparser_parts/from_cparser_statements_and_programs.c
@@ -1,5 +1,66 @@
 #include "../from_cparser_internal.h"
 
+static int directive_keyword_matches(const char *start, const char *end, const char *keyword)
+{
+    size_t keyword_len = strlen(keyword);
+    if ((size_t)(end - start) < keyword_len)
+        return 0;
+    if (strncasecmp(start, keyword, keyword_len) != 0)
+        return 0;
+    const char *after = start + keyword_len;
+    return after == end || isspace((unsigned char)*after);
+}
+
+static enum AsmSyntaxMode asm_syntax_mode_before_source_index(ast_t *stmt_node)
+{
+    enum AsmSyntaxMode mode = ASM_SYNTAX_ATT;
+    if (stmt_node == NULL || stmt_node->index <= 0 ||
+        preprocessed_source == NULL || preprocessed_length == 0)
+        return mode;
+
+    size_t limit = (size_t)stmt_node->index;
+    if (limit > preprocessed_length)
+        limit = preprocessed_length;
+
+    const char *src = preprocessed_source;
+    const char *end = preprocessed_source + limit;
+    for (const char *p = src; p < end; p++)
+    {
+        if (*p != '{' || p + 1 >= end || p[1] != '$')
+            continue;
+
+        const char *dir = p + 2;
+        while (dir < end && isspace((unsigned char)*dir))
+            dir++;
+
+        const char *close = dir;
+        while (close < end && *close != '}')
+            close++;
+        if (close >= end)
+            break;
+
+        if (directive_keyword_matches(dir, close, "ASMMODE"))
+        {
+            const char *arg = dir + strlen("ASMMODE");
+            while (arg < close && isspace((unsigned char)*arg))
+                arg++;
+            if (close - arg >= 5 && strncasecmp(arg, "INTEL", 5) == 0)
+                mode = ASM_SYNTAX_INTEL;
+            else if (close - arg >= 3 && strncasecmp(arg, "ATT", 3) == 0)
+                mode = ASM_SYNTAX_ATT;
+            else if (close - arg >= 3 && strncasecmp(arg, "GAS", 3) == 0)
+                mode = ASM_SYNTAX_ATT;
+            else if (close - arg >= 7 && strncasecmp(arg, "DEFAULT", 7) == 0)
+                mode = ASM_SYNTAX_ATT;
+            else if (close - arg >= 8 && strncasecmp(arg, "STANDARD", 8) == 0)
+                mode = ASM_SYNTAX_ATT;
+        }
+        p = close;
+    }
+
+    return mode;
+}
+
 struct Statement *convert_statement(ast_t *stmt_node) {
     stmt_node = unwrap_pascal_node(stmt_node);
     if (stmt_node == NULL)
@@ -91,7 +152,7 @@ struct Statement *convert_statement(ast_t *stmt_node) {
         asm_body_node->next = NULL;
         char *code = collect_asm_text(asm_body_node);
         asm_body_node->next = saved_next;
-        return mk_asmblock(stmt_node->line, code);
+        return mk_asmblock(stmt_node->line, code, asm_syntax_mode_before_source_index(stmt_node));
     }
     case PASCAL_T_BREAK_STMT:
         return mk_break(stmt_node->line);

--- a/KGPC/Parser/ParseTree/tree.c
+++ b/KGPC/Parser/ParseTree/tree.c
@@ -2973,7 +2973,7 @@ struct Statement *mk_for_in(int line_num, struct Expression *loop_var, struct Ex
     return new_stmt;
 }
 
-struct Statement *mk_asmblock(int line_num, char *code)
+struct Statement *mk_asmblock(int line_num, char *code, enum AsmSyntaxMode syntax_mode)
 {
     struct Statement *new_stmt;
     new_stmt = (struct Statement *)calloc(1, sizeof(struct Statement));
@@ -2984,6 +2984,7 @@ struct Statement *mk_asmblock(int line_num, char *code)
     new_stmt->source_index = -1;
     new_stmt->type = STMT_ASM_BLOCK;
     new_stmt->stmt_data.asm_block_data.code = code;
+    new_stmt->stmt_data.asm_block_data.syntax_mode = syntax_mode;
 
     return new_stmt;
 }

--- a/KGPC/Parser/ParseTree/tree.h
+++ b/KGPC/Parser/ParseTree/tree.h
@@ -311,7 +311,7 @@ struct Statement *mk_forvar(int line_num, struct Expression *for_var, struct Exp
 struct Statement *mk_for_in(int line_num, struct Expression *loop_var, struct Expression *collection,
                              struct Statement *do_stmt);
 
-struct Statement *mk_asmblock(int line_num, char *code);
+struct Statement *mk_asmblock(int line_num, char *code, enum AsmSyntaxMode syntax_mode);
 
 struct Statement *mk_exit(int line_num);
 struct Statement *mk_exit_with_value(int line_num, struct Expression *return_expr);

--- a/KGPC/Parser/ParseTree/tree_types.h
+++ b/KGPC/Parser/ParseTree/tree_types.h
@@ -281,6 +281,12 @@ struct CaseBranch
     struct Statement *stmt;
 };
 
+enum AsmSyntaxMode
+{
+    ASM_SYNTAX_ATT = 0,
+    ASM_SYNTAX_INTEL = 1
+};
+
 /* A statement subtree */
 struct Statement
 {
@@ -302,6 +308,7 @@ struct Statement
         struct AsmBlock
         {
             char *code;
+            enum AsmSyntaxMode syntax_mode;
         } asm_block_data;
 
         /* Procedure call */

--- a/cparser/examples/pascal_parser/pascal_preprocessor.c
+++ b/cparser/examples/pascal_parser/pascal_preprocessor.c
@@ -1331,6 +1331,8 @@ static bool handle_directive(PascalPreprocessor *pp,
             if (strcasecmp(asmmode_val, "INTEL") == 0)
                 pp->asmmode_intel = true;
             else if (strcasecmp(asmmode_val, "ATT") == 0 ||
+                     strcasecmp(asmmode_val, "GAS") == 0 ||
+                     strcasecmp(asmmode_val, "STANDARD") == 0 ||
                      strcasecmp(asmmode_val, "DEFAULT") == 0)
                 pp->asmmode_intel = false;
         }

--- a/tests/do_not_run_me_directly_but_through_meson.py
+++ b/tests/do_not_run_me_directly_but_through_meson.py
@@ -3443,6 +3443,31 @@ sys.exit(3)
         self.assertEqual(process.returncode, 0)
         self.assertEqual(process.stdout, "OK\n")
 
+    def test_asmmode_intel_directive_controls_inline_asm(self):
+        input_file = os.path.join(TEST_CASES_DIR, "asmmode_intel_explicit.p")
+        asm_file = os.path.join(TEST_OUTPUT_DIR, "asmmode_intel_explicit.s")
+        executable_file = os.path.join(TEST_OUTPUT_DIR, f"asmmode_intel_explicit{EXE_EXT}")
+
+        run_compiler(input_file, asm_file)
+
+        with open(asm_file, "r", encoding="utf-8") as f:
+            asm_source = f.read()
+
+        self.assertIn(".intel_syntax noprefix", asm_source)
+        self.assertIn("mov eax, 42", asm_source)
+        self.assertIn("movl $7, %eax", asm_source)
+        self.assertEqual(asm_source.count(".intel_syntax noprefix"), 1)
+
+        self.compile_executable(asm_file, executable_file)
+        process = subprocess.run(
+            [executable_file],
+            capture_output=True,
+            text=True,
+            timeout=EXEC_TIMEOUT,
+        )
+        self.assertEqual(process.returncode, 0)
+        self.assertEqual(process.stdout, "OK\n")
+
     def test_unix_gethostname(self):
         """Ensures the Unix unit exposes GetHostName with actual hostname output."""
         input_file = os.path.join(TEST_CASES_DIR, "unix_gethostname_demo.p")

--- a/tests/test_cases/asmmode_intel_explicit.p
+++ b/tests/test_cases/asmmode_intel_explicit.p
@@ -1,0 +1,13 @@
+{$asmmode intel}
+program asmmode_intel_explicit;
+
+begin
+  asm
+    mov eax, 42
+  end;
+  {$asmmode gas}
+  asm
+    movl $7, %eax
+  end;
+  writeln('OK');
+end.


### PR DESCRIPTION
Fixes #562

## Summary
- carry explicit asm syntax mode on STMT_ASM_BLOCK from preceding active {$ASMMODE ...} directives
- remove codegen text heuristics for deciding Intel vs AT&T inline asm
- add a regression where Intel asm has no bracket/ptr tokens and must still be wrapped correctly

## Validation
- meson compile -C build KGPC/kgpc
- MESON_BUILD_ROOT=build KGPC_RUNTIME_LIB=build/KGPC/libkgpc_runtime.a KGPC_CTYPES_HELPER=build/KGPC/libctypes_helper.so KGPC_CTYPES_HELPER_LINK=build/KGPC/libctypes_helper.so KGPC_HAVE_GMP=0 KGPC_PARALLEL_WORKERS=0 python3 tests/do_not_run_me_directly_but_through_meson.py TestCompiler.test_asmmode_intel_directive_controls_inline_asm
- MESON_BUILD_ROOT=build KGPC_RUNTIME_LIB=build/KGPC/libkgpc_runtime.a KGPC_CTYPES_HELPER=build/KGPC/libctypes_helper.so KGPC_CTYPES_HELPER_LINK=build/KGPC/libctypes_helper.so KGPC_HAVE_GMP=0 KGPC_PARALLEL_WORKERS=0 python3 tests/do_not_run_me_directly_but_through_meson.py TestCompiler.test_inline_asm_uses_pascal_const_equ
- MESON_BUILD_ROOT=build KGPC_RUNTIME_LIB=build/KGPC/libkgpc_runtime.a KGPC_CTYPES_HELPER=build/KGPC/libctypes_helper.so KGPC_CTYPES_HELPER_LINK=build/KGPC/libctypes_helper.so KGPC_HAVE_GMP=0 KGPC_PARALLEL_WORKERS=0 python3 tests/do_not_run_me_directly_but_through_meson.py TestCompiler.test_auto_nostackframe_asm_regsizing
- build/KGPC/kgpc tests/test_cases/test_asm_return.p tests/output/test_asm_return.s --emit-link-args && cc tests/output/test_asm_return.s build/KGPC/libkgpc_runtime.a -lm -lpthread -o tests/output/test_asm_return && tests/output/test_asm_return

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ASMMODE directive support to explicitly select Intel or AT&T assembler syntax for inline assembly.
* **Bug Fixes**
  * Inline-asm syntax detection now uses the explicit mode instead of heuristic text scanning, improving correctness for mixed/ambiguous asm.
* **Tests**
  * Added a test verifying Intel-mode directive emits the expected assembler syntax and runtime behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kreijstal/Pascal-Compiler/pull/742?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->