### PR TITLE
Centralize string storage classification

### DIFF
--- a/KGPC/CodeGenerator/Intel_x86-64/codegen_expr_array.c
+++ b/KGPC/CodeGenerator/Intel_x86-64/codegen_expr_array.c
@@ -64,6 +64,9 @@ static long long codegen_arr_decl_shortstring_elem_storage(const Tree_t *decl)
         return (long long)etype->type_alias->array_end + 1;
     }
 
+    if (kgpc_type_string_storage_kind(etype) != KGPC_STRING_STORAGE_SHORTSTRING)
+        return 0;
+
     /* TYPE_KIND_ARRAY of CHAR: shortstring is represented either as
      *   - array[0..N] of char  (start=0, end=N): includes the length-byte
      *     slot at index 0 — total storage is N+1 bytes and that's exactly
@@ -73,10 +76,7 @@ static long long codegen_arr_decl_shortstring_elem_storage(const Tree_t *decl)
      *     for the length prefix.
      * Distinguish by start_index so we don't double-count for the form
      * the AST actually emits for string[N] typed-const elements. */
-    if (etype->kind == TYPE_KIND_ARRAY &&
-        etype->info.array_info.element_type != NULL &&
-        etype->info.array_info.element_type->kind == TYPE_KIND_PRIMITIVE &&
-        etype->info.array_info.element_type->info.primitive_type_tag == CHAR_TYPE)
+    if (etype->kind == TYPE_KIND_ARRAY)
     {
         long long ds = kgpc_type_sizeof(etype);
         if (ds > 0)
@@ -202,17 +202,8 @@ static int codegen_expr_is_shortstring_array_local(const struct Expression *expr
         return 0;
     if (expr->resolved_kgpc_type != NULL)
     {
-        struct TypeAlias *alias = kgpc_type_get_type_alias(expr->resolved_kgpc_type);
-        if (alias != NULL && alias->is_shortstring)
-            return 1;
-    }
-    if (expr->is_array_expr &&
-        expr->array_element_type == CHAR_TYPE &&
-        expr_get_array_lower_bound(expr) == 0 &&
-        expr_get_array_upper_bound(expr) == 255)
-    {
-        if (expr->resolved_kgpc_type == NULL ||
-            kgpc_type_get_type_alias(expr->resolved_kgpc_type) == NULL)
+        if (kgpc_type_string_storage_kind(expr->resolved_kgpc_type) ==
+            KGPC_STRING_STORAGE_SHORTSTRING)
             return 1;
     }
     return 0;
@@ -253,67 +244,14 @@ static int codegen_expr_is_shortstring_value(const struct Expression *expr)
     KgpcType *expr_type = expr_get_kgpc_type(expr);
     if (expr_type != NULL)
     {
-        if (kgpc_type_is_shortstring(expr_type))
+        if (kgpc_type_string_storage_kind(expr_type) ==
+            KGPC_STRING_STORAGE_SHORTSTRING)
             return 1;
-        struct TypeAlias *alias = kgpc_type_get_type_alias(expr_type);
-        if (alias != NULL && alias->is_shortstring)
-            return 1;
-        if (kgpc_type_is_array(expr_type) &&
-            expr_type->type_alias != NULL &&
-            expr_type->type_alias->is_shortstring)
-        {
-            return 1;
-        }
     }
 
     if (codegen_expr_is_shortstring_array_local(expr))
         return 1;
 
-    if (expr_type != NULL && kgpc_type_is_array(expr_type))
-    {
-        KgpcType *elem_type = kgpc_type_get_array_element_type(expr_type);
-        if (elem_type != NULL &&
-            elem_type->kind == TYPE_KIND_PRIMITIVE &&
-            elem_type->info.primitive_type_tag == CHAR_TYPE)
-        {
-            if (codegen_expr_has_widechar_array_metadata(expr))
-                return 0;
-            int start = 0;
-            int end = -1;
-            if (kgpc_type_get_array_bounds(expr_type, &start, &end) == 0 &&
-                start == 0 && end >= 0 && end <= 255)
-                return 1;
-        }
-    }
-
-    if (expr->is_array_expr &&
-        expr->array_element_type == CHAR_TYPE &&
-        expr->array_element_size != 2 &&
-        (expr->array_element_type_id == NULL ||
-         (!pascal_identifier_equals(expr->array_element_type_id, "WideChar") &&
-          !pascal_identifier_equals(expr->array_element_type_id, "UnicodeChar"))) &&
-        expr_get_array_lower_bound(expr) == 0)
-    {
-        int upper = expr_get_array_upper_bound(expr);
-        if (upper >= 0 && upper <= 255)
-            return 1;
-    }
-
-    return 0;
-}
-
-static int codegen_expr_is_char_array_like(const struct Expression *expr)
-{
-    if (expr == NULL)
-        return 0;
-    if (expr->is_array_expr && expr->array_element_type == CHAR_TYPE)
-        return 1;
-    KgpcType *expr_type = expr_get_kgpc_type(expr);
-    if (expr_type != NULL && kgpc_type_is_array(expr_type) &&
-        expr_type->info.array_info.element_type != NULL &&
-        expr_type->info.array_info.element_type->kind == TYPE_KIND_PRIMITIVE &&
-        expr_type->info.array_info.element_type->info.primitive_type_tag == CHAR_TYPE)
-        return 1;
     return 0;
 }
 
@@ -330,12 +268,6 @@ static int codegen_array_access_targets_shortstring(const struct Expression *exp
         return 0;
     if (codegen_expr_is_shortstring_value(expr))
         return 1;
-    if (codegen_expr_is_char_array_like(expr))
-    {
-        long long size = expr_effective_size_bytes(expr);
-        if (size > 1 && size <= 256)
-            return 1;
-    }
 
     struct Expression *base_expr = expr->expr_data.array_access_data.array_expr;
     if (base_expr == NULL)
@@ -357,26 +289,8 @@ static int codegen_array_access_targets_shortstring(const struct Expression *exp
     if (base_type != NULL && kgpc_type_is_array(base_type))
     {
         KgpcType *elem_type = kgpc_type_get_array_element_type(base_type);
-        if (elem_type != NULL)
-        {
-            if (kgpc_type_is_shortstring(elem_type))
-                return 1;
-            struct TypeAlias *alias = kgpc_type_get_type_alias(elem_type);
-            if (alias != NULL && alias->is_shortstring)
-                return 1;
-            if (kgpc_type_is_array(elem_type))
-            {
-                KgpcType *inner = kgpc_type_get_array_element_type(elem_type);
-                int start = 0;
-                int end = 0;
-                if (inner != NULL && kgpc_type_is_char(inner) &&
-                    kgpc_type_get_array_bounds(elem_type, &start, &end) == 0 &&
-                    start == 0 && end >= 0 && end <= 255)
-                {
-                    return 1;
-                }
-            }
-        }
+        if (kgpc_type_string_storage_kind(elem_type) == KGPC_STRING_STORAGE_SHORTSTRING)
+            return 1;
     }
 
     return 0;
@@ -396,7 +310,7 @@ static int codegen_shortstring_capacity_from_type_expr(KgpcType *type)
             return (int)alias->storage_size;
     }
 
-    if (kgpc_type_is_shortstring(type))
+    if (kgpc_type_string_storage_kind(type) == KGPC_STRING_STORAGE_SHORTSTRING)
     {
         long long type_size = kgpc_type_sizeof(type);
         if (type_size > 1 && type_size <= INT_MAX)
@@ -2016,26 +1930,9 @@ ListNode_t *codegen_array_element_address(struct Expression *expr, ListNode_t *i
                         if (FindSymbol(&type_node, ctx->symtab, field->pointer_type_id) != 0 &&
                             type_node != NULL && type_node->type != NULL)
                         {
-                            if (kgpc_type_is_shortstring(type_node->type))
+                            if (kgpc_type_string_storage_kind(type_node->type) ==
+                                KGPC_STRING_STORAGE_SHORTSTRING)
                                 shortstring_index = 1;
-                            else
-                            {
-                                struct TypeAlias *alias = kgpc_type_get_type_alias(type_node->type);
-                                if (alias != NULL && alias->is_shortstring)
-                                    shortstring_index = 1;
-                                else if (kgpc_type_is_array(type_node->type))
-                                {
-                                    int start = 0;
-                                    int end = 0;
-                                    KgpcType *elem = kgpc_type_get_array_element_type(type_node->type);
-                                    if (elem != NULL && kgpc_type_is_char(elem) &&
-                                        kgpc_type_get_array_bounds(type_node->type, &start, &end) == 0 &&
-                                        start == 0 && end >= 0 && end <= 255)
-                                    {
-                                        shortstring_index = 1;
-                                    }
-                                }
-                            }
                         }
                     }
                 }
@@ -2050,26 +1947,9 @@ ListNode_t *codegen_array_element_address(struct Expression *expr, ListNode_t *i
                             KgpcType *points_to = type_node->type->info.points_to;
                             if (points_to != NULL)
                             {
-                                if (kgpc_type_is_shortstring(points_to))
+                                if (kgpc_type_string_storage_kind(points_to) ==
+                                    KGPC_STRING_STORAGE_SHORTSTRING)
                                     shortstring_index = 1;
-                                else
-                                {
-                                    struct TypeAlias *alias = kgpc_type_get_type_alias(points_to);
-                                    if (alias != NULL && alias->is_shortstring)
-                                        shortstring_index = 1;
-                                    else if (kgpc_type_is_array(points_to))
-                                    {
-                                        int start = 0;
-                                        int end = 0;
-                                        KgpcType *elem = kgpc_type_get_array_element_type(points_to);
-                                        if (elem != NULL && kgpc_type_is_char(elem) &&
-                                            kgpc_type_get_array_bounds(points_to, &start, &end) == 0 &&
-                                            start == 0 && end >= 0 && end <= 255)
-                                        {
-                                            shortstring_index = 1;
-                                        }
-                                    }
-                                }
                             }
                         }
                         if (!shortstring_index)
@@ -2085,26 +1965,9 @@ ListNode_t *codegen_array_element_address(struct Expression *expr, ListNode_t *i
                                     if (FindSymbol(&sub_node, ctx->symtab, alias->pointer_type_id) != 0 &&
                                         sub_node != NULL && sub_node->type != NULL)
                                     {
-                                        if (kgpc_type_is_shortstring(sub_node->type))
+                                        if (kgpc_type_string_storage_kind(sub_node->type) ==
+                                            KGPC_STRING_STORAGE_SHORTSTRING)
                                             shortstring_index = 1;
-                                        else
-                                        {
-                                            struct TypeAlias *sub_alias = kgpc_type_get_type_alias(sub_node->type);
-                                            if (sub_alias != NULL && sub_alias->is_shortstring)
-                                                shortstring_index = 1;
-                                            else if (kgpc_type_is_array(sub_node->type))
-                                            {
-                                                int start = 0;
-                                                int end = 0;
-                                                KgpcType *elem = kgpc_type_get_array_element_type(sub_node->type);
-                                                if (elem != NULL && kgpc_type_is_char(elem) &&
-                                                    kgpc_type_get_array_bounds(sub_node->type, &start, &end) == 0 &&
-                                                    start == 0 && end >= 0 && end <= 255)
-                                                {
-                                                    shortstring_index = 1;
-                                                }
-                                            }
-                                        }
                                     }
                                 }
                             }
@@ -2118,26 +1981,9 @@ ListNode_t *codegen_array_element_address(struct Expression *expr, ListNode_t *i
             KgpcType *points_to = ptr_type->info.points_to;
             if (points_to != NULL)
             {
-                if (kgpc_type_is_shortstring(points_to))
+                if (kgpc_type_string_storage_kind(points_to) ==
+                    KGPC_STRING_STORAGE_SHORTSTRING)
                     shortstring_index = 1;
-                else
-                {
-                    struct TypeAlias *alias = kgpc_type_get_type_alias(points_to);
-                    if (alias != NULL && alias->is_shortstring)
-                        shortstring_index = 1;
-                    else if (kgpc_type_is_array(points_to))
-                    {
-                        int start = 0;
-                        int end = 0;
-                        KgpcType *elem = kgpc_type_get_array_element_type(points_to);
-                        if (elem != NULL && kgpc_type_is_char(elem) &&
-                            kgpc_type_get_array_bounds(points_to, &start, &end) == 0 &&
-                            start == 0 && end >= 0 && end <= 255)
-                        {
-                            shortstring_index = 1;
-                        }
-                    }
-                }
             }
         }
     }

