### PR TITLE
runtime: make extended-narrowing & 256-bit set ops clang-safe (clang64 FPC bootstrap)

### DIFF
--- a/KGPC/runtime.c
+++ b/KGPC/runtime.c
@@ -1584,8 +1584,13 @@ int64_t kgpc_load_extended_to_bits(const void *src) {
           : "st");
   return bits;
 #else
+  /* x87 80-bit extended only exists on x86, so KGPC never reaches this path
+     on its supported targets.  Bound the copy by sizeof(long double) so it can
+     never overflow `ext` on a platform whose long double is narrower than the
+     10-byte source (e.g. an 8-byte long double on ARM/AArch64 or MSVC). */
   long double ext = 0.0L;
-  memcpy(&ext, src, 10);
+  size_t n = sizeof(ext) < 10 ? sizeof(ext) : 10;
+  memcpy(&ext, src, n);
   return kgpc_double_to_bits((double)ext);
 #endif
 }
@@ -5104,23 +5109,31 @@ static inline void kgpc__set_store64(void *p, int i, uint64_t v) {
 }
 
 void kgpc_set_union_256(void *dest, const void *a, const void *b) {
-  for (int i = 0; i < 4; i++)
-    kgpc__set_store64(dest, i, kgpc__set_load64(a, i) | kgpc__set_load64(b, i));
+  kgpc__set_store64(dest, 0, kgpc__set_load64(a, 0) | kgpc__set_load64(b, 0));
+  kgpc__set_store64(dest, 1, kgpc__set_load64(a, 1) | kgpc__set_load64(b, 1));
+  kgpc__set_store64(dest, 2, kgpc__set_load64(a, 2) | kgpc__set_load64(b, 2));
+  kgpc__set_store64(dest, 3, kgpc__set_load64(a, 3) | kgpc__set_load64(b, 3));
 }
 
 void kgpc_set_intersect_256(void *dest, const void *a, const void *b) {
-  for (int i = 0; i < 4; i++)
-    kgpc__set_store64(dest, i, kgpc__set_load64(a, i) & kgpc__set_load64(b, i));
+  kgpc__set_store64(dest, 0, kgpc__set_load64(a, 0) & kgpc__set_load64(b, 0));
+  kgpc__set_store64(dest, 1, kgpc__set_load64(a, 1) & kgpc__set_load64(b, 1));
+  kgpc__set_store64(dest, 2, kgpc__set_load64(a, 2) & kgpc__set_load64(b, 2));
+  kgpc__set_store64(dest, 3, kgpc__set_load64(a, 3) & kgpc__set_load64(b, 3));
 }
 
 void kgpc_set_diff_256(void *dest, const void *a, const void *b) {
-  for (int i = 0; i < 4; i++)
-    kgpc__set_store64(dest, i, kgpc__set_load64(a, i) & ~kgpc__set_load64(b, i));
+  kgpc__set_store64(dest, 0, kgpc__set_load64(a, 0) & ~kgpc__set_load64(b, 0));
+  kgpc__set_store64(dest, 1, kgpc__set_load64(a, 1) & ~kgpc__set_load64(b, 1));
+  kgpc__set_store64(dest, 2, kgpc__set_load64(a, 2) & ~kgpc__set_load64(b, 2));
+  kgpc__set_store64(dest, 3, kgpc__set_load64(a, 3) & ~kgpc__set_load64(b, 3));
 }
 
 void kgpc_set_symdiff_256(void *dest, const void *a, const void *b) {
-  for (int i = 0; i < 4; i++)
-    kgpc__set_store64(dest, i, kgpc__set_load64(a, i) ^ kgpc__set_load64(b, i));
+  kgpc__set_store64(dest, 0, kgpc__set_load64(a, 0) ^ kgpc__set_load64(b, 0));
+  kgpc__set_store64(dest, 1, kgpc__set_load64(a, 1) ^ kgpc__set_load64(b, 1));
+  kgpc__set_store64(dest, 2, kgpc__set_load64(a, 2) ^ kgpc__set_load64(b, 2));
+  kgpc__set_store64(dest, 3, kgpc__set_load64(a, 3) ^ kgpc__set_load64(b, 3));
 }
 
 /* _haltproc: asm-only startup procedure from si_prc.inc / si_c.inc.

--- a/KGPC/runtime.c
+++ b/KGPC/runtime.c
@@ -1560,9 +1560,34 @@ int64_t kgpc_load_extended_to_bits(const void *src) {
   if (src == NULL)
     return kgpc_double_to_bits(0.0);
 
+#if defined(__x86_64__) || defined(__i386__)
+  /*
+   * Narrow the 80-bit x87 extended value to a 64-bit double and return its
+   * bit pattern in an integer register, performing the conversion entirely on
+   * the x87 stack so that no SSE/xmm register is touched.
+   *
+   * This must be compiler-independent: written as plain C ("(double)ext"),
+   * some compilers (clang) lower the narrowing through xmm0 and leave the
+   * converted double live in xmm0 on return.  KGPC's generated code loads real
+   * operands into xmm registers lazily and treats this bit-conversion helper as
+   * leaving the SSE register file undisturbed, so a stray value left in xmm0
+   * corrupts later floating-point evaluation (observed as bogus overload
+   * resolution while self-hosting on the LLVM/clang64 toolchain).  The explicit
+   * fldt/fstpl keeps the whole operation on the x87 stack regardless of which C
+   * compiler builds the runtime.
+   */
+  int64_t bits;
+  __asm__("fldt %1\n\t"
+          "fstpl %0"
+          : "=m"(bits)
+          : "m"(*(const char(*)[10])src)
+          : "st");
+  return bits;
+#else
   long double ext = 0.0L;
   memcpy(&ext, src, 10);
   return kgpc_double_to_bits((double)ext);
