### PR TITLE
codegen: route UniqueString builtin to kgpc_string_unique runtime helper

### DIFF
--- a/KGPC/CodeGenerator/Intel_x86-64/codegen_statement_parts/codegen_stmt_builtins.c
+++ b/KGPC/CodeGenerator/Intel_x86-64/codegen_statement_parts/codegen_stmt_builtins.c
@@ -4027,7 +4027,7 @@ ListNode_t *codegen_builtin_proc(struct Statement *stmt, ListNode_t *inst_list,
     call_target = "kgpc_string_unique";
   if (call_target == NULL)
     call_target = "";
-  snprintf(buffer, 64, "\tcall\t%s\n", call_target);
+  snprintf(buffer, sizeof(buffer), "\tcall\t%s\n", call_target);
   inst_list = add_inst(inst_list, buffer);
   inst_list = codegen_cleanup_call_stack(inst_list, ctx);
 #ifdef DEBUG_CODEGEN

--- a/KGPC/CodeGenerator/Intel_x86-64/codegen_statement_parts/codegen_stmt_builtins.c
+++ b/KGPC/CodeGenerator/Intel_x86-64/codegen_statement_parts/codegen_stmt_builtins.c
@@ -4016,9 +4016,18 @@ ListNode_t *codegen_builtin_proc(struct Statement *stmt, ListNode_t *inst_list,
     else if (pascal_identifier_equals(call_target, "Initialize"))
       call_target = "Initialize";
   }
+  /* UniqueString(var S): codegen_pass_arguments already marshals the var-param
+   * address (a char**) into the first argument register, matching the runtime
+   * helper kgpc_string_unique(char **target) which makes S refcount-unique in
+   * place.  Route to it instead of the mangled `uniquestring_s`, which has no
+   * implementation (KGPC registers UniqueString as a builtin proc but emits no
+   * body).  FPC's compiler (e.g. omfbase.pas, cfileutl.fixpath) calls this. */
+  if (builtin_id != NULL &&
+      pascal_identifier_equals(builtin_id, "UniqueString"))
+    call_target = "kgpc_string_unique";
   if (call_target == NULL)
     call_target = "";
-  snprintf(buffer, 50, "\tcall\t%s\n", call_target);
+  snprintf(buffer, 64, "\tcall\t%s\n", call_target);
   inst_list = add_inst(inst_list, buffer);
   inst_list = codegen_cleanup_call_stack(inst_list, ctx);
 #ifdef DEBUG_CODEGEN

--- a/tests/test_cases/tdd_uniquestring_ansistring.expected
+++ b/tests/test_cases/tdd_uniquestring_ansistring.expected
@@ -1,0 +1,2 @@
+hello
+Hello

--- a/tests/test_cases/tdd_uniquestring_ansistring.p
+++ b/tests/test_cases/tdd_uniquestring_ansistring.p
@@ -1,0 +1,18 @@
+program tdd_uniquestring_ansistring;
+{$mode objfpc}{$H+}
+{ UniqueString(var S) must make a refcount-shared AnsiString into a private
+  copy so a later in-place mutation does not affect the aliased string.
+  KGPC registers UniqueString as a builtin proc; codegen must route the call
+  to the runtime helper kgpc_string_unique rather than emit an undefined
+  `uniquestring_s`.  FPC's own compiler (omfbase.pas, cfileutl.fixpath) relies
+  on this when compiling the 3.2.2 release. }
+var
+  a, b: ansistring;
+begin
+  a := 'hello';
+  b := a;            { b shares a's buffer (refcount 2) }
+  UniqueString(b);   { b must become a private copy }
+  b[1] := 'H';       { mutate b only }
+  writeln(a);        { must still be 'hello' }
+  writeln(b);        { must be 'Hello' }
+end.


### PR DESCRIPTION
## Summary

KGPC registers `UniqueString` as a builtin procedure but emitted no body for it: `codegen_builtin_proc` fell through to a generic call that emitted the mangled name `uniquestring_s`, undefined at link time. The argument marshalling was already correct (`codegen_pass_arguments` passes the var-param address — a `char**` — exactly what `kgpc_string_unique(char**)` expects), so only the call target was wrong.

## Fix

Route the `UniqueString` builtin to `kgpc_string_unique` in the call-target canonicalisation block, alongside the existing `Initialize`/`Finalize` mapping. `kgpc_string_unique` makes the AnsiString refcount-unique in place, matching FPC's `UniqueString` contract.

## Why it matters

FPC's own compiler calls `UniqueString` when compiling the **3.2.2 release** (`omfbase.pas`, `cfileutl.fixpath`), which KGPC previously failed to link. This is the second of the KGPC-vs-FPC-3.2.2 compatibility fixes (after #752).

## Test

`tdd_uniquestring_ansistring`: a refcount-shared AnsiString made unique before an in-place mutation — compiles, links and runs (`a` stays `hello`, `b` becomes `Hello`). Full suite green (1118/1118).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Route the UniqueString builtin to the correct runtime helper and add a regression test to ensure AnsiString uniqueness semantics.

Bug Fixes:
- Fix UniqueString builtin calls by mapping them to the kgpc_string_unique runtime helper instead of emitting an undefined uniquestring_s symbol.

Tests:
- Add a regression test ensuring UniqueString makes a shared AnsiString buffer unique before in-place mutation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed UniqueString builtin function to correctly handle case-sensitive string operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->