--- a/KGPC/CodeGenerator/Intel_x86-64/codegen_expression.c
+++ b/KGPC/CodeGenerator/Intel_x86-64/codegen_expression.c
@@ -768,17 +768,8 @@ static int codegen_expr_is_shortstring_array_local(const struct Expression *expr
         return 0;
     if (expr->resolved_kgpc_type != NULL)
     {
-        struct TypeAlias *alias = kgpc_type_get_type_alias(expr->resolved_kgpc_type);
-        if (alias != NULL && alias->is_shortstring)
-            return 1;
-    }
-    if (expr->is_array_expr &&
-        expr->array_element_type == CHAR_TYPE &&
-        expr_get_array_lower_bound(expr) == 0 &&
-        expr_get_array_upper_bound(expr) == 255)
-    {
-        if (expr->resolved_kgpc_type == NULL ||
-            kgpc_type_get_type_alias(expr->resolved_kgpc_type) == NULL)
+        if (kgpc_type_string_storage_kind(expr->resolved_kgpc_type) ==
+            KGPC_STRING_STORAGE_SHORTSTRING)
             return 1;
     }
     return 0;
@@ -819,51 +810,13 @@ static int codegen_expr_is_shortstring_value(const struct Expression *expr)
     KgpcType *expr_type = expr_get_kgpc_type(expr);
     if (expr_type != NULL)
     {
-        if (kgpc_type_is_shortstring(expr_type))
+        if (kgpc_type_string_storage_kind(expr_type) ==
+            KGPC_STRING_STORAGE_SHORTSTRING)
             return 1;
-        struct TypeAlias *alias = kgpc_type_get_type_alias(expr_type);
-        if (alias != NULL && alias->is_shortstring)
-            return 1;
-        if (kgpc_type_is_array(expr_type) &&
-            expr_type->type_alias != NULL &&
-            expr_type->type_alias->is_shortstring)
-        {
-            return 1;
-        }
     }
 
     if (codegen_expr_is_shortstring_array_local(expr))
         return 1;
-
-    if (expr_type != NULL && kgpc_type_is_array(expr_type))
-    {
-        KgpcType *elem_type = kgpc_type_get_array_element_type(expr_type);
-        if (elem_type != NULL &&
-            elem_type->kind == TYPE_KIND_PRIMITIVE &&
-            elem_type->info.primitive_type_tag == CHAR_TYPE)
-        {
-            if (codegen_expr_has_widechar_array_metadata(expr))
-                return 0;
-            int start = 0;
-            int end = -1;
-            if (kgpc_type_get_array_bounds(expr_type, &start, &end) == 0 &&
-                start == 0 && end >= 0 && end <= 255)
-                return 1;
-        }
-    }
-
-    if (expr->is_array_expr &&
-        expr->array_element_type == CHAR_TYPE &&
-        expr->array_element_size != 2 &&
-        (expr->array_element_type_id == NULL ||
-         (!pascal_identifier_equals(expr->array_element_type_id, "WideChar") &&
-          !pascal_identifier_equals(expr->array_element_type_id, "UnicodeChar"))) &&
-        expr_get_array_lower_bound(expr) == 0)
-    {
-        int upper = expr_get_array_upper_bound(expr);
-        if (upper >= 0 && upper <= 255)
-            return 1;
-    }
 
     return 0;
 }