+#endif
 }
 
 void kgpc_store_extended_from_int64(void *dest, int64_t value) {
@@ -5059,41 +5084,43 @@ int64_t fpc_in_hi_qword(uint64_t value) {
 }
 
 /* Set operations for 256-bit sets (set of Char / set of AnsiChar).
-   Each set is 32 bytes = 4 x uint64. */
+   Each set is 32 bytes = 4 x uint64.
+
+   The dest/a/b pointers point at Pascal set storage, which can sit at any
+   byte offset inside a record or on the stack -- they are NOT guaranteed to
+   be 8-byte aligned. Casting void* -> uint64_t* and dereferencing is therefore
+   undefined behaviour: a compiler may legally assume 8-byte alignment and emit
+   alignment-requiring loads/stores (or autovectorize into aligned moves).
+   clang -O2 does exactly this, corrupting set data on misaligned input.
+   Access the words through memcpy, which both gcc and clang lower back to a
+   plain mov while honouring the real (byte) alignment. */
+static inline uint64_t kgpc__set_load64(const void *p, int i) {
+  uint64_t v;
+  memcpy(&v, (const unsigned char *)p + (size_t)i * 8, 8);
+  return v;
+}
+static inline void kgpc__set_store64(void *p, int i, uint64_t v) {
+  memcpy((unsigned char *)p + (size_t)i * 8, &v, 8);
+}
+
 void kgpc_set_union_256(void *dest, const void *a, const void *b) {
-  const uint64_t *sa = (const uint64_t *)a, *sb = (const uint64_t *)b;
-  uint64_t *d = (uint64_t *)dest;
-  d[0] = sa[0] | sb[0];
-  d[1] = sa[1] | sb[1];
-  d[2] = sa[2] | sb[2];
-  d[3] = sa[3] | sb[3];
+  for (int i = 0; i < 4; i++)
+    kgpc__set_store64(dest, i, kgpc__set_load64(a, i) | kgpc__set_load64(b, i));
 }
 
 void kgpc_set_intersect_256(void *dest, const void *a, const void *b) {
-  const uint64_t *sa = (const uint64_t *)a, *sb = (const uint64_t *)b;
-  uint64_t *d = (uint64_t *)dest;
-  d[0] = sa[0] & sb[0];
-  d[1] = sa[1] & sb[1];
-  d[2] = sa[2] & sb[2];
-  d[3] = sa[3] & sb[3];
+  for (int i = 0; i < 4; i++)
+    kgpc__set_store64(dest, i, kgpc__set_load64(a, i) & kgpc__set_load64(b, i));
 }
 
 void kgpc_set_diff_256(void *dest, const void *a, const void *b) {
-  const uint64_t *sa = (const uint64_t *)a, *sb = (const uint64_t *)b;
-  uint64_t *d = (uint64_t *)dest;
-  d[0] = sa[0] & ~sb[0];
-  d[1] = sa[1] & ~sb[1];
-  d[2] = sa[2] & ~sb[2];
-  d[3] = sa[3] & ~sb[3];
+  for (int i = 0; i < 4; i++)
+    kgpc__set_store64(dest, i, kgpc__set_load64(a, i) & ~kgpc__set_load64(b, i));
 }
 
 void kgpc_set_symdiff_256(void *dest, const void *a, const void *b) {
-  const uint64_t *sa = (const uint64_t *)a, *sb = (const uint64_t *)b;
-  uint64_t *d = (uint64_t *)dest;
-  d[0] = sa[0] ^ sb[0];
-  d[1] = sa[1] ^ sb[1];
-  d[2] = sa[2] ^ sb[2];
-  d[3] = sa[3] ^ sb[3];
+  for (int i = 0; i < 4; i++)
+    kgpc__set_store64(dest, i, kgpc__set_load64(a, i) ^ kgpc__set_load64(b, i));
 }
 
 /* _haltproc: asm-only startup procedure from si_prc.inc / si_c.inc.


### PR DESCRIPTION
Lets the LLVM/clang64 MSYS2 toolchain bootstrap FPC 3.2.2 on Windows to a 3-stage fixpoint.

## Root cause
`kgpc_load_extended_to_bits` returns `int64_t` bits. Written as plain C (`(double)ext`), **clang lowers the 80→64-bit narrowing through `xmm0` and leaves the converted double live in `xmm0` on return**; gcc returns via `rax` and never touches `xmm0`. KGPC's generated code loads real operands into `xmm` lazily and relies on this internal bit-conversion helper leaving the SSE register file undisturbed, so the stray `xmm0` value corrupted later floating-point evaluation — observed as **22 bogus "Can't determine which overloaded function to call"** errors (plus a misleading `math.pp` IE 200212283) while `pp_bootstrap` built the RTL.

Diagnosis was nailed down by diffing the failing vs. working `pp.exe` (byte-identical except 2 instructions in `load_extended`; `rax` identical, only `xmm0` differed) and a controlled probe: `xmm0` untouched→0 errors, forced 0→0, loaded-double→22, garbage→22 (so the consumer requires `xmm0==0`). Determinism was confirmed (not a UAF).

## Fix
Do the narrowing entirely on the x87 stack (`fldt`/`fstpl`) and return via an integer register, so the emitted code is `xmm`-clean under **any** compiler. Guarded for x86; portable C fallback retained elsewhere.

Also folds in the related 256-bit set-op misalignment fix: the set storage isn't guaranteed 8-byte aligned, so `uint64_t*` deref is UB and clang `-O2` emits alignment-requiring/vectorized moves that corrupt misaligned set data — accessed via `memcpy` now.

## Verification
- Linux full suite: `Fail: 0`
- Linux FPC RTL suite: `Fail: 0`
- win11 **clang64** full bootstrap: RTL builds with **0** overload errors; `ppc2 == ppc3 == ppcx64` byte-identical (fixpoint); `ppcx64.exe -iV` → `3.2.2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Ensure KGPC runtime floating-point narrowing and 256-bit set operations behave correctly and compiler-independently across gcc/clang, particularly for clang-based Windows toolchains.

Bug Fixes:
- Prevent corruption of later floating-point evaluation by performing 80-bit to 64-bit narrowing entirely on the x87 stack for x86/x86_64 instead of via SSE/xmm registers.
- Avoid undefined behaviour and data corruption in 256-bit set operations on potentially misaligned Pascal set storage by accessing 64-bit words through memcpy rather than direct uint64_t pointer casts.

Enhancements:
- Introduce small helper routines to abstract 64-bit load/store access for 256-bit set operations, making the code alignment-safe while keeping the external API unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized extended precision floating-point conversion handling for x86 platforms (32-bit and 64-bit)
  * Enhanced 256-bit set operations (union, intersection, difference, symmetric difference) for improved stability and consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->