### PR TITLE
release: KGPC 0.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,11 @@ the Win64 counterpart of the Linux self-host milestone.
   dynamic arrays.
 - Promote `Single` record-field reads to `double` consistently, matching
   the promotion already applied to plain `Single` variables.
+- Honor `{$MAXSTACKSIZE}` / `{$MINSTACKSIZE}` on Win64: emit
+  `-Wl,--stack,<reserve>` (reserve = the larger of the two). A Win64
+  thread's stack cannot grow past the PE-header reserve, so programs that
+  request a large stack no longer overflow the linker's default ~2 MB at
+  startup.
 
 ### Compiler — front end
 - Compile the released FPC 3.2.2 sources: assorted codegen, semantic-check
@@ -41,6 +46,9 @@ the Win64 counterpart of the Linux self-host milestone.
 
 ### Tests
 - The AST-cache include-path regression now runs as a meson test.
+- Run the `pp.pas` bootstrap stage-2 self-host on Win64 as well as Linux:
+  `pp_bootstrap` builds the matching RTL from source (`rtl/win64` →
+  `rtl/units/x86_64-win64`) and recompiles `pp.pas` into `pp_stage2`.
 
 ## [0.0.2] — 2026-06-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,23 @@ under active development.
 
 ## [Unreleased]
 
+## [0.0.4] — 2026-06-04
+
+Native Windows `fpc-bootstrap` CI brought to green: the Win64 build of the
+FPC compiler now starts, self-hosts, and rebuilds its own RTL from source.
+
+### Compiler — code generator
+- Honor `{$MAXSTACKSIZE}` / `{$MINSTACKSIZE}` on Win64: emit
+  `-Wl,--stack,<reserve>` (reserve = the larger of the two). A Win64
+  thread's stack cannot grow past the PE-header reserve, so programs that
+  request a large stack — such as the recursion-heavy FPC compiler — no
+  longer overflow the linker's default ~2 MB and crash at startup.
+
+### Tests
+- Run the `pp.pas` bootstrap stage-2 self-host on Win64 as well as Linux:
+  `pp_bootstrap` builds the matching RTL from source (`rtl/win64` →
+  `rtl/units/x86_64-win64`) and recompiles `pp.pas` into `pp_stage2`.
+
 ## [0.0.3] — 2026-06-03
 
 Native Windows self-host fixpoint.  KGPC's Windows build of the FPC
@@ -23,11 +40,6 @@ the Win64 counterpart of the Linux self-host milestone.
   dynamic arrays.
 - Promote `Single` record-field reads to `double` consistently, matching
   the promotion already applied to plain `Single` variables.
-- Honor `{$MAXSTACKSIZE}` / `{$MINSTACKSIZE}` on Win64: emit
-  `-Wl,--stack,<reserve>` (reserve = the larger of the two). A Win64
-  thread's stack cannot grow past the PE-header reserve, so programs that
-  request a large stack no longer overflow the linker's default ~2 MB at
-  startup.
 
 ### Compiler — front end
 - Compile the released FPC 3.2.2 sources: assorted codegen, semantic-check
@@ -46,9 +58,6 @@ the Win64 counterpart of the Linux self-host milestone.
 
 ### Tests
 - The AST-cache include-path regression now runs as a meson test.
-- Run the `pp.pas` bootstrap stage-2 self-host on Win64 as well as Linux:
-  `pp_bootstrap` builds the matching RTL from source (`rtl/win64` →
-  `rtl/units/x86_64-win64`) and recompiles `pp.pas` into `pp_stage2`.
 
 ## [0.0.2] — 2026-06-03
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Kreijstal Gwinn Pascal Compiler (KGPC)
 
-> **Status: alpha (v0.0.1).**  KGPC is pre-release software.  The headline
+> **Status: alpha (v0.0.3).**  KGPC is pre-release software.  The headline
 > goal — bootstrapping Free Pascal without FPC or a proprietary
-> Delphi-compatible compiler — has been met: as of master `02633217` the
-> Stage 1–3 self-host chain is verified and exercised in CI on every push.
-> "Alpha" refers to language coverage, code quality, and API stability —
-> all of which are still moving.  See [`STATUS.md`](STATUS.md) for what
-> works, what doesn't, and the open compiler bugs.
+> Delphi-compatible compiler — has been met: the Stage 1–3 self-host chain
+> is verified in CI on both Linux and Windows (Win64).  "Alpha" refers to
+> language coverage, code quality, and API stability — all of which are
+> still moving.  See [`STATUS.md`](STATUS.md) for what works, what doesn't,
+> and the open compiler bugs.
 
 A fork of [gwinndr/Pascal-Compiler](https://github.com/gwinndr/Pascal-Compiler).
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Kreijstal Gwinn Pascal Compiler (KGPC)
 
-> **Status: alpha (v0.0.3).**  KGPC is pre-release software.  The headline
+> **Status: alpha (v0.0.4).**  KGPC is pre-release software.  The headline
 > goal — bootstrapping Free Pascal without FPC or a proprietary
 > Delphi-compatible compiler — has been met: the Stage 1–3 self-host chain
 > is verified in CI on both Linux and Windows (Win64).  "Alpha" refers to

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('kgpc-project', 'c',
-  version : '0.0.3',
+  version : '0.0.4',
 )
 
 add_project_arguments('-DKGPC_VERSION="' + meson.project_version() + '"',


### PR DESCRIPTION
The 0.0.3 tag was cut before the win-fpcrtl bootstrap work landed, so that work
is the 0.0.4 release rather than an addition to 0.0.3.

- Bump `meson.build` and README status to 0.0.4
- New `[0.0.4]` CHANGELOG entry: Win64 `{$MAXSTACKSIZE}`/`{$MINSTACKSIZE}` →
  `-Wl,--stack` reserve; pp.pas bootstrap stage-2 self-host now runs on Win64
- `[0.0.3]` restored to its released content

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Prepare the 0.0.4 release, documenting and enabling Win64 bootstrap support and updated stack handling.

Enhancements:
- Ensure the Win64 compiler honors {$MAXSTACKSIZE} and {$MINSTACKSIZE} by mapping them to the linker stack reserve, preventing startup crashes on large-stack programs.

Build:
- Bump project version to 0.0.4 in build configuration.

Documentation:
- Add 0.0.4 changelog entry describing Win64 bootstrap and stack handling improvements.
- Update README status and platform support details to reflect alpha v0.0.4 and verified Linux/Win64 self-hosting.

Tests:
- Extend CI/bootstrap tests to run the pp.pas stage-2 self-host flow on Win64, rebuilding the matching RTL from source.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project changelog and README for v0.0.4 release
  * Documented Windows (Win64) platform support status in project documentation

* **Chores**
  * Version number updated to 0.0.4
  * CI pipeline now includes Windows (Win64) bootstrap verification alongside Linux support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->