@@ -875,10 +828,7 @@ static int codegen_expr_is_char_array_like(const struct Expression *expr)
     if (expr->is_array_expr && expr->array_element_type == CHAR_TYPE)
         return 1;
     KgpcType *expr_type = expr_get_kgpc_type(expr);
-    if (expr_type != NULL && kgpc_type_is_array(expr_type) &&
-        expr_type->info.array_info.element_type != NULL &&
-        expr_type->info.array_info.element_type->kind == TYPE_KIND_PRIMITIVE &&
-        expr_type->info.array_info.element_type->info.primitive_type_tag == CHAR_TYPE)
+    if (kgpc_type_string_storage_kind(expr_type) == KGPC_STRING_STORAGE_CHAR_ARRAY)
         return 1;
     return 0;
 }
@@ -989,7 +939,7 @@ int codegen_expr_is_shortstring_value_ctx(const struct Expression *expr, CodeGen
                     return 1;
             }
             if (kgpc_type_equals_tag(node->type, STRING_TYPE) &&
-                !kgpc_type_is_shortstring(node->type))
+                kgpc_type_string_storage_kind(node->type) != KGPC_STRING_STORAGE_SHORTSTRING)
             {
                 struct TypeAlias *alias = kgpc_type_get_type_alias(node->type);
                 if (alias != NULL && !alias->is_shortstring)
@@ -999,25 +949,8 @@ int codegen_expr_is_shortstring_value_ctx(const struct Expression *expr, CodeGen
                 if (alias == NULL)
                     return 1;
             }
-            if (kgpc_type_is_shortstring(node->type))
+            if (kgpc_type_string_storage_kind(node->type) == KGPC_STRING_STORAGE_SHORTSTRING)
                 return 1;
-            struct TypeAlias *alias = kgpc_type_get_type_alias(node->type);
-            if (alias != NULL && alias->is_shortstring)
-                return 1;
-            if (kgpc_type_is_array(node->type))
-            {
-                KgpcType *elem = kgpc_type_get_array_element_type(node->type);
-                if (elem != NULL &&
-                    elem->kind == TYPE_KIND_PRIMITIVE &&
-                    elem->info.primitive_type_tag == CHAR_TYPE)
-                {
-                    int start = 0;
-                    int end = -1;
-                    if (kgpc_type_get_array_bounds(node->type, &start, &end) == 0 &&
-                        start == 0 && end >= 0 && end <= 255)
-                        return 1;
-                }
-            }
         }
     }
 
