### PR TITLE
codegen: resolve overloaded builtin call's formal params by mangled id

### DIFF
--- a/KGPC/CodeGenerator/Intel_x86-64/codegen_statement_parts/codegen_stmt_builtins.c
+++ b/KGPC/CodeGenerator/Intel_x86-64/codegen_statement_parts/codegen_stmt_builtins.c
@@ -3997,8 +3997,36 @@ ListNode_t *codegen_builtin_proc(struct Statement *stmt, ListNode_t *inst_list,
   if (proc_name_hint == NULL)
     proc_name_hint = stmt->stmt_data.procedure_call_data.mangled_id;
 
-  inst_list = codegen_pass_arguments(args_expr, inst_list, ctx, NULL,
-                                     proc_name_hint, 0, NULL, 0);
+  /* For an overloaded RTL procedure dispatched here by its mangled name (e.g.
+   * System.Assign -> assign_f_ss), resolve the formal parameters from the
+   * overload whose mangled_id matches the call target, rather than letting
+   * codegen_pass_arguments fall back to FindSymbol(proc_name_hint), which
+   * returns an arbitrary same-named overload.  Without this, a ShortString
+   * argument to System.Assign is matched against the RawByteString overload's
+   * AnsiString formal and wrongly promoted (kgpc_shortstring_to_string),
+   * dropping the string's first character (the FPC bootstrap "Cannot open
+   * file" / system.assign filename corruption). */
+  struct KgpcType *resolved_overload_type = NULL;
+  if (proc_name != NULL && proc_name_hint != NULL && ctx != NULL &&
+      ctx->symtab != NULL &&
+      !pascal_identifier_equals(proc_name, proc_name_hint)) {
+    ListNode_t *cands = FindAllIdents(ctx->symtab, proc_name_hint);
+    for (ListNode_t *c = cands; c != NULL; c = c->next) {
+      HashNode_t *hn = (HashNode_t *)c->cur;
+      if (hn != NULL && hn->mangled_id != NULL &&
+          strcmp(hn->mangled_id, proc_name) == 0 && hn->type != NULL &&
+          hn->type->kind == TYPE_KIND_PROCEDURE) {
+        resolved_overload_type = hn->type;
+        break;
+      }
+    }
+    if (cands != NULL)
+      DestroyList(cands);
+  }
+
+  inst_list = codegen_pass_arguments(args_expr, inst_list, ctx,
+                                     resolved_overload_type, proc_name_hint, 0,
+                                     NULL, 0);
   inst_list = codegen_vect_reg(inst_list, 0);
   const char *call_target =
       (proc_name != NULL) ? proc_name : stmt->stmt_data.procedure_call_data.id;

--- a/tests/harness/auto_discovery.py
+++ b/tests/harness/auto_discovery.py
@@ -289,6 +289,10 @@ SYSV_ABI_ONLY_TESTS = {
 # Tests that target overloads or units only present in the FPC RTL suite.
 FPC_RTL_ONLY_TESTS = {
     "fpc_bootstrap_hminus_extractfilepath",
+    # Exercises FPC's overloaded System.Assign(File, ShortString) -> assign_f_ss,
+    # which only exists when the FPC RTL is compiled in.  KGPC's default builtin
+    # runtime has no such symbol, so the default-mode link is undefined.
+    "fpc_bootstrap_system_assign_shortstring_var",
 }
 
 # Tests without explicit FPC RTL/package imports are skipped from the FPC RTL
@@ -375,6 +379,7 @@ FPC_RTL_IMPLICIT_UNIT_TESTS = {
     "fpc_bootstrap_syssbh_pos_alias",
     "fpc_bootstrap_system_qualified_const",
     "fpc_bootstrap_system_qualified_proccall",
+    "fpc_bootstrap_system_assign_shortstring_var",
     "fpc_bootstrap_tclass",
     "fpc_bootstrap_trtlcriticalsection",
     "fpc_bootstrap_typedfile",

--- a/tests/test_cases/fpc_bootstrap_system_assign_shortstring_var.expected
+++ b/tests/test_cases/fpc_bootstrap_system_assign_shortstring_var.expected
@@ -1,0 +1,1 @@
+roundtrip

--- a/tests/test_cases/fpc_bootstrap_system_assign_shortstring_var.p
+++ b/tests/test_cases/fpc_bootstrap_system_assign_shortstring_var.p
@@ -1,0 +1,53 @@
+{ Regression: unit-qualified System.Assign(f, s) with a ShortString *variable*
+  argument must pass the shortstring to FPC's Assign(File, ShortString) overload
+  AS a shortstring, not silently convert it to an AnsiString.
+
+  The qualified-call path used to route System.Assign through the coarse builtin
+  name-mangler, which only sees the STRING_TYPE tag and cannot tell a ShortString
+  from an AnsiString.  It picked the RawByteString overload and inserted a
+  shortstring->ansistring conversion of the argument; the ShortString-overload
+  body (Assign(f, ShortString) -> Assign(f, RawByteString(Name))) then read the
+  ansistring's first DATA byte as a length byte and copied from data+1, so the
+  filename lost its first character.  Unqualified Assign was unaffected because
+  it goes through the full overload resolver, which scores ShortString as an
+  exact match.
+
+  This is exactly how FPC 3.2.2's TCFileStream.Create -> system.assign(FHandle,
+  AFileName) failed to open "system.pp" (it tried "ystem.pp") during bootstrap.
+
+  The file is first created via a string literal (known-good path); it is then
+  reopened via a ShortString variable through System.Assign.  If the leading
+  character is dropped, the reopen targets a different, non-existent path and
+  Reset fails (IOResult <> 0).
+
+  The file/shortstring locals live inside a procedure on purpose: a *global*
+  `var f: file; s: shortstring` pair trips a separate, layout-sensitive
+  stdio-init memory-corruption bug (over-read in kgpc_string_to_char_array)
+  that has nothing to do with the qualified-Assign fix under test.  Keeping
+  them local isolates this regression to the argument-conversion path. }
+program fpc_bootstrap_system_assign_shortstring_var;
+
+procedure RoundTrip;
+var
+  f : file;
+  s : shortstring;
+begin
+  System.Assign(f, 'tests/output/sys_assign_ss_var.dat');   { literal: correct path }
+  System.Rewrite(f, 1);
+  System.Close(f);
+
+  s := 'tests/output/sys_assign_ss_var.dat';                { ShortString variable }
+  System.Assign(f, s);                                      { the bug trigger }
+  {$I-} System.Reset(f, 1); {$I+}
+  if IOResult <> 0 then
+    WriteLn('OPEN FAILED')
+  else
+  begin
+    System.Close(f);
+    WriteLn('roundtrip');
+  end;
+end;
+
+begin
+  RoundTrip;
+end.


### PR DESCRIPTION
## Problem

Unit-qualified `System.Assign(f, s)` with a **ShortString variable** argument dropped the filename's first character during FPC 3.2.2 bootstrap — `TCFileStream.Create → system.assign(FHandle, AFileName)` tried to open `ystem.pp` instead of `system.pp`.

The qualified-call path routed `System.Assign` through the coarse builtin name-mangler, which only sees the `STRING_TYPE` tag and cannot distinguish a ShortString from an AnsiString. It picked the RawByteString overload and inserted a spurious shortstring→ansistring conversion of the argument; the ShortString-overload body (`Assign(f, ShortString) → Assign(f, RawByteString(Name))`) then read the ansistring's first **data** byte as a length byte and copied from `data+1`, dropping the leading character. Unqualified `Assign` was unaffected because it goes through the full overload resolver, which scores ShortString as an exact match.

## Fix

When a builtin proc call is dispatched by a mangled name that differs from the source identifier (e.g. `System.Assign` → `assign_f_ss`), resolve the formal parameters from the overload whose `mangled_id` matches the call target, so a ShortString argument is matched against `assign_f_ss`'s ShortString formal (not an arbitrary RawByteString overload) and the spurious shortstring→ansistring promotion is suppressed.

Dispatch/resolution are unchanged (this is **not** a reroute), so `Val`/`Str` intrinsics and trunk RTL self-host are unaffected. An earlier reroute attempt regressed the trunk self-host test (`pp_pas_bootstrap`) and was abandoned in favor of this surgical conversion fix.

## Test

`tests/test_cases/fpc_bootstrap_system_assign_shortstring_var.p` creates a file via a string literal, reopens it via a ShortString variable through `System.Assign`, and asserts the reopen succeeds (`IOResult = 0`). Pre-fix: "OPEN FAILED"; post-fix: "roundtrip". The test is classified FPC-RTL-only (it links FPC's `assign_f_ss` overload, which KGPC's default builtin runtime does not define).

## Verification

- FPC RTL suite: 245/245 — regression test green, `pp_pas_bootstrap` trunk self-host stays green.
- Main suite: 7/7, 1117 subtests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Resolve builtin overloaded procedure parameter types by matching the call target’s mangled identifier and add a regression test for unit-qualified System.Assign with a ShortString variable.

Bug Fixes:
- Ensure System.Assign with a ShortString variable argument binds to the correct overload and no longer drops the filename’s first character in FPC bootstrap scenarios.

Tests:
- Add an FPC-RTL-only regression test that exercises System.Assign(File, ShortString) via a ShortString variable and verifies file reopen success.
- Register the new regression test in the auto-discovery harness for both default and FPC RTL suites.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed overloaded procedure parameter type resolution to ensure the correct procedure is called when multiple procedures share the same name.

* **Tests**
  * Added regression test for overloaded procedure assignments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->