@@ -1249,26 +1182,8 @@ static int codegen_array_access_targets_shortstring(const struct Expression *exp
     if (base_type != NULL && kgpc_type_is_array(base_type))
     {
         KgpcType *elem_type = kgpc_type_get_array_element_type(base_type);
-        if (elem_type != NULL)
-        {
-            if (kgpc_type_is_shortstring(elem_type))
-                return 1;
-            struct TypeAlias *alias = kgpc_type_get_type_alias(elem_type);
-            if (alias != NULL && alias->is_shortstring)
-                return 1;
-            if (kgpc_type_is_array(elem_type))
-            {
-                KgpcType *inner = kgpc_type_get_array_element_type(elem_type);
-                int start = 0;
-                int end = 0;
-                if (inner != NULL && kgpc_type_is_char(inner) &&
-                    kgpc_type_get_array_bounds(elem_type, &start, &end) == 0 &&
-                    start == 0 && end >= 0 && end <= 255)
-                {
-                    return 1;
-                }
-            }
-        }
+        if (kgpc_type_string_storage_kind(elem_type) == KGPC_STRING_STORAGE_SHORTSTRING)
+            return 1;
     }
 
     return 0;
@@ -1288,7 +1203,7 @@ static int codegen_shortstring_capacity_from_type_expr(KgpcType *type)
             return (int)alias->storage_size;
     }
 
-    if (kgpc_type_is_shortstring(type))
+    if (kgpc_type_string_storage_kind(type) == KGPC_STRING_STORAGE_SHORTSTRING)
     {
         long long type_size = kgpc_type_sizeof(type);
         if (type_size > 1 && type_size <= INT_MAX)

--- a/KGPC/CodeGenerator/Intel_x86-64/codegen_statement_parts/codegen_stmt_assignment.c
+++ b/KGPC/CodeGenerator/Intel_x86-64/codegen_statement_parts/codegen_stmt_assignment.c
@@ -434,12 +434,6 @@ int codegen_expr_is_shortstring_array(const struct Expression *expr)
         return 0;
     if (expr_get_type_tag(expr) == SHORTSTRING_TYPE)
         return 1;
-    if (expr->resolved_kgpc_type != NULL)
-    {
-        struct TypeAlias *alias = kgpc_type_get_type_alias(expr->resolved_kgpc_type);
-        if (alias != NULL && alias->is_shortstring)
-            return 1;
-    }
     /* For record field access, only the RecordField's type is authoritative.
      * Plain array[0..255] of AnsiChar fields are NOT shortstrings. */
     if (expr->type == EXPR_RECORD_ACCESS)
@@ -453,18 +447,10 @@ int codegen_expr_is_shortstring_array(const struct Expression *expr)
          * array[0..255] fields like TextRec.Name. */
         return 0;
     }
-    /* Also check by type bounds: string[N] is char array with bounds 0..N */
-    if (expr->is_array_expr &&
-        expr->array_element_type == CHAR_TYPE &&
-        expr->array_element_size != 2 &&
-        (expr->array_element_type_id == NULL ||
-         (!pascal_identifier_equals(expr->array_element_type_id, "WideChar") &&
-          !pascal_identifier_equals(expr->array_element_type_id, "UnicodeChar"))) &&
-        expr_get_array_lower_bound(expr) == 0)
+    if (expr->resolved_kgpc_type != NULL)
     {
-        /* Any char array starting at 0 and sized up to 256 is treated as shortstring */
-        int upper = expr_get_array_upper_bound(expr);
-        if (upper >= 0 && upper <= 255)
+        if (kgpc_type_string_storage_kind(expr->resolved_kgpc_type) ==
+            KGPC_STRING_STORAGE_SHORTSTRING)
             return 1;
     }
     return 0;
@@ -495,9 +481,8 @@ int codegen_expr_is_shortstring_value_local(const struct Expression *expr)
         return 1;
     if (expr->resolved_kgpc_type != NULL)
     {
-        struct TypeAlias *alias = kgpc_type_get_type_alias(expr->resolved_kgpc_type);
-        if (kgpc_type_is_shortstring(expr->resolved_kgpc_type) ||
-            (alias != NULL && alias->is_shortstring))
+        if (kgpc_type_string_storage_kind(expr->resolved_kgpc_type) ==
+            KGPC_STRING_STORAGE_SHORTSTRING)
             return 1;
     }
     return 0;
@@ -518,7 +503,7 @@ int codegen_shortstring_capacity_from_type_local(KgpcType *type)
         return 256;
     }
 
-    if (kgpc_type_is_shortstring(type))
+    if (kgpc_type_string_storage_kind(type) == KGPC_STRING_STORAGE_SHORTSTRING)
     {
         long long type_size = kgpc_type_sizeof(type);
         if (type_size > 1 && type_size <= INT_MAX)
@@ -588,9 +573,8 @@ static int codegen_record_field_shortstring_capacity(const struct Expression *ex
         KgpcType *expr_type = expr_get_kgpc_type(expr);
         if (expr_type != NULL)
         {
-            struct TypeAlias *alias = kgpc_type_get_type_alias(expr_type);
-            if (kgpc_type_is_shortstring(expr_type) ||
-                (alias != NULL && alias->is_shortstring))
+            if (kgpc_type_string_storage_kind(expr_type) ==
+                KGPC_STRING_STORAGE_SHORTSTRING)
                 shortstring_like = 1;
         }
     }
@@ -836,11 +820,9 @@ int codegen_get_char_array_bounds(const struct Expression *expr, CodeGenContext 
             if (!is_short)
             {
                 KgpcType *kgpc = expr_get_kgpc_type(expr);
-                if (kgpc != NULL && kgpc->type_alias != NULL && kgpc->type_alias->is_shortstring)
+                if (kgpc_type_string_storage_kind(kgpc) == KGPC_STRING_STORAGE_SHORTSTRING)
                     is_short = 1;
             }
-            if (!is_short && lower == 0 && upper == 255)
-                is_short = 1;
             *is_shortstring_out = is_short;
         }
     }
@@ -887,7 +869,7 @@ int codegen_expr_is_shortstring_rhs(const struct Expression *expr, CodeGenContex
     if (expr->type != EXPR_FUNCTION_CALL &&
         expr_type != NULL &&
         kgpc_type_equals_tag(expr_type, STRING_TYPE) &&
-        !kgpc_type_is_shortstring(expr_type))
+        kgpc_type_string_storage_kind(expr_type) != KGPC_STRING_STORAGE_SHORTSTRING)
     {
         struct TypeAlias *alias = kgpc_type_get_type_alias(expr_type);
         if (alias != NULL && !alias->is_shortstring &&

--- a/KGPC/CodeGenerator/Intel_x86-64/expr_tree/expr_tree.c
+++ b/KGPC/CodeGenerator/Intel_x86-64/expr_tree/expr_tree.c
@@ -2639,28 +2639,8 @@ static int expr_is_shortstring_storage(const struct Expression *expr)
         return 1;
     if (expr->resolved_kgpc_type != NULL)
     {
-        struct TypeAlias *alias = kgpc_type_get_type_alias(expr->resolved_kgpc_type);
-        if (kgpc_type_is_shortstring(expr->resolved_kgpc_type) ||
-            (alias != NULL && alias->is_shortstring))
-            return 1;
-        if (kgpc_type_is_array(expr->resolved_kgpc_type))
-        {
-            KgpcType *elem = kgpc_type_get_array_element_type(expr->resolved_kgpc_type);
-            int start = 0;
-            int end = -1;
-            if (elem != NULL &&
-                elem->kind == TYPE_KIND_PRIMITIVE &&
-                elem->info.primitive_type_tag == CHAR_TYPE &&
-                kgpc_type_get_array_bounds(expr->resolved_kgpc_type, &start, &end) == 0 &&
-                start == 0 && end >= 0 && end <= 255)
-                return 1;
-        }
-    }
-    if (expr->is_array_expr && expr->array_element_type == CHAR_TYPE)
-    {
-        int lower = expr_get_array_lower_bound(expr);
-        int upper = expr_get_array_upper_bound(expr);
-        if (lower == 0 && upper >= 0 && upper <= 255)
+        if (kgpc_type_string_storage_kind(expr->resolved_kgpc_type) ==
+            KGPC_STRING_STORAGE_SHORTSTRING)
             return 1;
     }
     if (expr->type == EXPR_POINTER_DEREF)
@@ -2672,17 +2652,8 @@ static int expr_is_shortstring_storage(const struct Expression *expr)
             KgpcType *points_to = pointer_expr->resolved_kgpc_type->info.points_to;
             if (points_to != NULL)
             {
-                struct TypeAlias *alias = kgpc_type_get_type_alias(points_to);
-                if (kgpc_type_is_shortstring(points_to) ||
-                    (alias != NULL && alias->is_shortstring))
-                    return 1;
-                if (points_to->kind == TYPE_KIND_ARRAY &&
-                    points_to->info.array_info.element_type != NULL &&
-                    points_to->info.array_info.element_type->kind == TYPE_KIND_PRIMITIVE &&
-                    points_to->info.array_info.element_type->info.primitive_type_tag == CHAR_TYPE &&
-                    points_to->info.array_info.start_index == 0 &&
-                    points_to->info.array_info.end_index >= 0 &&
-                    points_to->info.array_info.end_index <= 255)
+                if (kgpc_type_string_storage_kind(points_to) ==
+                    KGPC_STRING_STORAGE_SHORTSTRING)
                     return 1;
             }
         }
@@ -2702,10 +2673,7 @@ int expr_function_call_returns_ansistring(const struct Expression *expr, CodeGen
     {
         KgpcType *ret_type = kgpc_type_get_return_type(call_type);
         const char *ret_id = call_type->info.proc_info.return_type_id;
-        if (ret_type != NULL &&
-            ret_type->kind == TYPE_KIND_PRIMITIVE &&
-            kgpc_type_get_primitive_tag(ret_type) == STRING_TYPE &&
-            !kgpc_type_is_shortstring(ret_type))
+        if (kgpc_type_string_storage_kind(ret_type) == KGPC_STRING_STORAGE_MANAGED_ANSI)
         {
             return 1;
         }
@@ -2767,25 +2735,8 @@ int expr_is_shortstring_storage_ctx(const struct Expression *expr, CodeGenContex
         if (base_type != NULL && kgpc_type_is_array(base_type))
         {
             KgpcType *elem_type = kgpc_type_get_array_element_type(base_type);
-            if (elem_type != NULL)
-            {
-                struct TypeAlias *alias = kgpc_type_get_type_alias(elem_type);
-                if (kgpc_type_is_shortstring(elem_type) ||
-                    (alias != NULL && alias->is_shortstring))
-                    return 1;
-                if (kgpc_type_is_array(elem_type))
-                {
-                    KgpcType *inner = kgpc_type_get_array_element_type(elem_type);
-                    int start = 0;
-                    int end = -1;
-                    if (inner != NULL &&
-                        inner->kind == TYPE_KIND_PRIMITIVE &&
-                        inner->info.primitive_type_tag == CHAR_TYPE &&
-                        kgpc_type_get_array_bounds(elem_type, &start, &end) == 0 &&
-                        start == 0 && end >= 0 && end <= 255)
-                        return 1;
-                }
-            }
+            if (kgpc_type_string_storage_kind(elem_type) == KGPC_STRING_STORAGE_SHORTSTRING)
+                return 1;
         }
     }
 
@@ -2797,25 +2748,8 @@ int expr_is_shortstring_storage_ctx(const struct Expression *expr, CodeGenContex
         if (FindSymbol(&node, ctx->symtab, expr->expr_data.id) != 0 &&
             node != NULL && node->type != NULL)
         {
-            if (kgpc_type_is_shortstring(node->type))
+            if (kgpc_type_string_storage_kind(node->type) == KGPC_STRING_STORAGE_SHORTSTRING)
                 return 1;
-            struct TypeAlias *alias = kgpc_type_get_type_alias(node->type);
-            if (alias != NULL && alias->is_shortstring)
-                return 1;
-            if (kgpc_type_is_array(node->type))
-            {
-                KgpcType *elem = kgpc_type_get_array_element_type(node->type);
-                if (elem != NULL &&
-                    elem->kind == TYPE_KIND_PRIMITIVE &&
-                    elem->info.primitive_type_tag == CHAR_TYPE)
-                {
-                    int start = 0;
-                    int end = -1;
-                    if (kgpc_type_get_array_bounds(node->type, &start, &end) == 0 &&
-                        start == 0 && end >= 0 && end <= 255)
-                        return 1;
-                }
-            }
         }
     }
     return 0;

--- a/KGPC/Parser/ParseTree/KgpcType.c
+++ b/KGPC/Parser/ParseTree/KgpcType.c
@@ -3426,6 +3426,63 @@ int kgpc_type_is_shortstring(const KgpcType *type)
     return 0;
 }
 
+KgpcStringStorageKind kgpc_type_string_storage_kind(const KgpcType *type)
+{
+    if (type == NULL)
+        return KGPC_STRING_STORAGE_NONE;
+
+    struct TypeAlias *alias = type->type_alias;
+    if (kgpc_type_is_shortstring(type) ||
+        (alias != NULL && alias->is_shortstring))
+    {
+        return KGPC_STRING_STORAGE_SHORTSTRING;
+    }
+
+    if (type->kind == TYPE_KIND_ARRAY &&
+        type->info.array_info.element_type != NULL &&
+        type->info.array_info.element_type->kind == TYPE_KIND_PRIMITIVE &&
+        type->info.array_info.element_type->info.primitive_type_tag == CHAR_TYPE &&
+        type->info.array_info.start_index == 0 &&
+        type->info.array_info.end_index >= 0 &&
+        type->info.array_info.end_index <= 255)
+    {
+        return KGPC_STRING_STORAGE_SHORTSTRING;
+    }
+
+    if (kgpc_type_is_wide_string(type) ||
+        (alias != NULL && alias->target_type_id != NULL &&
+         (pascal_identifier_equals(alias->target_type_id, "UnicodeString") ||
+          pascal_identifier_equals(alias->target_type_id, "WideString"))))
+    {
+        return KGPC_STRING_STORAGE_MANAGED_WIDE;
+    }
+
+    if (type->kind == TYPE_KIND_PRIMITIVE &&
+        type->info.primitive_type_tag == STRING_TYPE)
+    {
+        return KGPC_STRING_STORAGE_MANAGED_ANSI;
+    }
+
+    if (alias != NULL && alias->target_type_id != NULL &&
+        (pascal_identifier_equals(alias->target_type_id, "AnsiString") ||
+         pascal_identifier_equals(alias->target_type_id, "RawByteString") ||
+         pascal_identifier_equals(alias->target_type_id, "UTF8String") ||
+         pascal_identifier_equals(alias->target_type_id, "String")))
+    {
+        return KGPC_STRING_STORAGE_MANAGED_ANSI;
+    }
+
+    if (type->kind == TYPE_KIND_ARRAY &&
+        type->info.array_info.element_type != NULL &&
+        type->info.array_info.element_type->kind == TYPE_KIND_PRIMITIVE &&
+        type->info.array_info.element_type->info.primitive_type_tag == CHAR_TYPE)
+    {
+        return KGPC_STRING_STORAGE_CHAR_ARRAY;
+    }
+
+    return KGPC_STRING_STORAGE_NONE;
+}
+
 int kgpc_type_is_integer(const KgpcType *type)
 {
     return (type != NULL &&

--- a/KGPC/Parser/ParseTree/KgpcType.h
+++ b/KGPC/Parser/ParseTree/KgpcType.h
@@ -30,6 +30,14 @@ typedef enum {
     KGPC_FLOAT_ABI_X87 = 2
 } KgpcFloatAbiClass;
 
+typedef enum {
+    KGPC_STRING_STORAGE_NONE = 0,
+    KGPC_STRING_STORAGE_SHORTSTRING,
+    KGPC_STRING_STORAGE_MANAGED_ANSI,
+    KGPC_STRING_STORAGE_MANAGED_WIDE,
+    KGPC_STRING_STORAGE_CHAR_ARRAY
+} KgpcStringStorageKind;
+
 // Defines what kind of type we are dealing with.
 typedef enum {
     TYPE_KIND_PRIMITIVE, // Integer, Real, Char, Boolean, etc.
@@ -162,6 +170,7 @@ int kgpc_type_is_char(const KgpcType *type);
 int kgpc_type_is_string(const KgpcType *type);
 int kgpc_type_is_wide_string(const KgpcType *type);
 int kgpc_type_is_shortstring(const KgpcType *type);
+KgpcStringStorageKind kgpc_type_string_storage_kind(const KgpcType *type);
 int kgpc_type_is_integer(const KgpcType *type);
 int kgpc_type_is_real(const KgpcType *type);
 int kgpc_type_is_extended(const KgpcType *type);


### PR DESCRIPTION
## Summary
- add `kgpc_type_string_storage_kind()` as the shared string storage/category query
- route assignment, expression, expression-tree, and array lowering through that query for ShortString/AnsiString/char-array decisions
- remove codegen-local ShortString classification from stack size and array-bound checks, while keeping record-field metadata authoritative for plain char array fields

Fixes #735

## Validation
- `meson compile -C build KGPC/kgpc`
- `MESON_BUILD_ROOT=build KGPC_RUNTIME_LIB=build/KGPC/libkgpc_runtime.a KGPC_CTYPES_HELPER=build/KGPC/libctypes_helper.so KGPC_CTYPES_HELPER_LINK=build/KGPC/libctypes_helper.so KGPC_HAVE_GMP=0 KGPC_PARALLEL_WORKERS=0 python3 tests/do_not_run_me_directly_but_through_meson.py TestCompiler.test_auto_shortstring_field_assign TestCompiler.test_auto_fpc_bootstrap_assign_textrec_cast TestCompiler.test_auto_gap_overload_shortstring_ansistring TestCompiler.test_auto_tencoding_getansistring TestCompiler.test_auto_tencoding_getansistring_ret TestCompiler.test_auto_reg_sysutils_split_string_array TestCompiler.test_auto_fpc_bootstrap_fina_shortstring_move TestCompiler.test_auto_fpc_bootstrap_include_shortstring_char_assign TestCompiler.test_typed_const_cross_unit_shortstring_array`
- `KGPC_FPC_RTL=1 KGPC_FPC_RTL_DIR=FPCSource MESON_BUILD_ROOT=build KGPC_RUNTIME_LIB=build/KGPC/libkgpc_runtime.a KGPC_CTYPES_HELPER=build/KGPC/libctypes_helper.so KGPC_CTYPES_HELPER_LINK=build/KGPC/libctypes_helper.so KGPC_HAVE_GMP=0 KGPC_PARALLEL_WORKERS=0 python3 tests/do_not_run_me_directly_but_through_meson.py TestCompiler.test_fpcrtl_pp_pas_bootstrap`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Unified string type detection logic in the compiler's code generator by consolidating multiple detection methods into a centralized approach, improving code consistency and reducing duplication across expression and statement handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kreijstal/Pascal-Compiler/pull/743?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->